### PR TITLE
Create Service Model

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ group :development, :test do
   gem 'sqlite3'
   gem 'pry'
   gem 'govuk-lint'
+  gem 'factory_bot_rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,11 @@ GEM
       railties (>= 3.2, < 6.1)
     erubi (1.8.0)
     execjs (2.7.0)
+    factory_bot (5.0.2)
+      activesupport (>= 4.2.0)
+    factory_bot_rails (5.0.2)
+      factory_bot (~> 5.0.2)
+      railties (>= 4.2.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     ffi (1.10.0)
@@ -334,6 +339,7 @@ DEPENDENCIES
   capybara
   colorize
   dotenv-rails
+  factory_bot_rails
   geckodriver-helper
   govuk-lint
   jbuilder (~> 2.5)

--- a/app/controllers/components_controller.rb
+++ b/app/controllers/components_controller.rb
@@ -12,7 +12,11 @@ class ComponentsController < ApplicationController
   end
 
   def create
-    @component = NewComponentEvent.create(component_params)
+    @component = if params['component']['component_type'] == 'MSA'
+                   NewMsaComponentEvent.create(component_params)
+                 else
+                   NewComponentEvent.create(component_params)
+                 end
     if @component.valid?
       redirect_to components_path
     else

--- a/app/controllers/components_controller.rb
+++ b/app/controllers/components_controller.rb
@@ -12,7 +12,7 @@ class ComponentsController < ApplicationController
   end
 
   def create
-    @component = if params['component']['component_type'] == 'MSA'
+    @component = if params.dig('component', 'component_type') == 'MSA'
                    NewMsaComponentEvent.create(component_params)
                  else
                    NewComponentEvent.create(component_params)

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -1,5 +1,6 @@
 class Component < Aggregate
   has_many :certificates
+  has_many :services
   has_many :signing_certificates,
            -> { where(usage: CONSTANTS::SIGNING) }, class_name: 'Certificate'
   has_many :encryption_certificates,

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -3,7 +3,7 @@ class Component < Aggregate
   has_many :signing_certificates,
            -> { where(usage: CONSTANTS::SIGNING) }, class_name: 'Certificate'
   has_many :encryption_certificates,
-           lambda {
+           -> {
              where(usage: CONSTANTS::ENCRYPTION).order(created_at: 'desc')
            }, class_name: 'Certificate'
   has_many :enabled_signing_certificates,

--- a/app/models/new_component_event.rb
+++ b/app/models/new_component_event.rb
@@ -4,7 +4,7 @@ class NewComponentEvent < AggregatedEvent
 
   validate :name_is_present
   validates_inclusion_of :component_type, in: %w[VSP MSA SP]
-  validate :component_is_new, :msa_has_entity_id, on: :create
+  validate :component_is_new, on: :create
 
   def build_component
     Component.new
@@ -14,7 +14,6 @@ class NewComponentEvent < AggregatedEvent
     {
       name: name,
       component_type: component_type,
-      entity_id: entity_id,
       created_at: created_at
     }
   end
@@ -31,14 +30,5 @@ private
 
   def name_present?
     name.present?
-  end
-
-  def msa_has_entity_id
-    if component_type == 'MSA'
-      errors.add(:entity_id, 'id is required for MSA component') unless entity_id.present?
-      entity_id.present?
-    else
-      self.assign_attributes(entity_id: nil)
-    end
   end
 end

--- a/app/models/new_msa_component_event.rb
+++ b/app/models/new_msa_component_event.rb
@@ -1,0 +1,23 @@
+class NewMsaComponentEvent < NewComponentEvent
+  validate :msa_has_entity_id
+
+  def build_msa_component
+    MsaComponent.new
+  end
+
+  def attributes_to_apply
+    {
+      name: name,
+      component_type: component_type,
+      entity_id: entity_id,
+      created_at: created_at
+    }
+  end
+
+private
+
+  def msa_has_entity_id
+    errors.add(:entity_id, 'id is required for MSA component') unless entity_id.present?
+    entity_id.present?
+  end
+end

--- a/app/models/new_service_event.rb
+++ b/app/models/new_service_event.rb
@@ -1,0 +1,18 @@
+class NewServiceEvent < AggregatedEvent
+  belongs_to_aggregate :service
+  data_attributes :entity_id, :component_id, :msa_component_id, :name
+
+  def build_service
+    Service.new
+  end
+
+  def attributes_to_apply
+    {
+      entity_id: entity_id,
+      component_id: component_id,
+      msa_component_id: msa_component_id,
+      name: name,
+      created_at: created_at
+    }
+  end
+end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -1,0 +1,6 @@
+class Service < Aggregate
+  belongs_to :component
+  belongs_to :msa_component, optional: true
+
+  validates_presence_of :entity_id
+end

--- a/db/migrate/20190528114026_create_services.rb
+++ b/db/migrate/20190528114026_create_services.rb
@@ -1,0 +1,12 @@
+class CreateServices < ActiveRecord::Migration[5.2]
+  def change
+    create_table :services do |t|
+      t.string :entity_id, null: false, index: { unique: true }
+      t.string :name
+      t.integer :component_id
+      t.integer :msa_component_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_20_094157) do
+ActiveRecord::Schema.define(version: 2019_05_28_114026) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -60,6 +60,16 @@ ActiveRecord::Schema.define(version: 2019_05_20_094157) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["aggregate_type", "aggregate_id"], name: "index_events_on_aggregate_type_and_aggregate_id"
+  end
+
+  create_table "services", force: :cascade do |t|
+    t.string "entity_id", null: false
+    t.string "name"
+    t.integer "component_id"
+    t.integer "msa_component_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["entity_id"], name: "index_services_on_entity_id", unique: true
   end
 
 end

--- a/spec/factories/component.rb
+++ b/spec/factories/component.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :component do
+    component_type { 'VSP' }
+  end
+end

--- a/spec/factories/service.rb
+++ b/spec/factories/service.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :service do
+    entity_id { 'https://not-a-real-entity-id' }
+    name  { SecureRandom.alphanumeric }
+    component { }
+    msa_component { }
+  end
+end

--- a/spec/models/component_spec.rb
+++ b/spec/models/component_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Component, type: :model do
     entity_id = 'http://test-entity-id'
     component_name = 'test component'
     component_params = { component_type: 'MSA', name: component_name, entity_id: entity_id }
-    let(:component) { NewComponentEvent.create(component_params).component }
+    let(:component) { NewMsaComponentEvent.create(component_params).component }
     let(:root) { PKI.new }
     let(:x509_cert_1) { root.generate_encoded_cert(expires_in: 2.months) }
     let(:x509_cert_2) { root.generate_encoded_cert(expires_in: 9.months) }
@@ -89,7 +89,7 @@ RSpec.describe Component, type: :model do
         component_type: 'MSA',
         name: component_name
       }
-      new_component = NewComponentEvent.create(component_params).component
+      new_component = NewMsaComponentEvent.create(component_params).component
       expect(new_component).not_to be_persisted
     end
 
@@ -99,7 +99,7 @@ RSpec.describe Component, type: :model do
         name: component_name,
         entity_id: entity_id
       }
-      new_component = NewComponentEvent.create(component_params).component
+      new_component = NewMsaComponentEvent.create(component_params).component
       expect(new_component).to be_persisted
       expect(new_component.entity_id).to eq(entity_id)
     end

--- a/spec/models/msa_component.rb
+++ b/spec/models/msa_component.rb
@@ -1,0 +1,2 @@
+class MsaComponent < Component
+end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe Service, type: :model do
+  context 'adding components to a service' do
+    it 'should create a new service correctly' do
+      service = create(:service, component: create(:component))
+
+      expect(service).to be_valid
+      expect(service).to be_persisted
+    end
+  end
+end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end


### PR DESCRIPTION
## What

This adds the (connected) service model. Each service:
- Can only have a maximum of 2 components
- Cannot have components of the same component_type
- Cannot not have both a VSP and a SP component type

## Also

- The `entity_id` is unique across all services
- Add factory_bot_rails gem
- Create a MSA specific component in order to make it easier to represent the relationship components and services.

https://trello.com/c/vK1m0UlX/391-add-connected-service-model-to-self-service-app

Co-authored-by: Rosa Fox <rosa.fox@digital.cabinet-office.gov.uk>
Co-authored-by: Jakub Miarka <jakub.miarka@digital.cabinet-office.gov.uk>