### PR TITLE
Wco3bukn/zfip1equ: assign encryption cert to component on upload

### DIFF
--- a/app/controllers/certificates_controller.rb
+++ b/app/controllers/certificates_controller.rb
@@ -5,8 +5,12 @@ class CertificatesController < ApplicationController
 
   def create
     @upload = UploadCertificateEvent.create(upload_params)
-
     if @upload.valid?
+      component = Component.find(@upload.component_id)
+      if @upload.certificate.usage == 'encryption'
+        component.encryption_certificate_id = @upload.certificate.id
+        component.save
+      end
       redirect_to component_path(@upload.component_id)
     else
       Rails.logger.info(@upload.errors.full_messages)

--- a/app/controllers/certificates_controller.rb
+++ b/app/controllers/certificates_controller.rb
@@ -6,10 +6,11 @@ class CertificatesController < ApplicationController
   def create
     @upload = UploadCertificateEvent.create(upload_params)
     if @upload.valid?
-      component = Component.find(@upload.component_id)
-      if @upload.certificate.usage == 'encryption'
-        component.encryption_certificate_id = @upload.certificate.id
-        component.save
+      if @upload.certificate.encryption?
+        ReplaceEncryptionCertificateEvent.create(
+          component: Component.find(@upload.component_id),
+          encryption_certificate_id: @upload.certificate.id
+        )
       end
       redirect_to component_path(@upload.component_id)
     else

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -1,4 +1,5 @@
 require 'utilities/certificate/certificate_factory'
+
 class Certificate < Aggregate
   include Utilities::Certificate
 
@@ -11,8 +12,12 @@ class Certificate < Aggregate
     subject = certificate_factory.to_subject
     { name: subject, value: self.value }
   end
+  
+  def encryption?
+    usage == CONSTANTS::ENCRYPTION
+  end
 
   def signing?
-    usage == 'signing'
+    usage == CONSTANTS::SIGNING
   end
 end

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -7,9 +7,9 @@ class Component < Aggregate
            -> { where(usage: 'signing', enabled: true) }, class_name: 'Certificate'
   has_many :disabled_signing_certificates,
            -> { where(usage: 'signing', enabled: false) }, class_name: 'Certificate'
-  has_one :encryption_certificate,
-          -> { where(usage: 'encryption').order(id: 'DESC') },
-          class_name: 'Certificate'
+  belongs_to :encryption_certificate, class_name: 'Certificate', optional: true
+  has_one :encryption_certificate, -> { where(usage: 'encryption').order(id: 'DESC') },
+  class_name: 'Certificate'
 
   scope :matching_service_adapters, -> { where(component_type: 'MSA') }
   scope :service_providers,

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -7,9 +7,10 @@ class Component < Aggregate
            -> { where(usage: 'signing', enabled: true) }, class_name: 'Certificate'
   has_many :disabled_signing_certificates,
            -> { where(usage: 'signing', enabled: false) }, class_name: 'Certificate'
-  belongs_to :encryption_certificate, class_name: 'Certificate', optional: true
-  has_one :encryption_certificate, -> { where(usage: 'encryption').order(id: 'DESC') },
-  class_name: 'Certificate'
+
+  belongs_to :encryption_certificate, -> { where(usage: 'encryption') },
+                                      class_name: 'Certificate', optional: true
+
 
   scope :matching_service_adapters, -> { where(component_type: 'MSA') }
   scope :service_providers,

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -2,13 +2,13 @@ class Component < Aggregate
 
   has_many :certificates
   has_many :signing_certificates,
-           -> { where(usage: 'signing') }, class_name: 'Certificate'
+           -> { where(usage: CONSTANTS::SIGNING) }, class_name: 'Certificate'
   has_many :enabled_signing_certificates,
-           -> { where(usage: 'signing', enabled: true) }, class_name: 'Certificate'
+           -> { where(usage: CONSTANTS::SIGNING, enabled: true) }, class_name: 'Certificate'
   has_many :disabled_signing_certificates,
-           -> { where(usage: 'signing', enabled: false) }, class_name: 'Certificate'
+           -> { where(usage: CONSTANTS::SIGNING, enabled: false) }, class_name: 'Certificate'
 
-  belongs_to :encryption_certificate, -> { where(usage: 'encryption') },
+  belongs_to :encryption_certificate, -> { where(usage: CONSTANTS::ENCRYPTION) },
                                       class_name: 'Certificate', optional: true
 
 

--- a/app/models/replace_encryption_certificate_event.rb
+++ b/app/models/replace_encryption_certificate_event.rb
@@ -1,0 +1,8 @@
+class ReplaceEncryptionCertificateEvent < AggregatedEvent
+  belongs_to_aggregate :component
+  data_attributes :encryption_certificate_id
+  
+  def attributes_to_apply
+    { encryption_certificate_id: encryption_certificate_id }
+  end
+end

--- a/app/models/upload_certificate_event.rb
+++ b/app/models/upload_certificate_event.rb
@@ -11,7 +11,7 @@ class UploadCertificateEvent < AggregatedEvent
 
   validate :component_is_persisted
 
-  validates_inclusion_of :usage, in: ['signing', 'encryption']
+  validates_inclusion_of :usage, in: [CONSTANTS::SIGNING, CONSTANTS::ENCRYPTION]
 
   def build_certificate
     Certificate.new

--- a/app/views/certificates/_certificates_table.html.erb
+++ b/app/views/certificates/_certificates_table.html.erb
@@ -17,7 +17,7 @@
         <td class="govuk-table__cell"><%= certificate.usage %></td>
         <td class="govuk-table__cell"><%= certificate.enabled %></td>
         <td class="govuk-table__cell">
-        <% if certificate.usage == 'encryption'%>
+        <% if certificate.encryption? %>
           <%= form_for [@component, certificate], method: :patch do |f| %>
               <%= f.submit 'TBC', class: 'govuk-button' %>
           <% end %>

--- a/app/views/certificates/_certificates_table.html.erb
+++ b/app/views/certificates/_certificates_table.html.erb
@@ -9,22 +9,29 @@
   </tr>
   </thead>
   <tbody class="govuk-table__body">
-  <% certificates.each do |certificate| %>
-    <tr class="govuk-table__row" id="certificate_table_<%= certificate.id %>">
-      <td class="govuk-table__cell"><%= format_date_time(certificate.updated_at) %></td>
-      <td class="govuk-table__cell"><%= certificate.id %></td>
-      <td class="govuk-table__cell"><%= certificate.usage %></td>
-      <td class="govuk-table__cell"><%= certificate.enabled %></td>
-      <td class="govuk-table__cell">
-        <%= form_for [@component, certificate],
-          method: :patch,
-          url: certificate.enabled ? 
-            disable_component_certificate_path(@component, certificate) : 
-            enable_component_certificate_path(@component, certificate) do |f| %>
-              <%= f.submit certificate.enabled ? 'Disable': 'Enable', class: 'govuk-button' %>
+
+    <% certificates.each do |certificate| %>
+      <tr class="govuk-table__row" id="certificate_table_<%= certificate.id %>">
+        <td class="govuk-table__cell"><%= format_date_time(certificate.updated_at) %></td>
+        <td class="govuk-table__cell"><%= certificate.id %></td>
+        <td class="govuk-table__cell"><%= certificate.usage %></td>
+        <td class="govuk-table__cell"><%= certificate.enabled %></td>
+        <td class="govuk-table__cell">
+        <% if certificate.usage == 'encryption'%>
+          <%= form_for [@component, certificate], method: :patch do |f| %>
+              <%= f.submit 'TBC', class: 'govuk-button' %>
+          <% end %>
+        <% else %>
+          <%= form_for [@component, certificate],
+            method: :patch,
+            url: certificate.enabled ?
+              disable_component_certificate_path(@component, certificate) :
+              enable_component_certificate_path(@component, certificate) do |f| %>
+                <%= f.submit certificate.enabled ? 'Disable': 'Enable', class: 'govuk-button' %>
+          <% end %>
         <% end %>
-      </td>
-    </tr>
-  <% end %>
+        </td>
+      </tr>
+  <%end %>
   </tbody>
 </table>

--- a/app/views/certificates/new.html.erb
+++ b/app/views/certificates/new.html.erb
@@ -11,12 +11,12 @@
       <%=error_message_on(f.object.errors, :usage) %>
       <div class="govuk-radios govuk-radios--inline">
         <div class="govuk-radios__item ">
-          <%= f.radio_button :usage, 'signing', class: 'govuk-radios__input'  %>
-          <%= f.label :usage, 'Signing', class: 'govuk-label govuk-radios__label' %>
+          <%= f.radio_button :usage, CONSTANTS::SIGNING, class: 'govuk-radios__input'  %>
+          <%= f.label :usage, CONSTANTS::SIGNING, class: 'govuk-label govuk-radios__label' %>
         </div>
         <div class="govuk-radios__item">
-          <%= f.radio_button :usage, 'encryption', class: 'govuk-radios__input'  %>
-          <%= f.label :usage, 'Encryption', class: 'govuk-label govuk-radios__label' %>
+          <%= f.radio_button :usage, CONSTANTS::ENCRYPTION, class: 'govuk-radios__input'  %>
+          <%= f.label :usage, CONSTANTS::ENCRYPTION, class: 'govuk-label govuk-radios__label' %>
         </div>
       </div>
     </div>

--- a/app/views/components/show.html.erb
+++ b/app/views/components/show.html.erb
@@ -13,11 +13,13 @@
  <%= render "certificates/certificates_table",
      certificates: @component.disabled_signing_certificates
  %>
-
- <h3 class="govuk-heading-m">Encryption Certificate</h3>
-  <%= render "certificates/certificates_table",
-     certificates: @component.encryption_certificate ? [@component.encryption_certificate] : []
- %>
+ 
+ <% if @component.encryption_certificate.present? %>
+    <h3 class="govuk-heading-m">Encryption Certificate</h3>
+      <%= render "certificates/certificates_table",
+        certificates: [@component.encryption_certificate]
+    %>
+ <% end %>
 
 
 <% if @component.certificates.present? %>

--- a/app/views/components/show.html.erb
+++ b/app/views/components/show.html.erb
@@ -5,13 +5,18 @@
 <%= link_to 'Upload', new_component_certificate_path(@component), class: 'govuk-button' %>
 
 <h3 class="govuk-heading-m">Signing Certificates (Enabled)</h3>
- <%= render "certificates/certificates_table", 
+ <%= render "certificates/certificates_table",
      certificates: @component.enabled_signing_certificates
  %>
 
 <h3 class="govuk-heading-m">Signing Certificates (Disabled)</h3>
- <%= render "certificates/certificates_table", 
+ <%= render "certificates/certificates_table",
      certificates: @component.disabled_signing_certificates
+ %>
+
+ <h3 class="govuk-heading-m">Encryption Certificate</h3>
+  <%= render "certificates/certificates_table",
+     certificates: @component.encryption_certificate ? [@component.encryption_certificate] : []
  %>
 
 

--- a/config/initializers/constants/vss_constants.rb
+++ b/config/initializers/constants/vss_constants.rb
@@ -1,0 +1,4 @@
+module CONSTANTS
+  SIGNING = 'signing'.freeze
+  ENCRYPTION = 'encryption'.freeze
+end

--- a/db/migrate/20190507132826_add_encryption_certificate_to_components.rb
+++ b/db/migrate/20190507132826_add_encryption_certificate_to_components.rb
@@ -1,0 +1,5 @@
+class AddEncryptionCertificateToComponents < ActiveRecord::Migration[5.2]
+  def change
+    add_column :components, :encryption_certificate_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_24_150803) do
+ActiveRecord::Schema.define(version: 2019_05_07_132826) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 2019_04_24_150803) do
     t.string "component_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "encryption_certificate_id"
   end
 
   create_table "events", force: :cascade do |t|

--- a/spec/models/certificate_spec.rb
+++ b/spec/models/certificate_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe Certificate, type: :model do
   let(:component) { NewComponentEvent.create(component_params).component }
   
   it 'is valid with valid attributes' do
-    expect(Certificate.new(usage: 'signing', value: good_cert_value, component_id: component.id)).to be_valid
-    expect(Certificate.new(usage: 'encryption', value: good_cert_value, component_id:component.id)).to be_valid
+    expect(Certificate.new(usage: CONSTANTS::SIGNING, value: good_cert_value, component_id: component.id)).to be_valid
+    expect(Certificate.new(usage: CONSTANTS::ENCRYPTION, value: good_cert_value, component_id:component.id)).to be_valid
   end
 
   it 'is not valid with non-valid attributes' do
@@ -22,19 +22,19 @@ RSpec.describe Certificate, type: :model do
 
   it 'is not valid without a usage and/or value' do
     expect(Certificate.new(usage: nil, value: good_cert_value, component_id: component.id)).to_not be_valid
-    expect(Certificate.new(usage: 'signing', value: nil, component_id: component.id)).to_not be_valid
+    expect(Certificate.new(usage: CONSTANTS::SIGNING, value: nil, component_id: component.id)).to_not be_valid
     expect(Certificate.new(usage: nil, value: nil, component_id: component.id)).to_not be_valid
   end
 
   it 'has events' do
-    event = UploadCertificateEvent.create!(usage: 'signing', value: good_cert_value, component_id: component.id)
+    event = UploadCertificateEvent.create!(usage: CONSTANTS::SIGNING, value: good_cert_value, component_id: component.id)
     certificate = event.certificate
     expect([certificate.events.last]).to eql [event]
   end
 
   it 'holds valid metadata' do
     cert = Base64.encode64(good_cert_value)
-    certificate = Certificate.new(usage: 'signing', value: cert, component_id: component.id)
+    certificate = Certificate.new(usage: CONSTANTS::SIGNING, value: cert, component_id: component.id)
     subject = certificate_subject(cert)
     expect(certificate).not_to be_nil
     expect(certificate.to_metadata).to include(name: subject, value: cert)

--- a/spec/models/component_spec.rb
+++ b/spec/models/component_spec.rb
@@ -10,40 +10,60 @@ RSpec.describe Component, type: :model do
     let(:published_at) { Time.now }
     let(:event_id) { 0 }
     let(:certificate) { root.generate_encoded_cert(expires_in: 2.months) }
-    it 'is an MSA component with signing and encryption certs' do
 
-      c = Component.create(name: 'lala', component_type: 'MSA')
-      c.certificates.create(usage: 'signing', value: certificate)
-      c.certificates.create(usage: 'signing', value: certificate)
-      encryption_certificate = Certificate.create(
-        usage: 'encryption', value: certificate, component_id: c.id
+    component_name = 'test component'
+    component_params = { component_type: 'MSA', name: component_name }
+    let(:component) { NewComponentEvent.create(component_params).component }
+    let(:root) { PKI.new }
+    let(:x509_cert_1) { root.generate_encoded_cert(expires_in: 2.months) }
+    let(:x509_cert_2) { root.generate_encoded_cert(expires_in: 9.months) }
+    let(:x509_cert_3) { root.generate_encoded_cert(expires_in: 9.months) }
+    let(:upload_signing_event) do
+      UploadCertificateEvent.create(
+        usage: CONSTANTS::SIGNING, value: x509_cert_1, component_id: component.id
       )
-      c.encryption_certificate_id = encryption_certificate.id
-      c.save
-      actual_config = Component.to_service_metadata(event_id, published_at)
+      UploadCertificateEvent.create(
+        usage: CONSTANTS::SIGNING, value: x509_cert_2, component_id: component.id
+      )
+    end
+  
+    let(:upload_encryption_event) do
+      event = UploadCertificateEvent.create(
+        usage: CONSTANTS::ENCRYPTION, value: x509_cert_3, component_id: component.id
+      )
+      ReplaceEncryptionCertificateEvent.create(
+        component: component,
+        encryption_certificate_id: event.certificate.id
+      )
+    end
 
+    it 'is an MSA component with signing and encryption certs' do
+      upload_signing_event
+      upload_encryption_event
+      actual_config = Component.to_service_metadata(event_id, published_at)
+  
       expected_config = {
         published_at: published_at,
         event_id: event_id,
         matching_service_adapters: [{
-          name: 'lala',
+          name: component_name,
           encryption_certificate: {
-            name: certificate_subject(certificate),
-            value: certificate
+            name: certificate_subject(x509_cert_3),
+            value: x509_cert_3
           },
           signing_certificates: [{
-            name: certificate_subject(certificate),
-            value: certificate
+            name: certificate_subject(x509_cert_1),
+            value: x509_cert_1
           }, {
-            name: certificate_subject(certificate),
-            value: certificate
+            name: certificate_subject(x509_cert_2),
+            value: x509_cert_2
           }]
         }],
         service_providers: []
       }
- 
+
       expect(actual_config).to include('matching_service_adapters')
-      expect(actual_config).to include(expected_config.to_json)
+      expect(actual_config).to eq(expected_config.to_json)
     end
     it 'produces required output structure' do
       Component.destroy_all

--- a/spec/models/component_spec.rb
+++ b/spec/models/component_spec.rb
@@ -15,8 +15,11 @@ RSpec.describe Component, type: :model do
       c = Component.create(name: 'lala', component_type: 'MSA')
       c.certificates.create(usage: 'signing', value: certificate)
       c.certificates.create(usage: 'signing', value: certificate)
-      c.certificates.create(usage: 'encryption', value: certificate)
-
+      encryption_certificate = Certificate.create(
+        usage: 'encryption', value: certificate, component_id: c.id
+      )
+      c.encryption_certificate_id = encryption_certificate.id
+      c.save
       actual_config = Component.to_service_metadata(event_id, published_at)
 
       expected_config = {

--- a/spec/models/disable_signing_certificate_event_spec.rb
+++ b/spec/models/disable_signing_certificate_event_spec.rb
@@ -10,19 +10,19 @@ RSpec.describe DisableSigningCertificateEvent, type: :model do
 
   let(:signing_certificate) do
     UploadCertificateEvent.create(
-        usage: 'signing', value: good_cert_value, component_id: component.id
+        usage: CONSTANTS::SIGNING, value: good_cert_value, component_id: component.id
     ).certificate
   end
 
   let(:expired_signing_certificate) do
     UploadCertificateEvent.create(
-        usage: 'signing', value: expired_cert_value, component_id: component.id
+        usage: CONSTANTS::SIGNING, value: expired_cert_value, component_id: component.id
     ).certificate
   end
 
   let(:encryption_certificate) do
     UploadCertificateEvent.create(
-        usage: 'encryption', value: good_cert_value, component_id: component.id
+        usage: CONSTANTS::ENCRYPTION, value: good_cert_value, component_id: component.id
     ).certificate
   end
 
@@ -55,7 +55,7 @@ RSpec.describe DisableSigningCertificateEvent, type: :model do
         certificate: encryption_certificate
     )
     cert = event.certificate
-    expect(cert.usage).to eq('encryption')
+    expect(cert.usage).to eq(CONSTANTS::ENCRYPTION)
     expect(event).not_to be_persisted
   end
 

--- a/spec/models/enable_signing_certificate_event_spec.rb
+++ b/spec/models/enable_signing_certificate_event_spec.rb
@@ -10,19 +10,19 @@ RSpec.describe EnableSigningCertificateEvent, type: :model do
 
   let(:signing_certificate) do
     UploadCertificateEvent.create(
-      usage: 'signing', value: good_cert_value, component_id: component.id
+      usage: CONSTANTS::SIGNING, value: good_cert_value, component_id: component.id
     ).certificate
   end
 
   let(:expired_signing_certificate) do
     UploadCertificateEvent.create(
-      usage: 'signing', value: expired_cert_value, component_id: component.id
+      usage: CONSTANTS::SIGNING, value: expired_cert_value, component_id: component.id
     ).certificate
   end
 
   let(:encryption_certificate) do
     UploadCertificateEvent.create(
-      usage: 'encryption', value: good_cert_value, component_id: component.id
+      usage: CONSTANTS::ENCRYPTION, value: good_cert_value, component_id: component.id
     ).certificate
   end
 
@@ -66,7 +66,7 @@ RSpec.describe EnableSigningCertificateEvent, type: :model do
       certificate: encryption_certificate
     )
     cert = event.certificate
-    expect(cert.usage).to eq('encryption')
+    expect(cert.usage).to eq(CONSTANTS::ENCRYPTION)
     expect(event).not_to be_persisted
   end
 

--- a/spec/models/replace_encryption_certificate_event_spec.rb
+++ b/spec/models/replace_encryption_certificate_event_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+require 'auth_test_helper'
+
+RSpec.describe ReplaceEncryptionCertificateEvent, type: :model do
+  before(:each) do
+    stub_auth
+  end
+  let(:component_name) { 'test component' }
+  let(:component) do
+    component_params = { component_type: 'MSA', name: component_name }
+    NewComponentEvent.create(component_params).component
+  end
+  let(:root) { PKI.new }
+  let(:upload_encryption_cert) do
+    x509_cert = root.generate_encoded_cert(expires_in: 9.months)
+    UploadCertificateEvent.create(
+      usage: CONSTANTS::ENCRYPTION, value: x509_cert, component_id: component.id
+    ).certificate
+  end
+
+  it 'creates valid and persisted replace encryption certificate event' do
+    event = ReplaceEncryptionCertificateEvent.create(
+      component: component, encryption_certificate_id: upload_encryption_cert.id
+    )
+    expect(event).to be_valid
+    expect(event).to be_persisted
+  end
+
+  it 'creates with component encryption id set to encryption certificate id' do
+    this_component = ReplaceEncryptionCertificateEvent.create(
+      component: component, encryption_certificate_id: upload_encryption_cert.id
+    ).component
+    expect(this_component.encryption_certificate_id).to eq(upload_encryption_cert.id)
+  end
+end

--- a/spec/models/upload_certificate_event_spec.rb
+++ b/spec/models/upload_certificate_event_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe UploadCertificateEvent, type: :model do
 
   root = PKI.new
   good_cert_value = root.generate_encoded_cert(expires_in: 2.months)
-  component_params = { component_type: 'MSA', name:'fake_name' }
+  component_params = { component_type: 'MSA', name: 'fake_name' }
   component = NewComponentEvent.create(component_params).component
   include_examples 'has data attributes', UploadCertificateEvent, [:usage, :value, :component_id]
-  include_examples 'is aggregated', UploadCertificateEvent, {usage: 'signing', value: good_cert_value, component_id: component.id }
-  include_examples 'is a creation event', UploadCertificateEvent, {usage: 'signing', value: good_cert_value, component_id: component.id}
+  include_examples 'is aggregated', UploadCertificateEvent, {usage: CONSTANTS::SIGNING, value: good_cert_value, component_id: component.id }
+  include_examples 'is a creation event', UploadCertificateEvent, {usage: CONSTANTS::SIGNING, value: good_cert_value, component_id: component.id}
 
   context '#value' do
     it 'must be present' do
@@ -25,7 +25,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
     let(:root) { PKI.new }
 
     it 'must error with invalid x509 certificate' do
-      event = UploadCertificateEvent.create(usage: 'signing', value: 'Not a valid certificate',component_id: component.id)
+      event = UploadCertificateEvent.create(usage: CONSTANTS::SIGNING, value: 'Not a valid certificate',component_id: component.id)
       expect(event).to_not be_valid
       expect(event.errors[:certificate]).to eql ['is not a valid x509 certificate']
     end
@@ -33,7 +33,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
     it 'must allow base64 encoded DER format x509 certificate' do
       cert = root.generate_encoded_cert(expires_in: 2.months)
 
-      event = UploadCertificateEvent.create(usage: 'signing', value: cert, component_id: component.id)
+      event = UploadCertificateEvent.create(usage: CONSTANTS::SIGNING, value: cert, component_id: component.id)
       expect(event).to be_valid
       expect(event.errors[:certificate]).to be_empty
     end
@@ -41,7 +41,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
     it 'must allow PEM format x509 certificate' do
       cert = root.generate_signed_cert(expires_in: 2.months)
 
-      event = UploadCertificateEvent.create(usage: 'signing', value: cert.to_pem, component_id: component.id)
+      event = UploadCertificateEvent.create(usage: CONSTANTS::SIGNING, value: cert.to_pem, component_id: component.id)
       expect(event).to be_valid
       expect(event.errors[:certificate]).to be_empty
     end
@@ -49,7 +49,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
     it 'must not be expired' do
       cert = root.generate_encoded_cert(expires_in: -1.months)
 
-      event = UploadCertificateEvent.create(usage: 'signing', value: cert, component_id: component.id)
+      event = UploadCertificateEvent.create(usage: CONSTANTS::SIGNING, value: cert, component_id: component.id)
       expect(event).to_not be_valid
       expect(event.errors[:certificate]).to eql ['has expired']
     end
@@ -57,7 +57,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
     it 'must not expire within 1 month' do
       cert = root.generate_encoded_cert(expires_in: 15.days)
 
-      event = UploadCertificateEvent.create(usage: 'signing', value: cert, component_id: component.id)
+      event = UploadCertificateEvent.create(usage: CONSTANTS::SIGNING, value: cert, component_id: component.id)
       expect(event).to_not be_valid
       expect(event.errors[:certificate]).to eql ['expires too soon']
     end
@@ -65,7 +65,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
     it 'must expire within 1 year' do
       cert = root.generate_encoded_cert(expires_in: 2.years)
 
-      event = UploadCertificateEvent.create(usage: 'signing', value: cert, component_id: component.id)
+      event = UploadCertificateEvent.create(usage: CONSTANTS::SIGNING, value: cert, component_id: component.id)
       expect(event).to_not be_valid
       expect(event.errors[:certificate]).to eql ['valid for too long']
     end
@@ -73,7 +73,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
     it 'must be RSA' do
       cert = root.generate_signed_ec_cert(6.months)
 
-      event = UploadCertificateEvent.create(usage: 'signing', value: cert.to_pem, component_id: component.id)
+      event = UploadCertificateEvent.create(usage: CONSTANTS::SIGNING, value: cert.to_pem, component_id: component.id)
       expect(event).to_not be_valid
       expect(event.errors[:certificate]).to eql ['in not RSA']
     end
@@ -81,7 +81,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
     it 'must be at least 2048 bits' do
       cert = root.generate_signed_rsa_cert_and_key(size: 1024)[0]
 
-      event = UploadCertificateEvent.create(usage: 'signing', value: cert.to_pem, component_id: component.id)
+      event = UploadCertificateEvent.create(usage: CONSTANTS::SIGNING, value: cert.to_pem, component_id: component.id)
       expect(event).to_not be_valid
       expect(event.errors[:certificate]).to eql ['key size is less than 2048']
     end
@@ -102,13 +102,13 @@ RSpec.describe UploadCertificateEvent, type: :model do
     end
 
     it 'happy when signing' do
-      event = UploadCertificateEvent.create(usage: 'signing', component_id: component.id)
+      event = UploadCertificateEvent.create(usage: CONSTANTS::SIGNING, component_id: component.id)
       expect(event).to_not be_valid
       expect(event.errors[:usage]).to be_empty
     end
 
     it 'happy when encryption' do
-      event = UploadCertificateEvent.create(usage: 'encryption', component_id: component.id)
+      event = UploadCertificateEvent.create(usage: CONSTANTS::ENCRYPTION, component_id: component.id)
       expect(event).to_not be_valid
       expect(event.errors[:usage]).to be_empty
     end
@@ -135,7 +135,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
 
   context '#component=' do
     it 'will set component_id when called during ::create' do
-      event = UploadCertificateEvent.create(usage: 'signing', component_id: component.id)
+      event = UploadCertificateEvent.create(usage: CONSTANTS::SIGNING, component_id: component.id)
       expect(event.component).to eql component
     end
 
@@ -166,7 +166,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
 
   context '#trigger_publish_event' do
     it 'is triggered on creation' do
-      event = UploadCertificateEvent.create!(usage: 'signing', value: good_cert_value, component_id: component.id)
+      event = UploadCertificateEvent.create!(usage: CONSTANTS::SIGNING, value: good_cert_value, component_id: component.id)
       publish_event = PublishServicesMetadataEvent.last
       expect(event.id).to_not be_nil
       expect(event.id).to eql publish_event.event_id

--- a/spec/system/user_visits_events_page_spec.rb
+++ b/spec/system/user_visits_events_page_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe 'the events page', type: :system do
     good_cert_2 = root.generate_encoded_cert(expires_in: 2.months)
     good_cert_3 = root.generate_encoded_cert(expires_in: 2.months)
 
-    UploadCertificateEvent.create(usage: 'signing', value: good_cert_1, component_id: component.id)
-    UploadCertificateEvent.create(usage: 'signing', value: good_cert_2, component_id: component.id)
-    UploadCertificateEvent.create(usage: 'signing', value: good_cert_3, component_id: component.id)
+    UploadCertificateEvent.create(usage: CONSTANTS::SIGNING, value: good_cert_1, component_id: component.id)
+    UploadCertificateEvent.create(usage: CONSTANTS::SIGNING, value: good_cert_2, component_id: component.id)
+    UploadCertificateEvent.create(usage: CONSTANTS::SIGNING, value: good_cert_3, component_id: component.id)
 
     visit events_path
     expect(page).to have_content good_cert_1
@@ -31,7 +31,7 @@ RSpec.describe 'the events page', type: :system do
   it 'is paginated' do
 
      55.times.each do
-      UploadCertificateEvent.create(usage: 'signing', value: root.generate_encoded_cert(expires_in: 2.months), component_id: component.id)
+      UploadCertificateEvent.create(usage: CONSTANTS::SIGNING, value: root.generate_encoded_cert(expires_in: 2.months), component_id: component.id)
     end
 
     visit events_path

--- a/spec/system/visit_component_show_spec.rb
+++ b/spec/system/visit_component_show_spec.rb
@@ -8,18 +8,30 @@ RSpec.describe 'New Component Page', type: :system do
   end
 
   component_name = 'test component'
-  component_params = {component_type: 'MSA', name: component_name}
+  component_params = { component_type: 'MSA', name: component_name }
 
   let(:component) { NewComponentEvent.create(component_params).component }
-
+  let(:root) { PKI.new }
   let(:upload_certs) do
-        root = PKI.new
-        x509_cert_1 = root.generate_encoded_cert(expires_in: 2.months)
-        x509_cert_2 = root.generate_encoded_cert(expires_in: 9.months)
-        UploadCertificateEvent.create({usage: "signing", value: x509_cert_1, component_id: component.id}).certificate
-        UploadCertificateEvent.create({usage: "signing", value: x509_cert_2, component_id: component.id}).certificate
+    x509_cert_1 = root.generate_encoded_cert(expires_in: 2.months)
+    x509_cert_2 = root.generate_encoded_cert(expires_in: 9.months)
+    UploadCertificateEvent.create(
+      usage: 'signing', value: x509_cert_1, component_id: component.id
+    ).certificate
+    UploadCertificateEvent.create(
+      usage: 'signing', value: x509_cert_2, component_id: component.id
+    ).certificate
   end
 
+  let(:upload_encryption_cert) do
+    x509_cert = root.generate_encoded_cert(expires_in: 9.months)
+    encryption_cert = UploadCertificateEvent.create(
+      usage: 'encryption', value: x509_cert, component_id: component.id
+    ).certificate
+    component.encryption_certificate_id = encryption_cert.id
+    component.save
+    encryption_cert
+  end
 
   it 'successfully creates a new component' do
     visit component_path(component.id)
@@ -48,7 +60,6 @@ RSpec.describe 'New Component Page', type: :system do
     expect(page).to have_selector("#edit_certificate_#{certs[0].id}")
     expect(page).to have_selector("#edit_certificate_#{certs[1].id}")
     expect(page).to have_selector("#certificate_table_#{certs[0].id} > td:nth-child(4)", text: "false")
-
   end
 
   it 'shows list of disabled certificates' do
@@ -68,6 +79,15 @@ RSpec.describe 'New Component Page', type: :system do
 
   end
 
+  it 'displays encryption certificate for component' do
+    upload_encryption_cert
+    cert = component.encryption_certificate
+    visit component_path(component.id)
+
+    expect(page).to have_selector('h3', text: 'Encryption Certificate')
+    expect(page).to have_selector("#certificate_table_#{cert.id}")
+  end
+
   it 'successfully enables a certificate' do
     upload_certs
     certs = component.enabled_signing_certificates
@@ -85,7 +105,5 @@ RSpec.describe 'New Component Page', type: :system do
 
     expect(page).to have_selector('h1', text: component_name)
     expect(page).to have_selector("#certificate_table_#{disabled_certs[0].id} > td:nth-child(4)", text: "true")
-
   end
-
 end

--- a/spec/system/visit_component_show_spec.rb
+++ b/spec/system/visit_component_show_spec.rb
@@ -16,20 +16,22 @@ RSpec.describe 'New Component Page', type: :system do
     x509_cert_1 = root.generate_encoded_cert(expires_in: 2.months)
     x509_cert_2 = root.generate_encoded_cert(expires_in: 9.months)
     UploadCertificateEvent.create(
-      usage: 'signing', value: x509_cert_1, component_id: component.id
+      usage: CONSTANTS::SIGNING, value: x509_cert_1, component_id: component.id
     ).certificate
     UploadCertificateEvent.create(
-      usage: 'signing', value: x509_cert_2, component_id: component.id
+      usage: CONSTANTS::SIGNING, value: x509_cert_2, component_id: component.id
     ).certificate
   end
 
   let(:upload_encryption_cert) do
     x509_cert = root.generate_encoded_cert(expires_in: 9.months)
     encryption_cert = UploadCertificateEvent.create(
-      usage: 'encryption', value: x509_cert, component_id: component.id
+      usage: CONSTANTS::ENCRYPTION, value: x509_cert, component_id: component.id
     ).certificate
-    component.encryption_certificate_id = encryption_cert.id
-    component.save
+    ReplaceEncryptionCertificateEvent.create(
+      component: component,
+      encryption_certificate_id: encryption_cert.id
+    )
     encryption_cert
   end
 


### PR DESCRIPTION
[This](https://trello.com/c/ZfIp1eQu/376-assign-encryption-certificate-to-component-on-upload) is first of a line of PR's for [Model encryption certificate rotation](https://trello.com/c/WCo3BuKn/347-model-encryption-certificate-rotation-in-the-app)
**What**
- This enables an encryption certificate to be assigned with a Component via a belongs_to association on the component.
- ReplaceEncryptionCertificateEvent is used to carry out this assignment.
- Since this happens at the time a new encryption certificate is created it follows that, this certificate becomes the assigned one.
- The associated encryption certificate is displayed on the Show view
**To do**
- To show a list of the previous encryption certs and to be able to replace the ‘current’ encryption certificate with a previous encryption cert
- make sure replacement is with a valid encryption certificate i.e. it hasn't expired
- trigger publish metadata anytime replace occurs