### PR TITLE
BAU: Refactor the publish event

### DIFF
--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -24,7 +24,7 @@ class Component < Aggregate
                                            :encryption_certificate)
       { published_at: published_at, event_id: event_id,
         matching_service_adapters: matching_service_adapters.map(&:to_metadata),
-        service_providers: service_providers.map(&:to_metadata) }.to_json
+        service_providers: service_providers.map(&:to_metadata) }
   end
 
   def to_metadata

--- a/app/models/publish_services_metadata_event.rb
+++ b/app/models/publish_services_metadata_event.rb
@@ -5,18 +5,19 @@ require 'utilities/configuration/settings'
 class PublishServicesMetadataEvent < Event
   include Utilities::Configuration::Settings
 
-  attr_reader :storage_key, :json_data
+  attr_reader :storage_key, :metadata
   data_attributes :event_id, :services_metadata
   validates_presence_of :event_id
   before_create :populate_data_attributes
   after_create :upload
   
   def populate_data_attributes
-    @json_data = services_metadata
-    assign_attributes(services_metadata: json_data)
+    @metadata = services_metadata
+    assign_attributes(services_metadata: metadata)
   end
 
   def upload
+    json_data = metadata.to_json
     @storage_key = "verify_services_metadata.json"
     check_sum = Digest::MD5.base64digest(json_data)
     current_active_storage_env = Rails.configuration.active_storage.service

--- a/app/models/publish_services_metadata_event.rb
+++ b/app/models/publish_services_metadata_event.rb
@@ -17,7 +17,7 @@ class PublishServicesMetadataEvent < Event
   end
 
   def upload
-    @storage_key = "#{Time.now.to_formatted_s(:number)}_services_metadata.json"
+    @storage_key = "verify_services_metadata.json"
     check_sum = Digest::MD5.base64digest(json_data)
     current_active_storage_env = Rails.configuration.active_storage.service
     service = ActiveStorage::Service.configure(

--- a/app/models/publish_services_metadata_event.rb
+++ b/app/models/publish_services_metadata_event.rb
@@ -5,7 +5,7 @@ require 'utilities/configuration/settings'
 class PublishServicesMetadataEvent < Event
   include Utilities::Configuration::Settings
 
-  attr_reader :storage_key, :metadata
+  attr_reader :metadata
   data_attributes :event_id, :services_metadata
   validates_presence_of :event_id
   before_create :populate_data_attributes
@@ -18,7 +18,7 @@ class PublishServicesMetadataEvent < Event
 
   def upload
     json_data = metadata.to_json
-    @storage_key = "verify_services_metadata.json"
+    storage_key = "verify_services_metadata.json"
     check_sum = Digest::MD5.base64digest(json_data)
     current_active_storage_env = Rails.configuration.active_storage.service
     service = ActiveStorage::Service.configure(

--- a/spec/models/component_spec.rb
+++ b/spec/models/component_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe Component, type: :model do
         service_providers: []
       }
  
-      expect(actual_config).to include('matching_service_adapters')
-      expect(actual_config).to include(expected_config.to_json)
+      expect(actual_config).to include(:matching_service_adapters)
+      expect(actual_config).to include(expected_config)
     end
     it 'produces required output structure' do
       Component.destroy_all
@@ -51,8 +51,8 @@ RSpec.describe Component, type: :model do
         matching_service_adapters: [],
         service_providers: []
       }
-      expect(actual_config).to include('published_at', 'service_providers')
-      expect(actual_config).to eq(expected_config.to_json)
+      expect(actual_config).to include(:published_at, :service_providers)
+      expect(actual_config).to eq(expected_config)
     end
   end
 end

--- a/spec/models/publish_services_event_metadata_spec.rb
+++ b/spec/models/publish_services_event_metadata_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe PublishServicesMetadataEvent, type: :model do
 
     it 'downloaded content is the same as upload with given key' do
       event.upload
-      key = event.storage_key
+      key = "verify_services_metadata.json"
       expected_chunks = event.json_data
       current_active_storage_env = Rails.configuration.active_storage.service
 

--- a/spec/models/publish_services_event_metadata_spec.rb
+++ b/spec/models/publish_services_event_metadata_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe PublishServicesMetadataEvent, type: :model do
     it 'downloaded content is the same as upload with given key' do
       event.upload
       key = "verify_services_metadata.json"
-      expected_chunks = event.json_data
+      expected_chunks = event.metadata
       current_active_storage_env = Rails.configuration.active_storage.service
 
       service = ActiveStorage::Service.configure(
@@ -43,7 +43,7 @@ RSpec.describe PublishServicesMetadataEvent, type: :model do
         actual_chunks << chunk
       end
 
-      expect(expected_chunks).to eq(actual_chunks.first)
+      expect(expected_chunks.to_json).to eq(actual_chunks.first)
     end
   end
 end


### PR DESCRIPTION
Review commit by commit.

1. Changed the logic so that we always generate the same filename for the metadata file.

2. Currently, we're converting the metadata object to a json and storing it.
We should only convert the data to JSON when we export them. Internally we should
use native hashes.
This PR:
- renames the json_data to metadata object
- removes the JSON conversion from the component
- moves the JSON conversion to the PublishServicesMetadataEvent to the point when it generates
the JSON file.