### PR TITLE
JEayxx4g: improve interface of PKI support class

### DIFF
--- a/spec/models/certificate_spec.rb
+++ b/spec/models/certificate_spec.rb
@@ -4,9 +4,10 @@ include CertificateSupport
 
 RSpec.describe Certificate, type: :model do
 
-  root = PKI.new
-  good_cert = root.sign(generate_cert_with_expiry(Time.now + 2.months))
-  good_cert_value = PKI.inline_pem(good_cert)
+  let(:good_cert_value) {
+    root = PKI.new
+    root.generate_signed_cert(expires_in: 2.months).to_pem
+  }
 
   it "is valid with valid attributes" do
     expect(Certificate.new(usage: 'signing', value: good_cert_value)).to be_valid

--- a/spec/models/upload_certificate_event_spec.rb
+++ b/spec/models/upload_certificate_event_spec.rb
@@ -5,7 +5,7 @@ include CertificateSupport
 RSpec.describe UploadCertificateEvent, type: :model do
 
   root = PKI.new
-  good_cert_value = root.generate_encoded_cert_with_expiry(Time.now + 2.months)
+  good_cert_value = root.generate_encoded_cert(expires_in: 2.months)
 
   include_examples 'has data attributes', UploadCertificateEvent, [:usage, :value]
   include_examples 'is aggregated', UploadCertificateEvent, {usage: 'signing', value: good_cert_value }
@@ -30,7 +30,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
     end
 
     it 'must allow base64 encoded DER format x509 certificate' do
-      cert = root.generate_encoded_cert_with_expiry(Time.now + 2.months)
+      cert = root.generate_encoded_cert(expires_in: 2.months)
 
       event = UploadCertificateEvent.create(usage: 'signing', value: cert)
       expect(event).to be_valid
@@ -38,7 +38,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
     end
 
     it 'must allow PEM format x509 certificate' do
-      cert = root.generate_signed_cert_with_expiry Time.now + 2.months
+      cert = root.generate_signed_cert(expires_in: 2.months)
 
       event = UploadCertificateEvent.create(usage: 'signing', value: cert.to_pem)
       expect(event).to be_valid
@@ -46,7 +46,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
     end
 
     it 'must not be expired' do
-      cert = root.generate_encoded_cert_with_expiry Time.now - 1.months
+      cert = root.generate_encoded_cert(expires_in: -1.months)
 
       event = UploadCertificateEvent.create(usage: 'signing', value: cert)
       expect(event).to_not be_valid
@@ -54,7 +54,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
     end
 
     it 'must not expire within 1 month' do
-      cert = root.generate_encoded_cert_with_expiry Time.now + 15.days
+      cert = root.generate_encoded_cert(expires_in: 15.days)
 
       event = UploadCertificateEvent.create(usage: 'signing', value: cert)
       expect(event).to_not be_valid
@@ -62,7 +62,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
     end
 
     it 'must expire within 1 year' do
-      cert = root.generate_encoded_cert_with_expiry Time.now + 2.years
+      cert = root.generate_encoded_cert(expires_in: 2.years)
 
       event = UploadCertificateEvent.create(usage: 'signing', value: cert)
       expect(event).to_not be_valid
@@ -70,7 +70,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
     end
 
     it 'must be RSA' do
-      cert = root.generate_signed_ec_cert(Time.now + 6.months)
+      cert = root.generate_signed_ec_cert(6.months)
 
       event = UploadCertificateEvent.create(usage: 'signing', value: cert.to_pem)
       expect(event).to_not be_valid
@@ -78,8 +78,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
     end
 
     it 'must be at least 2048 bits' do
-      cert = root.generate_signed_rsa_cert_and_key(1024, Time.now + 6.months)[0]
-
+      cert = root.generate_signed_rsa_cert_and_key(size: 1024)[0]
 
       event = UploadCertificateEvent.create(usage: 'signing', value: cert.to_pem)
       expect(event).to_not be_valid

--- a/spec/support/certificate_support.rb
+++ b/spec/support/certificate_support.rb
@@ -1,33 +1,30 @@
 module CertificateSupport
-
-  def generate_cert_with_expiry(expiry, cn = "GENERATED TEST CERTIFICATE")
-    generate_rsa_cert_and_key(2048, expiry, cn)[0]
+  def generate_cert(**args)
+    generate_rsa_cert_and_key(args)[0]
   end
 
-  def generate_cert(cn = "GENERATED TEST CERTIFICATE")
-    generate_rsa_cert_and_key(2048, (Time.now + 1.year), cn)[0]
-  end
-
-  def generate_rsa_cert_and_key(size, expiry, cn = "GENERATED TEST CERTIFICATE")
+  def generate_rsa_cert_and_key(expires_in: 1.year, size: 2048, cn: "GENERATED TEST CERTIFICATE")
     key = OpenSSL::PKey::RSA.new size
-    generate_cert_using_key(key.public_key, expiry, cn)
+    generate_cert_using_key(key.public_key, expires_in, cn)
   end
 
-  def generate_ec_cert_and_key(expiry, cn = "GENERATED TEST CERTIFICATE")
+  def generate_ec_cert_and_key(expires_in: 1.year, size: 2048, cn: "GENERATED TEST CERTIFICATE")
     ec_key = OpenSSL::PKey::EC.new('prime256v1').generate_key!
     point = ec_key.public_key
     key = OpenSSL::PKey::EC.new(point.group)
     key.public_key = point
-    generate_cert_using_key(key, expiry, cn)
+    generate_cert_using_key(key, expires_in, cn)
   end
 
-  def generate_cert_using_key(public_key, expiry, cn = "GENERATED TEST CERTIFICATE")
+  private
+
+  def generate_cert_using_key(public_key, expires_in, cn)
     cert = OpenSSL::X509::Certificate.new
     cert.version = 2
     cert.subject = OpenSSL::X509::Name.parse "/DC=org/DC=TEST/CN=#{cn}"
     cert.public_key = public_key
-    cert.not_before = expiry - 5.years
-    cert.not_after = expiry
+    cert.not_before = Time.now - 5.years
+    cert.not_after = Time.now + expires_in
     [cert, public_key]
   end
 

--- a/spec/support/pki.rb
+++ b/spec/support/pki.rb
@@ -51,30 +51,26 @@ class PKI
     cert
   end
 
-  def generate_signed_cert_with_expiry(time)
-    sign(generate_cert_with_expiry(time))
+  def generate_signed_cert(**args)
+    sign(generate_cert(args))
   end
 
-  def generate_encoded_cert_with_expiry(time)
-    Base64.strict_encode64(generate_signed_cert_with_expiry(time).to_der)
+  def generate_encoded_cert(**args)
+    Base64.strict_encode64(generate_signed_cert(args).to_der)
   end
 
-  def generate_signed_ec_cert(time)
-    cert = generate_ec_cert_and_key(time)[0]
-    self.sign cert
+  def generate_signed_ec_cert(period)
+    cert, _key = *generate_ec_cert_and_key(expires_in: period)
+    sign(cert)
   end
 
-  def generate_signed_rsa_cert_and_key(size, time)
-    cert, key = *generate_rsa_cert_and_key(size, time)
+  def generate_signed_rsa_cert_and_key(**args)
+    cert, key = *generate_rsa_cert_and_key(args)
     [self.sign(cert), key]
   end
 
-  def generate_signed_cert(cn = "SIGNED TEST CERTIFICATE")
-    sign(generate_cert(cn))
-  end
-
-  def generate_signed_cert_and_private_key(cn = "SIGNED TEST CERTIFICATE")
-    cert, key = *generate_cert_and_key((Time.now+60*60*24*365), cn)
+  def generate_signed_cert_and_private_key(**args)
+    cert, key = *generate_cert_and_key(args)
     [sign(cert), key]
   end
 

--- a/spec/system/user_visits_events_page_spec.rb
+++ b/spec/system/user_visits_events_page_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe 'the events page', type: :system do
   let(:root) { PKI.new }
 
   it 'there are some events' do
-    good_cert_1 = root.generate_encoded_cert_with_expiry(Time.now + 2.months)
-    good_cert_2 = root.generate_encoded_cert_with_expiry(Time.now + 2.months)
-    good_cert_3 = root.generate_encoded_cert_with_expiry(Time.now + 2.months)
+    good_cert_1 = root.generate_encoded_cert(expires_in: 2.months)
+    good_cert_2 = root.generate_encoded_cert(expires_in: 2.months)
+    good_cert_3 = root.generate_encoded_cert(expires_in: 2.months)
 
     UploadCertificateEvent.create(usage: 'signing', value: good_cert_1)
     UploadCertificateEvent.create(usage: 'signing', value: good_cert_2)
@@ -22,7 +22,7 @@ RSpec.describe 'the events page', type: :system do
 
   it 'is paginated' do
     events = 55.times.map do
-      UploadCertificateEvent.create(usage: 'signing', value: root.generate_encoded_cert_with_expiry(Time.now + 2.months))
+      UploadCertificateEvent.create(usage: 'signing', value: root.generate_encoded_cert(expires_in: 2.months))
     end.reverse
 
     visit events_path

--- a/spec/system/visit_upload_page_spec.rb
+++ b/spec/system/visit_upload_page_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'UploadPage', type: :system do
   let(:root) { PKI.new }
 
   let(:test_certificate) do
-    good_cert = root.generate_encoded_cert_with_expiry(Time.now + 2.months)
+    root.generate_encoded_cert(expires_in: 2.months)
   end
 
   it 'successfully submits a certificate' do


### PR DESCRIPTION
# What
This PR introduces optional arguments for `PKI` to control the content of the certificate. 

# Why
This should allow for easy extensibility.