### PR TITLE
BAU: Setting Entity_id to nil when not msa

### DIFF
--- a/app/models/new_component_event.rb
+++ b/app/models/new_component_event.rb
@@ -38,7 +38,7 @@ class NewComponentEvent < AggregatedEvent
       errors.add(:entity_id, 'id is required for MSA component') unless entity_id.present?
       return entity_id.present?
     else
-      self.update_attribute(:entity_id, nil)
+      self.assign_attributes(entity_id: nil)
     end
   end
 end


### PR DESCRIPTION
Clicking the Create component button on /components/new i.e the
**Upload your component page** currently generates an error due using
update_attribute changing to assign_attributes fixes this error.