### PR TITLE
BAU: Remove Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: rake db:migrate && bin/rails server


### PR DESCRIPTION
We shouldn't need this file. It runs db:migration (again) which we don't want to
do when deployed.