### PR TITLE
bau: use a link helper for stray link

### DIFF
--- a/app/views/certificates/index.html.erb
+++ b/app/views/certificates/index.html.erb
@@ -19,6 +19,4 @@
   </tbody>
 </table>
 
-<a href="/upload" role="button" draggable="false" class="govuk-button govuk-button--start">
-  Upload a certificate
-</a>
+<%= link_to('Upload a certificate', upload_path, {class:  "govuk-button govuk-button--start", role: 'button', draggable: 'false'}) %>


### PR DESCRIPTION
We should be using link_to for all local links as this will ensure that
the any base paths are added if they're needed.