### PR TITLE
Thxe01tp: Add entity_id to MSA components

### DIFF
--- a/app/controllers/components_controller.rb
+++ b/app/controllers/components_controller.rb
@@ -26,7 +26,8 @@ private
   def component_params
     params.require(:component).permit(
       :name,
-      :component_type
+      :component_type,
+      :entity_id
     )
   end
 end

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -20,14 +20,14 @@ class Component < Aggregate
   scope :service_providers,
         -> { where(component_type: 'VSP').or(where(component_type: 'SP')) }
 
-  def self.to_service_metadata(event_id: 0, entity_id: '', published_at: Time.now)
+  def self.to_service_metadata(event_id, published_at = Time.now)
     matching_service_adapters = Component.matching_service_adapters
                                          .includes(:enabled_signing_certificates,
                                                    :encryption_certificate)
     service_providers = Component.service_providers
                                  .includes(:enabled_signing_certificates,
                                            :encryption_certificate)
-      { entity_id: entity_id, published_at: published_at, event_id: event_id,
+      { published_at: published_at, event_id: event_id,
         matching_service_adapters: matching_service_adapters.map(&:to_metadata),
         service_providers: service_providers.map(&:to_metadata) }
   end
@@ -35,15 +35,20 @@ class Component < Aggregate
   def previous_encryption_certificates
     encryption_certificates.where.not(id: encryption_certificate&.id)
   end
- 
+
   def to_metadata
     signing = self.enabled_signing_certificates.map(&:to_metadata)
 
     encryption = self.encryption_certificate&.to_metadata
-    {
+
+    metadata = {
       name: self.name,
       encryption_certificate: encryption,
       signing_certificates: signing
     }
+
+    metadata.merge!({ entity_id: entity_id }) if component_type == 'MSA'
+
+    metadata
   end
 end

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -20,14 +20,14 @@ class Component < Aggregate
   scope :service_providers,
         -> { where(component_type: 'VSP').or(where(component_type: 'SP')) }
 
-  def self.to_service_metadata(event_id, published_at = Time.now)
+  def self.to_service_metadata(event_id: 0, entity_id: '', published_at: Time.now)
     matching_service_adapters = Component.matching_service_adapters
                                          .includes(:enabled_signing_certificates,
                                                    :encryption_certificate)
     service_providers = Component.service_providers
                                  .includes(:enabled_signing_certificates,
                                            :encryption_certificate)
-      { published_at: published_at, event_id: event_id,
+      { entity_id: entity_id, published_at: published_at, event_id: event_id,
         matching_service_adapters: matching_service_adapters.map(&:to_metadata),
         service_providers: service_providers.map(&:to_metadata) }
   end
@@ -35,7 +35,7 @@ class Component < Aggregate
   def previous_encryption_certificates
     encryption_certificates.where.not(id: encryption_certificate&.id)
   end
-
+ 
   def to_metadata
     signing = self.enabled_signing_certificates.map(&:to_metadata)
 

--- a/app/models/new_component_event.rb
+++ b/app/models/new_component_event.rb
@@ -1,17 +1,23 @@
 class NewComponentEvent < AggregatedEvent
   belongs_to_aggregate :component
-  data_attributes :name, :component_type
+  data_attributes :name, :component_type, :entity_id
 
   validate :name_is_present
   validates_inclusion_of :component_type, in: %w[VSP MSA SP]
-  validate :component_is_new, on: :create
+  validate :persist_entity_id_only_for_msa
+  validate :component_is_new, :persist_entity_id_only_for_msa, on: :create
 
   def build_component
     Component.new
   end
 
   def attributes_to_apply
-    { name: name, component_type: component_type, created_at: created_at }
+    {
+      name: name,
+      component_type: component_type,
+      entity_id: entity_id,
+      created_at: created_at
+    }
   end
 
   def component_is_new
@@ -26,5 +32,11 @@ class NewComponentEvent < AggregatedEvent
 
   def name_present?
     name.present?
+  end
+
+  def persist_entity_id_only_for_msa
+    return if component_type == 'MSA' && entity_id.present?
+
+    errors.add(:component, 'Entity id can not be set on VSP component') if entity_id.present?
   end
 end

--- a/app/models/new_component_event.rb
+++ b/app/models/new_component_event.rb
@@ -1,10 +1,8 @@
 class NewComponentEvent < AggregatedEvent
   belongs_to_aggregate :component
   data_attributes :name, :component_type, :entity_id
-
   validate :name_is_present
   validates_inclusion_of :component_type, in: %w[VSP MSA SP]
-  validate :persist_entity_id_only_for_msa
   validate :component_is_new, :persist_entity_id_only_for_msa, on: :create
 
   def build_component
@@ -34,9 +32,22 @@ class NewComponentEvent < AggregatedEvent
     name.present?
   end
 
-  def persist_entity_id_only_for_msa
-    return if component_type == 'MSA' && entity_id.present?
+  def msa_has_entity_id?
+    component_type == 'MSA' && entity_id.present?
+  end
 
-    errors.add(:component, 'Entity id can not be set on VSP component') if entity_id.present?
+  def msa_does_not_have_entity_id?
+    component_type == 'MSA' && entity_id.blank?
+  end
+
+  def vsp_does_not_require_entity_id?
+    component_type != 'MSA' && entity_id.blank?
+  end
+
+  def persist_entity_id_only_for_msa
+    return if msa_has_entity_id? || vsp_does_not_require_entity_id?
+     
+    errors.add(:entity_id, 'id is required for MSA component') if msa_does_not_have_entity_id?
+    errors.add(:entity_id, 'id can not be set on VSP component') if entity_id.present?
   end
 end

--- a/app/models/publish_services_metadata_event.rb
+++ b/app/models/publish_services_metadata_event.rb
@@ -29,6 +29,6 @@ class PublishServicesMetadataEvent < Event
   private
 
   def services_metadata
-    Component.to_service_metadata(event_id)
+    Component.to_service_metadata(event_id: event_id)
   end
 end

--- a/app/models/publish_services_metadata_event.rb
+++ b/app/models/publish_services_metadata_event.rb
@@ -29,6 +29,6 @@ class PublishServicesMetadataEvent < Event
   private
 
   def services_metadata
-    Component.to_service_metadata(event_id: event_id)
+    Component.to_service_metadata(event_id)
   end
 end

--- a/app/views/components/new.html.erb
+++ b/app/views/components/new.html.erb
@@ -10,6 +10,11 @@
       <%=error_message_on(f.object.errors, :name) %>
       <%= f.text_field :name, class: "govuk-input#{@component.errors.key?(:name) ? ' govuk-input--error' : ''}" %>
     </div>
+    <div class="govuk-form-group <%= 'govuk-form-group--error' if @component.errors.key?(:entity_id) %>">
+      <h3 class="govuk-heading-m">Component entity id</h3>
+      <%=error_message_on(f.object.errors, :entity_id) %>
+      <%= f.text_field :entity_id, class: "govuk-input#{@component.errors.key?(:entity_id) ? ' govuk-input--error' : ''}" %>
+    </div>
     <div class="govuk-form-group <%= 'govuk-form-group--error' if @component.errors.key?(:component_type) %>">
       <h3 class="govuk-heading-m">Component type</h3>
 
@@ -30,7 +35,7 @@
       </div>
     </div>
     <div class="govuk-form-group">
-        <%= f.submit "Create component", class: "govuk-button" %>
+        <%=f.submit "Create component", class: "govuk-button" %>
     </div>
   <% end %>
 </fieldset>

--- a/db/migrate/20190520094157_add_entity_id_to_components.rb
+++ b/db/migrate/20190520094157_add_entity_id_to_components.rb
@@ -1,0 +1,5 @@
+class AddEntityIdToComponents < ActiveRecord::Migration[5.2]
+  def change
+    add_column :components, :entity_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_07_132826) do
+ActiveRecord::Schema.define(version: 2019_05_20_094157) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 2019_05_07_132826) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "encryption_certificate_id"
+    t.string "entity_id"
   end
 
   create_table "events", force: :cascade do |t|

--- a/spec/models/certificate_spec.rb
+++ b/spec/models/certificate_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
-
+require 'securerandom'
 include CertificateSupport
 
 RSpec.describe Certificate, type: :model do
@@ -7,8 +7,9 @@ RSpec.describe Certificate, type: :model do
   let(:good_cert_value) do
     pki.generate_signed_cert(expires_in: 2.months).to_pem
   end
-
-  component_params = { component_type: 'MSA', name: 'fake_name' }
+  
+  entity_id = SecureRandom.hex(10)
+  component_params = { component_type: 'MSA', name: 'fake_name', entity_id: entity_id }
   let(:component) { NewComponentEvent.create(component_params).component }
   
   it 'is valid with valid attributes' do

--- a/spec/models/certificate_spec.rb
+++ b/spec/models/certificate_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require 'securerandom'
 include CertificateSupport
 
 RSpec.describe Certificate, type: :model do
@@ -8,7 +7,7 @@ RSpec.describe Certificate, type: :model do
     pki.generate_signed_cert(expires_in: 2.months).to_pem
   end
   
-  entity_id = SecureRandom.hex(10)
+  entity_id = 'http://test-entity-id'
   component_params = { component_type: 'MSA', name: 'fake_name', entity_id: entity_id }
   let(:component) { NewComponentEvent.create(component_params).component }
   

--- a/spec/models/component_spec.rb
+++ b/spec/models/component_spec.rb
@@ -10,11 +10,10 @@ RSpec.describe Component, type: :model do
     let(:root) { PKI.new }
     let(:published_at) { Time.now }
     let(:event_id) { 0 }
-    let(:entity_id) { SecureRandom.hex(10) }
     let(:certificate) { root.generate_encoded_cert(expires_in: 2.months) }
-
+    entity_id = SecureRandom.hex(10)
     component_name = 'test component'
-    component_params = { component_type: 'MSA', name: component_name }
+    component_params = { component_type: 'MSA', name: component_name, entity_id: entity_id }
     let(:component) { NewComponentEvent.create(component_params).component }
     let(:root) { PKI.new }
     let(:x509_cert_1) { root.generate_encoded_cert(expires_in: 2.months) }
@@ -89,6 +88,15 @@ RSpec.describe Component, type: :model do
       expect(actual_config).to eq(expected_config)
     end
 
+    it 'entity id is required MSA component' do
+      component_params = {
+        component_type: 'MSA',
+        name: component_name
+      }
+      new_component = NewComponentEvent.create(component_params).component
+      expect(new_component).not_to be_persisted
+    end
+
     it 'can set entity id on MSA component' do
       component_params = {
         component_type: 'MSA',
@@ -98,7 +106,7 @@ RSpec.describe Component, type: :model do
       new_component = NewComponentEvent.create(component_params).component
       expect(new_component).to be_persisted
     end
-    
+
     it 'cannot set entity id on VSP component' do
       component_params = {
         component_type: 'VSP',
@@ -107,6 +115,15 @@ RSpec.describe Component, type: :model do
       }
       new_component = NewComponentEvent.create(component_params).component
       expect(new_component).not_to be_persisted
+    end
+
+    it 'entity id not required on VSP component' do
+      component_params = {
+        component_type: 'VSP',
+        name: component_name
+      }
+      new_component = NewComponentEvent.create(component_params).component
+      expect(new_component).to be_persisted
     end
   end
 end

--- a/spec/models/new_component_event_spec.rb
+++ b/spec/models/new_component_event_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
-require 'securerandom'
+
 RSpec.describe NewComponentEvent, type: :model do
-  entity_id = SecureRandom.hex(10)
+  entity_id = 'http://test-entity-id'
+
   include_examples 'has data attributes', NewComponentEvent, [:name, :component_type, :entity_id]
   include_examples 'is aggregated', NewComponentEvent, {name: 'New component', component_type: 'MSA', entity_id: entity_id }
   include_examples 'is a creation event', NewComponentEvent, {name: 'New component', component_type: 'MSA', entity_id: entity_id }

--- a/spec/models/new_component_event_spec.rb
+++ b/spec/models/new_component_event_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
-
+require 'securerandom'
 RSpec.describe NewComponentEvent, type: :model do
-
-  include_examples 'has data attributes', NewComponentEvent, [:name, :component_type]
-  include_examples 'is aggregated', NewComponentEvent, {name: 'New component', component_type: 'MSA' }
-  include_examples 'is a creation event', NewComponentEvent, {name: 'New component', component_type: 'MSA'}
+  entity_id = SecureRandom.hex(10)
+  include_examples 'has data attributes', NewComponentEvent, [:name, :component_type, :entity_id]
+  include_examples 'is aggregated', NewComponentEvent, {name: 'New component', component_type: 'MSA', entity_id: entity_id }
+  include_examples 'is a creation event', NewComponentEvent, {name: 'New component', component_type: 'MSA', entity_id: entity_id }
 
   context '#component_type' do
     it 'must be one of the known types' do
@@ -16,7 +16,7 @@ RSpec.describe NewComponentEvent, type: :model do
 
   context 'name' do
     it 'must be provided' do
-      event = NewComponentEvent.create(name:'', component_type: 'MSA')
+      event = NewComponentEvent.create(name: '', component_type: 'MSA', entity_id: entity_id)
       expect(event).to_not be_valid
       expect(event.errors[:name]).to eql ['can\'t be blank']
     end

--- a/spec/models/replace_encryption_certificate_event_spec.rb
+++ b/spec/models/replace_encryption_certificate_event_spec.rb
@@ -1,13 +1,15 @@
 require 'rails_helper'
 require 'auth_test_helper'
+require 'securerandom'
 
 RSpec.describe ReplaceEncryptionCertificateEvent, type: :model do
   before(:each) do
     stub_auth
   end
+  entity_id = SecureRandom.hex(10)
   let(:component_name) { 'test component' }
   let(:component) do
-    component_params = { component_type: 'MSA', name: component_name }
+    component_params = { component_type: 'MSA', name: component_name, entity_id: entity_id }
     NewComponentEvent.create(component_params).component
   end
   let(:root) { PKI.new }

--- a/spec/models/replace_encryption_certificate_event_spec.rb
+++ b/spec/models/replace_encryption_certificate_event_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 require 'auth_test_helper'
-require 'securerandom'
 
 RSpec.describe ReplaceEncryptionCertificateEvent, type: :model do
   before(:each) do
     stub_auth
   end
-  entity_id = SecureRandom.hex(10)
+
+  entity_id = 'http://test-entity-id'
   let(:component_name) { 'test component' }
   let(:component) do
     component_params = { component_type: 'MSA', name: component_name, entity_id: entity_id }

--- a/spec/models/upload_certificate_event_spec.rb
+++ b/spec/models/upload_certificate_event_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
-require 'securerandom'
+
 RSpec.describe UploadCertificateEvent, type: :model do
   include CertificateSupport
   
   root = PKI.new
-  entity_id = SecureRandom.hex(10)
+  entity_id = 'http://test-entity-id'
   good_cert_value = root.generate_encoded_cert(expires_in: 2.months)
   component_params = { component_type: 'MSA', name: 'fake_name', entity_id: entity_id }
   component = NewComponentEvent.create(component_params).component

--- a/spec/models/upload_certificate_event_spec.rb
+++ b/spec/models/upload_certificate_event_spec.rb
@@ -1,10 +1,12 @@
 require 'rails_helper'
+require 'securerandom'
 RSpec.describe UploadCertificateEvent, type: :model do
   include CertificateSupport
   
   root = PKI.new
+  entity_id = SecureRandom.hex(10)
   good_cert_value = root.generate_encoded_cert(expires_in: 2.months)
-  component_params = { component_type: 'MSA', name: 'fake_name' }
+  component_params = { component_type: 'MSA', name: 'fake_name', entity_id: entity_id }
   component = NewComponentEvent.create(component_params).component
   include_examples 'has data attributes', UploadCertificateEvent, [:usage, :value, :component_id]
   include_examples 'is aggregated', UploadCertificateEvent, {usage: CONSTANTS::SIGNING, value: good_cert_value, component_id: component.id }
@@ -12,7 +14,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
 
   context '#value' do
     it 'must be present' do
-      event = UploadCertificateEvent.create()
+      event = UploadCertificateEvent.create
       expect(event).to_not be_valid
       expect(event.errors[:certificate]).to eql ['can\'t be blank']
     end

--- a/spec/system/user_visits_events_page_spec.rb
+++ b/spec/system/user_visits_events_page_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 require 'auth_test_helper'
-require 'securerandom'
+
 include CertificateSupport
 
 RSpec.describe 'the events page', type: :system do
@@ -8,7 +8,7 @@ RSpec.describe 'the events page', type: :system do
   before(:each) do
     stub_auth
   end
-  entity_id = SecureRandom.hex(10)
+  entity_id = 'http://test-entity-id'
   component_params = { component_type: 'MSA', name: 'fake_name', entity_id: entity_id }
   let(:component) { NewComponentEvent.create(component_params).component }
   let(:root) { PKI.new }

--- a/spec/system/user_visits_events_page_spec.rb
+++ b/spec/system/user_visits_events_page_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 require 'auth_test_helper'
-
+require 'securerandom'
 include CertificateSupport
 
 RSpec.describe 'the events page', type: :system do
@@ -8,8 +8,8 @@ RSpec.describe 'the events page', type: :system do
   before(:each) do
     stub_auth
   end
-
-  component_params = { component_type: 'MSA', name:'fake_name' }
+  entity_id = SecureRandom.hex(10)
+  component_params = { component_type: 'MSA', name: 'fake_name', entity_id: entity_id }
   let(:component) { NewComponentEvent.create(component_params).component }
   let(:root) { PKI.new }
 

--- a/spec/system/visit_component_new_spec.rb
+++ b/spec/system/visit_component_new_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
-require 'securerandom'
+
 RSpec.describe 'New Component Page', type: :system do
-  let(:entity_id) { SecureRandom.hex(10) }
+  let(:entity_id) { 'http://test-entity-id' }
   context 'creation is successful' do
     it 'when required input is specified' do
       component_name = 'test component'
@@ -68,18 +68,6 @@ RSpec.describe 'New Component Page', type: :system do
       click_button 'Create component'
 
       expect(page).to have_content 'Entity id is required for MSA component'
-    end
-
-    it 'when entity id is specified for VSP component' do
-      entity = entity_id
-      component_name = 'test component'
-      visit new_component_path
-      choose 'component_component_type_vsp', allow_label_click: true
-      fill_in 'component_name', with: component_name
-      fill_in 'component_entity_id', with: entity
-      click_button 'Create component'
-
-      expect(page).to have_content 'Entity id can not be set on VSP component'
     end
   end
 end

--- a/spec/system/visit_component_new_spec.rb
+++ b/spec/system/visit_component_new_spec.rb
@@ -1,13 +1,37 @@
 require 'rails_helper'
-
+require 'securerandom'
 RSpec.describe 'New Component Page', type: :system do
-
+  let(:entity_id) { SecureRandom.hex(10) }
   context 'creation is successful' do
     it 'when required input is specified' do
       component_name = 'test component'
       visit new_component_path
       choose 'component_component_type_vsp', allow_label_click: true
       fill_in 'component_name', with: component_name
+      click_button 'Create component'
+
+      expect(current_path).to eql components_path
+    end
+
+    it 'when required input with entity id for msa is specified' do
+      entity = entity_id
+      component_name = 'test component'
+      visit new_component_path
+      choose 'component_component_type_msa', allow_label_click: true
+      fill_in 'component_name', with: component_name
+      fill_in 'component_entity_id', with: entity
+      click_button 'Create component'
+
+      expect(current_path).to eql components_path
+    end
+
+    it 'when required input without entity id for vsp is not specified' do
+      entity = nil
+      component_name = 'test component'
+      visit new_component_path
+      choose 'component_component_type_vsp', allow_label_click: true
+      fill_in 'component_name', with: component_name
+      fill_in 'component_entity_id', with: entity
       click_button 'Create component'
 
       expect(current_path).to eql components_path
@@ -32,6 +56,30 @@ RSpec.describe 'New Component Page', type: :system do
       click_button 'Create component'
 
       expect(page).to have_content 'Component type is not included in the list'
+    end
+
+    it 'when entity id is not specified for msa component' do
+      entity = nil
+      component_name = 'test component'
+      visit new_component_path
+      choose 'component_component_type_msa', allow_label_click: true
+      fill_in 'component_name', with: component_name
+      fill_in 'component_entity_id', with: entity
+      click_button 'Create component'
+
+      expect(page).to have_content 'Entity id is required for MSA component'
+    end
+
+    it 'when entity id is specified for VSP component' do
+      entity = entity_id
+      component_name = 'test component'
+      visit new_component_path
+      choose 'component_component_type_vsp', allow_label_click: true
+      fill_in 'component_name', with: component_name
+      fill_in 'component_entity_id', with: entity
+      click_button 'Create component'
+
+      expect(page).to have_content 'Entity id can not be set on VSP component'
     end
   end
 end

--- a/spec/system/visit_component_show_spec.rb
+++ b/spec/system/visit_component_show_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 require 'auth_test_helper'
-require 'securerandom'
+
 RSpec.describe 'New Component Page', type: :system do
   before(:each) do
     stub_auth
   end
 
-  entity_id = SecureRandom.hex(10)
+  entity_id = 'http://test-entity-id'
   component_name = 'test component'
   component_params = { component_type: 'MSA', name: component_name, entity_id: entity_id }
 

--- a/spec/system/visit_component_show_spec.rb
+++ b/spec/system/visit_component_show_spec.rb
@@ -1,13 +1,14 @@
 require 'rails_helper'
 require 'auth_test_helper'
-
+require 'securerandom'
 RSpec.describe 'New Component Page', type: :system do
   before(:each) do
     stub_auth
   end
 
+  entity_id = SecureRandom.hex(10)
   component_name = 'test component'
-  component_params = { component_type: 'MSA', name: component_name }
+  component_params = { component_type: 'MSA', name: component_name, entity_id: entity_id }
 
   let(:component) { NewComponentEvent.create(component_params).component }
   let(:root) { PKI.new }

--- a/spec/system/visit_upload_page_spec.rb
+++ b/spec/system/visit_upload_page_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 require 'auth_test_helper'
-require 'securerandom'
+
 include CertificateSupport
 
 RSpec.describe 'UploadPage', type: :system do
@@ -9,11 +9,11 @@ RSpec.describe 'UploadPage', type: :system do
     stub_auth
   end
 
-  entity_id = SecureRandom.hex(10)
+  entity_id = 'http://test-entity-id'
   component_params = { component_type: 'MSA', name: 'fake_name', entity_id: entity_id }
   let(:component) { NewComponentEvent.create(component_params).component }
   let(:root) { PKI.new }
-  let(:test_certificate){root.generate_encoded_cert(expires_in: 2.months) }
+  let(:test_certificate) { root.generate_encoded_cert(expires_in: 2.months) }
 
   it 'successfully submits a certificate' do
     visit new_component_certificate_path(component)
@@ -22,7 +22,5 @@ RSpec.describe 'UploadPage', type: :system do
     click_button 'Upload'
     expect(page).to have_selector ("#edit_certificate_#{component.certificates.last.id}")
     expect(current_path).to eql component_path(component)
-
   end
-
 end

--- a/spec/system/visit_upload_page_spec.rb
+++ b/spec/system/visit_upload_page_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 require 'auth_test_helper'
-
+require 'securerandom'
 include CertificateSupport
 
 RSpec.describe 'UploadPage', type: :system do
@@ -8,11 +8,12 @@ RSpec.describe 'UploadPage', type: :system do
   before(:each) do
     stub_auth
   end
-  
-  component_params = {component_type: 'MSA', name:'fake_name'}
+
+  entity_id = SecureRandom.hex(10)
+  component_params = { component_type: 'MSA', name: 'fake_name', entity_id: entity_id }
   let(:component) { NewComponentEvent.create(component_params).component }
   let(:root) { PKI.new }
-  let(:test_certificate){root.generate_encoded_cert(expires_in: 2.months)}
+  let(:test_certificate){root.generate_encoded_cert(expires_in: 2.months) }
 
   it 'successfully submits a certificate' do
     visit new_component_certificate_path(component)


### PR DESCRIPTION
Components of type MSA must have an entityId. We should be able to set this in the frontend and it should be exported with the configuration metadata to S3.

Why do we need it?
We need to be able to retrieve certificates that are used by the MSA given the entityId that it identifies itself with. We therefore need to able to configure this and make it available to the hub config service.