### PR TITLE
Eox5bz3c - events for enabling and disabling signing certificates

### DIFF
--- a/app/controllers/certificates_controller.rb
+++ b/app/controllers/certificates_controller.rb
@@ -16,7 +16,12 @@ class CertificatesController < ApplicationController
 
   def update
     @certificate = Certificate.find(params[:id])
-    @certificate.update_attributes(update_params)
+
+    if @certificate.enabled
+      DisableSigningCertificateEvent.create(certificate: @certificate)
+    else
+      EnableSigningCertificateEvent.create(certificate: @certificate)
+    end
     redirect_to component_path(@certificate.component_id)
   end
 
@@ -28,7 +33,6 @@ class CertificatesController < ApplicationController
     params.require(:certificate)
           .permit(:value, :usage, :id)
           .merge(component_id: component_id)
-
   end
 
   def update_params

--- a/app/models/disable_signing_certificate_event.rb
+++ b/app/models/disable_signing_certificate_event.rb
@@ -1,0 +1,6 @@
+class DisableSigningCertificateEvent < SigningCertificateEvent
+
+  def enabled
+    false
+  end
+end

--- a/app/models/enable_signing_certificate_event.rb
+++ b/app/models/enable_signing_certificate_event.rb
@@ -1,0 +1,6 @@
+class EnableSigningCertificateEvent < SigningCertificateEvent
+
+  def enabled
+    true
+  end
+end

--- a/app/models/signing_certificate_event.rb
+++ b/app/models/signing_certificate_event.rb
@@ -1,0 +1,16 @@
+class SigningCertificateEvent < AggregatedEvent
+  self.abstract_class = true
+  belongs_to_aggregate :certificate
+  validates_presence_of :certificate
+  validate :certificate_is_signing?
+
+  def attributes_to_apply
+    { enabled: enabled }
+  end
+
+  def certificate_is_signing?
+    return if certificate.usage == 'signing'
+
+    errors.add(:signing_certificate_event, 'signing certificate required')
+  end
+end

--- a/app/models/signing_certificate_event.rb
+++ b/app/models/signing_certificate_event.rb
@@ -1,11 +1,21 @@
 class SigningCertificateEvent < AggregatedEvent
   self.abstract_class = true
+  data_attributes :usage, :value, :component_id, :id, :enabled, :created_at
   belongs_to_aggregate :certificate
   validates_presence_of :certificate
   validate :certificate_is_signing?
 
   def attributes_to_apply
+    assign_attributes(event_metadata_hash)
     { enabled: enabled }
+  end
+
+  private
+
+  def event_metadata_hash
+    certificate.attributes.slice(
+      'usage', 'value', 'component_id', 'id', 'enabled', 'created_at'
+    )
   end
 
   def certificate_is_signing?

--- a/spec/models/disable_signing_certificate_event_spec.rb
+++ b/spec/models/disable_signing_certificate_event_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe DisableSigningCertificateEvent, type: :model do
+  include CertificateSupport
+  root = PKI.new
+  good_cert_value = root.generate_encoded_cert(expires_in: 2.months)
+  expired_cert_value = root.generate_encoded_cert(expires_in: -2.months)
+  component_params = { component_type: 'SP', name: 'Test Service Provider' }
+  component = NewComponentEvent.create(component_params).component
+
+  let(:signing_certificate) do
+    UploadCertificateEvent.create(
+        usage: 'signing', value: good_cert_value, component_id: component.id
+    ).certificate
+  end
+
+  let(:expired_signing_certificate) do
+    UploadCertificateEvent.create(
+        usage: 'signing', value: expired_cert_value, component_id: component.id
+    ).certificate
+  end
+
+  let(:encryption_certificate) do
+    UploadCertificateEvent.create(
+        usage: 'encryption', value: good_cert_value, component_id: component.id
+    ).certificate
+  end
+
+  def disable_signing_certificate_event
+    DisableSigningCertificateEvent.create(certificate: signing_certificate)
+  end
+
+
+  it 'disables a signing certificate' do
+    cert = disable_signing_certificate_event.certificate
+    expect(cert.enabled).to eq(false)
+  end
+
+  it 'must be persisted' do
+    event = disable_signing_certificate_event
+    expect(event).to be_valid
+    expect(event).to be_persisted
+  end
+
+  it 'cannot be created with expired certificate' do
+    event = DisableSigningCertificateEvent.create(
+        certificate: expired_signing_certificate
+    )
+    expect(event.certificate).not_to be_valid
+    expect(event).not_to be_persisted
+  end
+
+  it 'must be signing' do
+    event = DisableSigningCertificateEvent.create(
+        certificate: encryption_certificate
+    )
+    cert = event.certificate
+    expect(cert.usage).to eq('encryption')
+    expect(event).not_to be_persisted
+  end
+end

--- a/spec/models/enable_signing_certificate_event_spec.rb
+++ b/spec/models/enable_signing_certificate_event_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe EnableSigningCertificateEvent, type: :model do
+  include CertificateSupport
+  root = PKI.new
+  good_cert_value = root.generate_encoded_cert(expires_in: 2.months)
+  expired_cert_value = root.generate_encoded_cert(expires_in: -2.months)
+  component_params = { component_type: 'SP', name: 'Test Service Provider' }
+  component = NewComponentEvent.create(component_params).component
+
+  let(:signing_certificate) do
+    UploadCertificateEvent.create(
+      usage: 'signing', value: good_cert_value, component_id: component.id
+    ).certificate
+  end
+
+  let(:expired_signing_certificate) do
+    UploadCertificateEvent.create(
+      usage: 'signing', value: expired_cert_value, component_id: component.id
+    ).certificate
+  end
+
+  let(:encryption_certificate) do
+    UploadCertificateEvent.create(
+      usage: 'encryption', value: good_cert_value, component_id: component.id
+    ).certificate
+  end
+
+  def enable_signing_certificate_event
+    EnableSigningCertificateEvent.create(certificate: signing_certificate)
+  end
+
+  def disable_signing_certificate_event
+    DisableSigningCertificateEvent.create(certificate: signing_certificate)
+  end
+
+  it 'must be persisted' do
+    event = enable_signing_certificate_event
+    expect(event).to be_valid
+    expect(event).to be_persisted
+  end
+
+  it 'signing certificate is enabled by default' do
+    cert = enable_signing_certificate_event.certificate
+    expect(cert.enabled).to eq(true)
+  end
+
+  it 'can enable a disabled certificate' do
+    disabled_cert = disable_signing_certificate_event.certificate
+    expect(disabled_cert.enabled).to eq(false)
+    enabled_cert = enable_signing_certificate_event.certificate
+    expect(enabled_cert.enabled).to eq(true)
+    expect(enabled_cert.enabled).to eq(disabled_cert.enabled)
+  end
+
+  it 'cannot be created with expired certificate' do
+    event = EnableSigningCertificateEvent.create(
+      certificate: expired_signing_certificate
+    )
+    expect(event.certificate).not_to be_valid
+    expect(event).not_to be_persisted
+  end
+
+  it 'must be signing' do
+    event = EnableSigningCertificateEvent.create(
+      certificate: encryption_certificate
+    )
+    cert = event.certificate
+    expect(cert.usage).to eq('encryption')
+    expect(event).not_to be_persisted
+  end
+end


### PR DESCRIPTION
- Create events for enabling and disabling certificates.

#TODO in next PR:
- Replace `certificate#update` with separate `enable` and `disable` actions.
- Trigger publish event when a signing certificate is enabled or disabled.

Co-authored-by: Olakunle Jegede <olakunle.jegede@digital.cabinet-office.gov.uk>