### PR TITLE
0xDiu18N: Fix assets

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,3 +6,5 @@ require_relative 'config/application'
 Rails.application.load_tasks
 
 task :spec => ["yarn:install"]
+
+task "assets:precompile" => ["copy_govuk_dependencies"]

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -11,5 +11,4 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
-Rails.application.config.assets.precompile << %r{govuk-frontend/assets/fonts/[\w-]+\.(?:eot|woff|woff2?)$}
-Rails.application.config.assets.precompile << %r{govuk-frontend/assets/images/[\w-]+\.(?:ico|svg|png?)$}
+# Rails.application.config.assets.precompile += %w( admin.js admin.css )

--- a/lib/tasks/copy_govuk_dependencies.rake
+++ b/lib/tasks/copy_govuk_dependencies.rake
@@ -1,0 +1,11 @@
+require 'fileutils'
+
+desc 'Copy govuk-frontend assets'
+task 'copy_govuk_dependencies' do
+  source = 'node_modules/govuk-frontend/assets/'
+  destination = 'public/assets/govuk-frontend/assets/'
+
+  dirname = File.dirname(destination)
+  FileUtils.mkdir_p(dirname)
+  FileUtils.copy_entry source, destination
+end


### PR DESCRIPTION
In the previous attempt the assets got copied correctly but included digest.
Given the files are referenced by a library, that wouldn't work.
Therefore adding a new Rake task to handle copying the dependencies over.

[Known issue](https://github.com/rails/rails/issues/29563)