### PR TITLE
omtujEyR: Use PAAS backing service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ capybara-*.html
 /db/*.sqlite3
 /db/*.sqlite3-journal
 /public/system
+/public/assets/
 /coverage/
 /spec/tmp
 *.orig

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,8 @@ ruby '2.6.0'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.2'
-# Use sqlite3 as the database for Active Record
-gem 'sqlite3'
+# Use postgres as the database for Active Record
+gem 'pg'
 # Use Puma as the app server
 gem 'puma', '~> 3.11'
 # Use SCSS for stylesheets
@@ -42,6 +42,8 @@ group :development, :test do
   gem 'capybara'
   gem 'selenium-webdriver'
   gem 'geckodriver-helper'
+  # still use sqlite3 in development and testing.
+  gem 'sqlite3'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,7 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
+    pg (1.1.4)
     public_suffix (3.0.3)
     puma (3.12.0)
     rack (2.0.6)
@@ -212,6 +213,7 @@ DEPENDENCIES
   geckodriver-helper
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
+  pg
   puma (~> 3.11)
   rails (~> 5.2.2)
   rspec-rails

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,21 +5,24 @@
 #   gem 'sqlite3'
 #
 default: &default
-  adapter: sqlite3
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
+  encoding: unicode
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  adapter: sqlite3
+  database: db/vss_development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  adapter: sqlite3
+  database: db/vss_test.sqlite3
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  adapter: postgresql
+  url: <%= ENV['DATABASE_URL'] %>

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,4 +4,7 @@ applications:
   routes:
   - route: verify-self-service-((environment)).cloudapps.digital
   buildpacks:
-    - https://github.com/cloudfoundry/ruby-buildpack/releases/download/v1.7.30/ruby-buildpack-cflinuxfs2-v1.7.30.zip
+  - ruby_buildpack
+  services:
+  - verify-self-service-db
+


### PR DESCRIPTION
Update application config and CF manifest to use a Postgres backing
service that has been setup in GOV.UK PaaS.

co-authored-by: Olakunle Jegede <olakunle.jegede@digital.cabinet-office.gov.uk>