### PR TITLE
VavuzB9e: add an `Aggregate` class

### DIFF
--- a/app/models/aggregate.rb
+++ b/app/models/aggregate.rb
@@ -1,0 +1,4 @@
+class Aggregate < ApplicationRecord
+  self.abstract_class = true
+  has_many :events
+end

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -1,4 +1,4 @@
-class Certificate < ApplicationRecord
+class Certificate < Aggregate
   validates_inclusion_of :usage, in: ['signing', 'encryption']
   validates_presence_of :usage, :value
 end

--- a/spec/models/certificate_spec.rb
+++ b/spec/models/certificate_spec.rb
@@ -15,4 +15,10 @@ RSpec.describe Certificate, type: :model do
     expect(Certificate.new(usage: 'signing', value: nil)).to_not be_valid
     expect(Certificate.new(usage: nil, value: nil)).to_not be_valid
   end
+
+  it 'has events' do
+    event = UploadCertificateEvent.create!(usage: 'signing', value: 'foobar')
+    certificate = event.certificate
+    expect(certificate.events.to_a).to eql [event]
+  end
 end


### PR DESCRIPTION
Currently, just provides an association to events, but we will extend it
later with some extras (e.g. protection against out of event saving).