### PR TITLE
ee2PV5rg - model signing cert rotation

### DIFF
--- a/app/controllers/certificates_controller.rb
+++ b/app/controllers/certificates_controller.rb
@@ -14,13 +14,26 @@ class CertificatesController < ApplicationController
     end
   end
 
+  def update
+    certificate = Certificate.find(params[:id])
+    if certificate.enabled
+      certificate.enabled = false
+    else
+      certificate.enabled = true
+    end
+
+    certificate.save
+
+    redirect_to component_path(certificate.component_id)
+  end
+
   private
 
   def upload_params
     component_id ||= params[:component_id]
 
     params.require(:certificate)
-          .permit(:value,:usage)
+          .permit(:value, :usage, :id)
           .merge(component_id: component_id)
 
   end

--- a/app/controllers/certificates_controller.rb
+++ b/app/controllers/certificates_controller.rb
@@ -15,16 +15,9 @@ class CertificatesController < ApplicationController
   end
 
   def update
-    certificate = Certificate.find(params[:id])
-    if certificate.enabled
-      certificate.enabled = false
-    else
-      certificate.enabled = true
-    end
-
-    certificate.save
-
-    redirect_to component_path(certificate.component_id)
+    @certificate = Certificate.find(params[:id])
+    @certificate.update_attributes(update_params)
+    redirect_to component_path(@certificate.component_id)
   end
 
   private
@@ -36,5 +29,10 @@ class CertificatesController < ApplicationController
           .permit(:value, :usage, :id)
           .merge(component_id: component_id)
 
+  end
+
+  def update_params
+    params.require(:certificate)
+        .permit(:enabled)
   end
 end

--- a/app/controllers/certificates_controller.rb
+++ b/app/controllers/certificates_controller.rb
@@ -26,7 +26,7 @@ class CertificatesController < ApplicationController
     component_id ||= params[:component_id]
 
     params.require(:certificate)
-          .permit(:value, :usage, :id)
+          .permit(:value, :usage)
           .merge(component_id: component_id)
 
   end

--- a/app/controllers/components_controller.rb
+++ b/app/controllers/components_controller.rb
@@ -9,7 +9,6 @@ class ComponentsController < ApplicationController
 
   def show
     @component = Component.find(params[:id])
-    @component_certificates = @component.certificates
   end
 
   def create

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -3,6 +3,10 @@ class Component < Aggregate
   has_many :certificates
   has_many :signing_certificates,
            -> { where(usage: 'signing') }, class_name: 'Certificate'
+  has_many :enabled_signing_certificates,
+           -> { where(usage: 'signing', enabled: true) }, class_name: 'Certificate'
+  has_many :disabled_signing_certificates,
+           -> { where(usage: 'signing', enabled: false) }, class_name: 'Certificate'
   has_one :encryption_certificate,
           -> { where(usage: 'encryption').order(id: 'DESC') },
           class_name: 'Certificate'

--- a/app/views/certificates/_certificates_table.html.erb
+++ b/app/views/certificates/_certificates_table.html.erb
@@ -1,0 +1,27 @@
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+  <tr class="govuk-table__row">
+    <th class="govuk-table__header" scope="col">Last updated</th>
+    <th class="govuk-table__header" scope="col">ID</th>
+    <th class="govuk-table__header" scope="col">Usage</th>
+    <th class="govuk-table__header" scope="col">Enabled</th>
+    <th class="govuk-table__header" scope="col"></th>
+  </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+  <% @certificates.each do |certificate| %>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell"><%= format_date_time(certificate.updated_at) %></td>
+      <td class="govuk-table__cell"><%= certificate.id %></td>
+      <td class="govuk-table__cell"><%= certificate.usage %></td>
+      <td class="govuk-table__cell"><%= certificate.enabled %></td>
+      <td class="govuk-table__cell">
+        <%= form_for [@component, certificate], method: :patch do |f| %>
+          <%= f.hidden_field :enabled, value: !certificate.enabled %>
+          <%= f.submit certificate.enabled ? 'Disable' : 'Enable', class: 'govuk-button' %>
+        <% end %>
+      </td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/app/views/certificates/_certificates_table.html.erb
+++ b/app/views/certificates/_certificates_table.html.erb
@@ -10,7 +10,7 @@
   </thead>
   <tbody class="govuk-table__body">
   <% @certificates.each do |certificate| %>
-    <tr class="govuk-table__row">
+    <tr class="govuk-table__row" id="certificate_table_<%= certificate.id %>">
       <td class="govuk-table__cell"><%= format_date_time(certificate.updated_at) %></td>
       <td class="govuk-table__cell"><%= certificate.id %></td>
       <td class="govuk-table__cell"><%= certificate.usage %></td>

--- a/app/views/components/index.html.erb
+++ b/app/views/components/index.html.erb
@@ -1,8 +1,7 @@
-<h1>Components#index</h1>
+<h1 class="govuk-heading-xl">Components</h1>
 
 <% if @components.present? %>
   <table class="govuk-table">
-    <h3 class="govuk-heading-m">Components</h3>
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col">Name</th>

--- a/app/views/components/show.html.erb
+++ b/app/views/components/show.html.erb
@@ -1,69 +1,45 @@
-<h1 class="govuk-heading-l"><%= @component.name %></h1>
+<h1 class="govuk-heading-xl"><%= @component.name %></h1>
 
-<h2 class="govuk-heading-m"><%= @component.component_type %></h2>
+<h2 class="govuk-heading-l"><%= @component.component_type %></h2>
 
 
 </table>
 <%= link_to 'Upload', new_component_certificate_path(@component), class: 'govuk-button' %>
 
-<table class="govuk-table">
-  <h3 class="govuk-heading-m">Signing Certificates Enabled</h3>
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th class="govuk-table__header" scope="col">Last updated</th>
-      <th class="govuk-table__header" scope="col"></th>
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body">
-    <% @component.enabled_signing_certificates.each do |certificate| %>
-      <tr class="govuk-table__row">
-        <td class="govuk-table__cell"><%= format_date_time(certificate.updated_at) %></td>
-        <td class="govuk-table__cell">
-          <%= form_for [@component, certificate], method: :put do |f| %>
-              <%= f.submit "Disable" %>
-          <% end %>
-        </td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<h3 class="govuk-heading-m">Signing Certificates (Enabled)</h3>
+<% @certificates =  @component.enabled_signing_certificates %>
+<%= render "certificates/certificates_table" %>
 
-<table class="govuk-table">
-  <h3 class="govuk-heading-m">Signing Certificates Disabled</h3>
-  <thead class="govuk-table__head">
-  <tr class="govuk-table__row">
-    <th class="govuk-table__header" scope="col">Last updated</th>
-    <th class="govuk-table__header" scope="col"></th>
-  </tr>
-  </thead>
-  <tbody class="govuk-table__body">
-  <% @component.disabled_signing_certificates.each do |certificate| %>
-      <tr class="govuk-table__row">
-        <td class="govuk-table__cell"><%= format_date_time(certificate.updated_at) %></td>
-        <td class="govuk-table__cell">
-          <%= form_for [@component, certificate], method: :put do |f| %>
-              <%= f.submit "Enable" %>
-          <% end %>
-        </td>
-      </tr>
-  <% end %>
-  </tbody>
-</table>
+<h3 class="govuk-heading-m">Signing Certificates (Disabled)</h3>
+<% @certificates =  @component.disabled_signing_certificates %>
+<%= render "certificates/certificates_table" %>
+
 
 <% if @component.certificates.present? %>
     <table class="govuk-table">
-      <h3 class="govuk-heading-m">All certificates currently in use</h3>
+      <h3 class="govuk-heading-m">All certificates for this component</h3>
       <thead class="govuk-table__head">
       <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="col">ID</th>
         <th class="govuk-table__header" scope="col">Usage</th>
+        <th class="govuk-table__header" scope="col">Enabled</th>
         <th class="govuk-table__header" scope="col">Last updated</th>
+        <th class="govuk-table__header" scope="col"></th>
       </tr>
       </thead>
       <tbody class="govuk-table__body">
       <% @component.certificates.each do |certificate| %>
           <tr class="govuk-table__row">
+            <td class="govuk-table__cell" scope="row"><%= certificate.id %></td>
             <td class="govuk-table__cell" scope="row"><%= certificate.usage %></td>
+            <td class="govuk-table__cell" scope="row"><%= certificate.enabled %></td>
             <td class="govuk-table__cell"><%= format_date_time(certificate.updated_at) %></td>
+            <td class="govuk-table__cell">
+              <%= form_for [@component, certificate], method: :put do |f| %>
+                <%= f.hidden_field :enabled, value: !certificate.enabled %>
+                <%= f.submit "Enable/Disable", class: "govuk-button" %>
+              <% end %>
+            </td>
           </tr>
       <% end %>
       </tbody>

--- a/app/views/components/show.html.erb
+++ b/app/views/components/show.html.erb
@@ -2,8 +2,6 @@
 
 <h2 class="govuk-heading-l"><%= @component.component_type %></h2>
 
-
-</table>
 <%= link_to 'Upload', new_component_certificate_path(@component), class: 'govuk-button' %>
 
 <h3 class="govuk-heading-m">Signing Certificates (Enabled)</h3>
@@ -16,22 +14,22 @@
 
 
 <% if @component.certificates.present? %>
+  <h3 class="govuk-heading-m">All certificates for this component</h3>
     <table class="govuk-table">
-      <h3 class="govuk-heading-m">All certificates for this component</h3>
       <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        <th class="govuk-table__header" scope="col">ID</th>
-        <th class="govuk-table__header" scope="col">Usage</th>
-        <th class="govuk-table__header" scope="col">Enabled</th>
-        <th class="govuk-table__header" scope="col">Last updated</th>
+        <th class="govuk-table__header">ID</th>
+        <th class="govuk-table__header">Usage</th>
+        <th class="govuk-table__header">Enabled</th>
+        <th class="govuk-table__header">Last updated</th>
       </tr>
       </thead>
       <tbody class="govuk-table__body">
       <% @component.certificates.each do |certificate| %>
           <tr class="govuk-table__row">
-            <td class="govuk-table__cell" scope="row"><%= certificate.id %></td>
-            <td class="govuk-table__cell" scope="row"><%= certificate.usage %></td>
-            <td class="govuk-table__cell" scope="row"><%= certificate.enabled %></td>
+            <td class="govuk-table__cell"><%= certificate.id %></td>
+            <td class="govuk-table__cell"><%= certificate.usage %></td>
+            <td class="govuk-table__cell"><%= certificate.enabled %></td>
             <td class="govuk-table__cell"><%= format_date_time(certificate.updated_at) %></td>
           </tr>
       <% end %>

--- a/app/views/components/show.html.erb
+++ b/app/views/components/show.html.erb
@@ -1,39 +1,63 @@
-<h1><%= @component.name %></h1>
+<h1 class="govuk-heading-l"><%= @component.name %></h1>
 
-<table class="govuk-table">
-  <h3 class="govuk-heading-m">Certificates to upload</h3>
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th class="govuk-table__header" scope="col">Name</th>
-      <th class="govuk-table__header" scope="col">Type</th>
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body">
-      <tr class="govuk-table__row">
-        <td class="govuk-table__cell" scope="row"><%= @component.name %></td>
-        <td class="govuk-table__cell"><%= @component.component_type %></td>
-      </tr>
-  </tbody>
+<h2 class="govuk-heading-m"><%= @component.component_type %></h2>
+
 
 </table>
 <%= link_to 'Upload', new_component_certificate_path(@component), class: 'govuk-button' %>
 
-<% if @component_certificates.present? %>
-  <table class="govuk-table">
-    <h3 class="govuk-heading-m">Certificates currently in use</h3>
-    <thead class="govuk-table__head">
+<table class="govuk-table">
+  <h3 class="govuk-heading-m">Signing Certificates Enabled</h3>
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header" scope="col">Last updated</th>
+      <th class="govuk-table__header" scope="col"></th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <% @component.enabled_signing_certificates.each do |certificate| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell"><%= format_date_time(certificate.updated_at) %></td>
+        <td class="govuk-table__cell">Disable</td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<table class="govuk-table">
+  <h3 class="govuk-heading-m">Signing Certificates Disabled</h3>
+  <thead class="govuk-table__head">
+  <tr class="govuk-table__row">
+    <th class="govuk-table__header" scope="col">Last updated</th>
+    <th class="govuk-table__header" scope="col"></th>
+  </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+  <% @component.disabled_signing_certificates.each do |certificate| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell"><%= format_date_time(certificate.updated_at) %></td>
+        <td class="govuk-table__cell">Enable</td>
+      </tr>
+  <% end %>
+  </tbody>
+</table>
+
+<% if @component.certificates.present? %>
+    <table class="govuk-table">
+      <h3 class="govuk-heading-m">All certificates currently in use</h3>
+      <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col">Usage</th>
         <th class="govuk-table__header" scope="col">Last updated</th>
       </tr>
-    </thead>
-    <tbody class="govuk-table__body">
-      <% @component_certificates.each do |certificate| %>
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell" scope="row"><%= certificate.usage %></td>
-          <td class="govuk-table__cell"><%= format_date_time(certificate.updated_at) %></td>
-        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+      <% @component.certificates.each do |certificate| %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell" scope="row"><%= certificate.usage %></td>
+            <td class="govuk-table__cell"><%= format_date_time(certificate.updated_at) %></td>
+          </tr>
       <% end %>
-    </tbody>
-  </table>
+      </tbody>
+    </table>
 <% end %>

--- a/app/views/components/show.html.erb
+++ b/app/views/components/show.html.erb
@@ -24,7 +24,6 @@
         <th class="govuk-table__header" scope="col">Usage</th>
         <th class="govuk-table__header" scope="col">Enabled</th>
         <th class="govuk-table__header" scope="col">Last updated</th>
-        <th class="govuk-table__header" scope="col"></th>
       </tr>
       </thead>
       <tbody class="govuk-table__body">
@@ -34,12 +33,6 @@
             <td class="govuk-table__cell" scope="row"><%= certificate.usage %></td>
             <td class="govuk-table__cell" scope="row"><%= certificate.enabled %></td>
             <td class="govuk-table__cell"><%= format_date_time(certificate.updated_at) %></td>
-            <td class="govuk-table__cell">
-              <%= form_for [@component, certificate], method: :put do |f| %>
-                <%= f.hidden_field :enabled, value: !certificate.enabled %>
-                <%= f.submit "Enable/Disable", class: "govuk-button" %>
-              <% end %>
-            </td>
           </tr>
       <% end %>
       </tbody>

--- a/app/views/components/show.html.erb
+++ b/app/views/components/show.html.erb
@@ -18,7 +18,11 @@
     <% @component.enabled_signing_certificates.each do |certificate| %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell"><%= format_date_time(certificate.updated_at) %></td>
-        <td class="govuk-table__cell">Disable</td>
+        <td class="govuk-table__cell">
+          <%= form_for [@component, certificate], method: :put do |f| %>
+              <%= f.submit "Disable" %>
+          <% end %>
+        </td>
       </tr>
     <% end %>
   </tbody>
@@ -36,7 +40,11 @@
   <% @component.disabled_signing_certificates.each do |certificate| %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell"><%= format_date_time(certificate.updated_at) %></td>
-        <td class="govuk-table__cell">Enable</td>
+        <td class="govuk-table__cell">
+          <%= form_for [@component, certificate], method: :put do |f| %>
+              <%= f.submit "Enable" %>
+          <% end %>
+        </td>
       </tr>
   <% end %>
   </tbody>

--- a/db/migrate/20190424150803_add_enabled_to_certificates.rb
+++ b/db/migrate/20190424150803_add_enabled_to_certificates.rb
@@ -1,0 +1,5 @@
+class AddEnabledToCertificates < ActiveRecord::Migration[5.2]
+  def change
+    add_column :certificates, :enabled, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_10_203341) do
+ActiveRecord::Schema.define(version: 2019_04_24_150803) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -39,6 +39,7 @@ ActiveRecord::Schema.define(version: 2019_04_10_203341) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "component_id"
+    t.boolean "enabled", default: true
     t.index ["component_id"], name: "index_certificates_on_component_id"
   end
 

--- a/spec/system/visit_component_show_spec.rb
+++ b/spec/system/visit_component_show_spec.rb
@@ -12,10 +12,6 @@ RSpec.describe 'New Component Page', type: :system do
 
   let(:component) { NewComponentEvent.create(component_params).component }
 
-  # let(:root) { PKI.new }
-  # let(:test_certificate_1){root.generate_encoded_cert(expires_in: 2.months)}
-  # let(:test_certificate_2){root.generate_encoded_cert(expires_in: 2.months)}
-
   let(:upload_certs) do
         root = PKI.new
         x509_cert_1 = root.generate_encoded_cert(expires_in: 2.months)

--- a/spec/system/visit_component_show_spec.rb
+++ b/spec/system/visit_component_show_spec.rb
@@ -1,9 +1,29 @@
 require 'rails_helper'
+require 'auth_test_helper'
 
 RSpec.describe 'New Component Page', type: :system do
+
+  before(:each) do
+    stub_auth
+  end
+
   component_name = 'test component'
   component_params = {component_type: 'MSA', name: component_name}
+
   let(:component) { NewComponentEvent.create(component_params).component }
+
+  # let(:root) { PKI.new }
+  # let(:test_certificate_1){root.generate_encoded_cert(expires_in: 2.months)}
+  # let(:test_certificate_2){root.generate_encoded_cert(expires_in: 2.months)}
+
+  let(:upload_certs) do
+        root = PKI.new
+        x509_cert_1 = root.generate_encoded_cert(expires_in: 2.months)
+        x509_cert_2 = root.generate_encoded_cert(expires_in: 9.months)
+        UploadCertificateEvent.create({usage: "signing", value: x509_cert_1, component_id: component.id}).certificate
+        UploadCertificateEvent.create({usage: "signing", value: x509_cert_2, component_id: component.id}).certificate
+  end
+
 
   it 'successfully creates a new component' do
     visit component_path(component.id)
@@ -11,4 +31,65 @@ RSpec.describe 'New Component Page', type: :system do
     expect(page).to have_selector('h1', text: component_name)
     expect(page).to have_link 'Upload'
   end
+
+  it 'shows list of enabled signing certificates' do
+    upload_certs
+    certs = component.certificates
+    visit component_path(component.id)
+    expect(page).to have_selector("#edit_certificate_#{certs[0].id}")
+    expect(page).to have_selector("#edit_certificate_#{certs[1].id}")
+  end
+
+  it 'successfully disables a certificate' do
+    upload_certs
+    certs = component.enabled_signing_certificates
+    visit component_path(component.id)
+    expect(page).to have_selector("#certificate_table_#{certs[0].id}")
+    button_element = page.find(:css, "#edit_certificate_#{certs[0].id} > input[name='commit']")
+    button_element.click
+
+    expect(page).to have_selector('h1', text: component_name)
+    expect(page).to have_selector("#edit_certificate_#{certs[0].id}")
+    expect(page).to have_selector("#edit_certificate_#{certs[1].id}")
+    expect(page).to have_selector("#certificate_table_#{certs[0].id} > td:nth-child(4)", text: "false")
+
+  end
+
+  it 'shows list of disabled certificates' do
+    upload_certs
+    certs = component.enabled_signing_certificates
+    visit component_path(component.id)
+    button_element = page.find(:css, "#edit_certificate_#{certs[0].id} > input[name='commit']")
+    button_element.click
+    button_element = page.find(:css, "#edit_certificate_#{certs[1].id} > input[name='commit']")
+    button_element.click
+
+    disabled_certs = component.disabled_signing_certificates
+
+    expect(page).to have_selector('h1', text: component_name)
+    expect(page).to have_selector("#certificate_table_#{disabled_certs[0].id} > td:nth-child(4)", text: "false")
+    expect(page).to have_selector("#certificate_table_#{disabled_certs[1].id} > td:nth-child(4)", text: "false")
+
+  end
+
+  it 'successfully enables a certificate' do
+    upload_certs
+    certs = component.enabled_signing_certificates
+    visit component_path(component.id)
+    button_element = page.find(:css, "#edit_certificate_#{certs[0].id} > input[name='commit']")
+    button_element.click
+    button_element = page.find(:css, "#edit_certificate_#{certs[1].id} > input[name='commit']")
+    button_element.click
+
+    disabled_certs = component.disabled_signing_certificates
+
+    expect(page).to have_selector("#certificate_table_#{disabled_certs[0].id}")
+    button_element = page.find(:css, "#edit_certificate_#{disabled_certs[0].id} > input[name='commit']")
+    button_element.click
+
+    expect(page).to have_selector('h1', text: component_name)
+    expect(page).to have_selector("#certificate_table_#{disabled_certs[0].id} > td:nth-child(4)", text: "true")
+
+  end
+
 end

--- a/spec/system/visit_index_page_spec.rb
+++ b/spec/system/visit_index_page_spec.rb
@@ -3,11 +3,11 @@ require 'rails_helper'
 RSpec.describe 'IndexPage', type: :system do
   it 'shows greeting without JS' do
     visit '/'
-    expect(page).to have_content 'Components#index'
+    expect(page).to have_content 'Components'
   end
 
   it 'shows greeting with JS', js: true do
     visit '/'
-    expect(page).to have_content 'Components#index'
+    expect(page).to have_content 'Components'
   end
 end

--- a/spec/system/visit_upload_page_spec.rb
+++ b/spec/system/visit_upload_page_spec.rb
@@ -19,7 +19,9 @@ RSpec.describe 'UploadPage', type: :system do
     choose 'certificate_usage_signing', allow_label_click: true
     fill_in 'certificate_value', with: test_certificate
     click_button 'Upload'
-    expect(page).to have_content component.certificates.last.usage
+    expect(page).to have_selector ("#edit_certificate_#{component.certificates.last.id}")
     expect(current_path).to eql component_path(component)
+
   end
+
 end


### PR DESCRIPTION
This is initial PR for the ticket: [model-signing-certificate-rotation-in-the-app](https://trello.com/c/ee2PV5rg/348-model-signing-certificate-rotation-in-the-app). 

* Added a boolean enabled column to the certificates table that is set true by default.
* In the component view show separate tables for 'Signing certs (enabled)' and 'Signing certs (disabled)'
* Provide buttons for the entries in those tables to update the certificate enabled setting.
* Add tests to exercise these buttons.

Todo:
* Create events for enabling and disabling the certificates
* Drive changes to the event status on the certificate from the events.