### PR TITLE
8wA933sS: Add Acceptance tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ capybara-*.html
 *.orig
 rerun.txt
 pickle-email-*.html
+.idea
 
 # TODO Comment out this rule if you are OK with secrets being uploaded to the repo
 config/initializers/secret_token.rb

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,0 +1,4 @@
+class HomeController < ApplicationController
+  def index
+  end
+end

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -1,0 +1,2 @@
+module HomeHelper
+end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,0 +1,3 @@
+<h1>Home#index</h1>
+<p>Find me in app/views/home/index.html.erb</p>
+<p>Pipeline Test 1</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get 'home/index'
   get '/upload', to: 'certificates#upload'
   post '/upload', to: 'certificates#create'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  get 'home/index'
+  get 'home/index', to: 'home#index'
   get '/upload', to: 'certificates#upload'
   post '/upload', to: 'certificates#create'
 

--- a/lib/tasks/acceptance_tests.rake
+++ b/lib/tasks/acceptance_tests.rake
@@ -1,0 +1,7 @@
+require 'rspec/core/rake_task'
+
+desc 'Run acceptance tests'
+RSpec::Core::RakeTask.new(:acceptance_tests) do |t|
+  t.pattern = 'spec/acceptance/*_spec.rb'
+  t.rspec_opts = "--tag acceptance"
+end

--- a/spec/acceptance/visit_home_controller_acceptance_spec.rb
+++ b/spec/acceptance/visit_home_controller_acceptance_spec.rb
@@ -1,0 +1,12 @@
+require 'acceptance_helper'
+
+RSpec.describe 'Homepage', type: :feature, acceptance: true do
+
+  it 'shows greeting with JS', js: true do
+    #visit "https://#{ENV["TEST_URL"]}/home/index"
+    visit "https://verify-self-service-dev.cloudapps.digital/home/index"
+    expect(page).to have_content 'Home#index'
+    expect(page).to have_content 'Pipeline Test 1'
+  end
+
+end

--- a/spec/acceptance/visit_home_controller_acceptance_spec.rb
+++ b/spec/acceptance/visit_home_controller_acceptance_spec.rb
@@ -3,8 +3,7 @@ require 'acceptance_helper'
 RSpec.describe 'Homepage', type: :feature, acceptance: true do
 
   it 'shows greeting with JS', js: true do
-    #visit "https://#{ENV["TEST_URL"]}/home/index"
-    visit "https://verify-self-service-dev.cloudapps.digital/home/index"
+    visit "https://#{ENV["TEST_DOMAIN"]}/home/index"
     expect(page).to have_content 'Home#index'
     expect(page).to have_content 'Pipeline Test 1'
   end

--- a/spec/acceptance_helper.rb
+++ b/spec/acceptance_helper.rb
@@ -29,9 +29,6 @@ RSpec.configure do |config|
   # assertions if you prefer.
   config.filter_run_excluding :acceptance => true
 
-  if config.filter_manager.inclusions[:acceptance]
-
-  end
 
   # The settings below are suggested to provide a good initial experience
   # with RSpec, but feel free to customize to your heart's content.

--- a/spec/acceptance_helper.rb
+++ b/spec/acceptance_helper.rb
@@ -13,51 +13,28 @@
 # it.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
+require 'capybara/rspec'
+
+Capybara.configure do |config|
+  # config.run_server = false
+  config.default_driver = :selenium_headless
+  config.javascript_driver = :selenium_headless
+
+end
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.
-
   config.filter_run_excluding :acceptance => true
 
-  config.before(:each, type: :system) do
-    driven_by :rack_test
+  if config.filter_manager.inclusions[:acceptance]
+
   end
 
-  config.before(:each, type: :system, js: true) do
-    driven_by :selenium, using: :headless_firefox
-  end
-
-
-  config.expect_with :rspec do |expectations|
-    # This option will default to `true` in RSpec 4. It makes the `description`
-    # and `failure_message` of custom matchers include text for helper methods
-    # defined using `chain`, e.g.:
-    #     be_bigger_than(2).and_smaller_than(4).description
-    #     # => "be bigger than 2 and smaller than 4"
-    # ...rather than:
-    #     # => "be bigger than 2"
-    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
-  end
-
-  # rspec-mocks config goes here. You can use an alternate test double
-  # library (such as bogus or mocha) by changing the `mock_with` option here.
-  config.mock_with :rspec do |mocks|
-    # Prevents you from mocking or stubbing a method that does not exist on
-    # a real object. This is generally recommended, and will default to
-    # `true` in RSpec 4.
-    mocks.verify_partial_doubles = true
-  end
-
-  # This option will default to `:apply_to_host_groups` in RSpec 4 (and will
-  # have no way to turn it off -- the option exists only for backwards
-  # compatibility in RSpec 3). It causes shared context metadata to be
-  # inherited by the metadata hash of host groups and examples, rather than
-  # triggering implicit auto-inclusion in groups with matching metadata.
-  config.shared_context_metadata_behavior = :apply_to_host_groups
-
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
 =begin
   # This allows you to limit a spec run to individual examples or groups
   # you care about by tagging them with `:focus` metadata. When nothing
@@ -65,19 +42,16 @@ RSpec.configure do |config|
   # aliases for `it`, `describe`, and `context` that include `:focus`
   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
   config.filter_run_when_matching :focus
-
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend
   # you configure your source control system to ignore this file.
   config.example_status_persistence_file_path = "spec/examples.txt"
-
   # Limits the available syntax to the non-monkey patched syntax that is
   # recommended. For more details, see:
   #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
   config.disable_monkey_patching!
-
   # Many RSpec users commonly either run the entire suite or an individual
   # file, and it's useful to allow more verbose output when running an
   # individual spec file.
@@ -87,18 +61,15 @@ RSpec.configure do |config|
     # (e.g. via a command-line flag).
     config.default_formatter = "doc"
   end
-
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running
   # particularly slow.
   config.profile_examples = 10
-
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing
   # the seed, which is printed after each run.
   #     --seed 1234
   config.order = :random
-
   # Seed global randomization in this process using the `--seed` CLI option.
   # Setting this allows you to use `--seed` to deterministically reproduce
   # test failures related to randomization by passing the same `--seed` value

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe HomeController, type: :controller do
+
+  describe "GET #index" do
+    it "returns http success" do
+      get :index
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/system/visit_home_controller_spec.rb
+++ b/spec/system/visit_home_controller_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe 'Homepage', type: :system do
+  it 'shows greeting without JS' do
+    visit 'home/index'
+    expect(page).to have_content 'Home#index'
+  end
+
+  it 'shows greeting with JS', js: true do
+    visit 'home/index'
+    expect(page).to have_content 'Home#index'
+  end
+end


### PR DESCRIPTION
* Replaced Home view and Controller for a stable entry point for testing.
* Added Rake task for acceptance tests.
* Added basic acceptance test that visits the Home page.
* Added acceptance helper to configure the acceptance test environment.
* Filtered out acceptance tests so they do not run under when not required.
* Replaced system test for home page.

Co-authored-by: Rosa Fox <rosa.fox@digital.cabinet-office.gov.uk>
Co-authored-by: Olakunle Jegede <olakunle.jegede@digital.cabinet-office.gov.uk>

This is a new branch with all the work from the old one on top of master after my git-fu spectacularly failed me.