### PR TITLE
0xDiu18N: Fix govuk assets loading

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -11,4 +11,5 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
-# Rails.application.config.assets.precompile += %w( admin.js admin.css )
+Rails.application.config.assets.precompile << %r{govuk-frontend/assets/fonts/[\w-]+\.(?:eot|woff|woff2?)$}
+Rails.application.config.assets.precompile << %r{govuk-frontend/assets/images/[\w-]+\.(?:ico|svg|png?)$}


### PR DESCRIPTION
When deployed, the govuk-frontend assets are missing. We need
to explicitly add them to the asset pipeline.

Caused by https://github.com/rails/rails/issues/29563