### PR TITLE
7kgfqv0Q: Add Procfile to run database migrations on PaaS

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: rake db:migrate && bin/rails server


### PR DESCRIPTION
This will run the database migrations on start up when deployed to PaaS

Co-authored-by: Rosa Fox <rosa.fox@digital.cabinet-office.gov.uk>