### PR TITLE
NDRHGGrk: Add minimal PaaS manifest

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -3,4 +3,5 @@ applications:
 - name: verify-self-service
   routes:
   - route: verify-self-service-((environment)).cloudapps.digital
-  buildpacks: ruby_buildpack
+  buildpacks:
+    - https://github.com/cloudfoundry/ruby-buildpack/releases/download/v1.7.30/ruby-buildpack-cflinuxfs2-v1.7.30.zip


### PR DESCRIPTION
Add a minimal manifest for deployment to PaaS.

Co-authored-by: Rosa Fox <rosa.fox@digital.cabinet-office.gov.uk>