### PR TITLE
BAU: Fix event ordering

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -3,7 +3,6 @@ class EventsController < ApplicationController
   def index
     @page_number = params[:page] || 1
     @events = Event
-      .order(id: 'DESC')
       .page(@page_number)
     render :index
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,5 +1,6 @@
 class Event < ApplicationRecord
   after_initialize :default_values
+  scope :newest_first, -> { order("created_at DESC")}
 
   private def default_values
     self.data ||= {}

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -10,13 +10,13 @@
     </tr>
   </thead>
   <tbody class="govuk-table__body">
-    <% @events.order('created_at DESC').each do |event| %>
+    <% @events.newest_first.each do |event| %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell" scope="row"><%= event.type %></th>
         <td class="govuk-table__cell" scope="row">
           <details>
             <summary>Event details</summary>
-            <code><%= JSON.pretty_generate(event.data) %></code>
+            <code><pre><%= JSON.pretty_generate(event.data) %></pre></code>
           </details>
         </td>
         <td class="govuk-table__cell" scope="row"><%= event.created_at.strftime('%Y-%m-%d %H:%M:%S.%N') %></td>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -10,11 +10,16 @@
     </tr>
   </thead>
   <tbody class="govuk-table__body">
-    <% @events.reverse.each do |event| %>
+    <% @events.order('created_at DESC').each do |event| %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell" scope="row"><%= event.type %></th>
-        <td class="govuk-table__cell" scope="row"><code><%= JSON.pretty_generate(event.data) %></code></td>
-        <td class="govuk-table__cell" scope="row"><%= event.created_at %></td>
+        <td class="govuk-table__cell" scope="row">
+          <details>
+            <summary>Event details</summary>
+            <code><%= JSON.pretty_generate(event.data) %></code>
+          </details>
+        </td>
+        <td class="govuk-table__cell" scope="row"><%= event.created_at.strftime('%Y-%m-%d %H:%M:%S.%N') %></td>
         <td class="govuk-table__cell" scope="row"><%= event.aggregate_id %></td>
         <td class="govuk-table__cell" scope="row"><%= event.aggregate_type %></td>
       </tr>


### PR DESCRIPTION
- events are ordered by date now (created_at)
- event details are not expanded by default anymore (too much content)
- added miliseconds on the timestamp