### PR TITLE
NDRHGGrk: Add minimal PaaS manifest

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,6 @@
+---
+applications:
+- name: verify-self-service
+  routes:
+  - route: verify-self-service-((environment)).cloudapps.digital
+  buildpacks: ruby_buildpack


### PR DESCRIPTION
Add a minimal manifest for deployment to PaaS.

Co-authored-by: Rosa Fox <rosa.fox@digital.cabinet-office.gov.uk>