### PR TITLE
BAU: Capybara spins up the puma server with its output

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -58,4 +58,7 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  # Silence puma output during tests
+  Capybara.server = :puma, { Silent: true }
 end


### PR DESCRIPTION
This hides it so the test results are cleaner.

Before:
<img width="415" alt="image" src="https://user-images.githubusercontent.com/30629434/52112653-0b6b9980-25ff-11e9-8aff-00a487435b18.png">

After:
<img width="422" alt="image" src="https://user-images.githubusercontent.com/30629434/52112663-11fa1100-25ff-11e9-8b9c-277a355300b6.png">
