### PR TITLE
Add Connected Services views and controller

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -9,22 +9,20 @@ class ServicesController < ApplicationController
 
   def new
     @component = component_by_klass_name(params)
-    @service = NewServiceEvent.new
+    @service_event = NewServiceEvent.new
   end
 
   def create
     @component = component_by_klass_name(params)
-    @service = NewServiceEvent.create(service_params)
+    @service_event = NewServiceEvent.create(service_params)
 
-    if @service.valid?
+    if @service_event.valid? && @service_event.service.valid?
       redirect_to polymorphic_url(@component)
     else
-      Rails.logger.info(@service.errors.full_messages)
+      @service_event.errors.merge!(@service_event.service.errors)
+      Rails.logger.info(@service_event.errors.full_messages)
       render :new
     end
-  rescue ActiveRecord::RecordNotUnique
-    Rails.logger.info('Entity ID exists')
-    render :new
   end
 
 private

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -1,0 +1,44 @@
+class ServicesController < ApplicationController
+  include ControllerConcern
+  include ComponentConcern
+
+  def index
+    component = component_by_klass_name(params)
+    @services = component.services
+  end
+
+  def new
+    @component = component_by_klass_name(params)
+    @service = NewServiceEvent.new
+  end
+
+  def create
+    @component = component_by_klass_name(params)
+    @service = NewServiceEvent.create(service_params)
+
+    if @service.valid?
+      redirect_to polymorphic_url(@component)
+    else
+      Rails.logger.info(@service.errors.full_messages)
+      render :new
+    end
+  rescue ActiveRecord::RecordNotUnique
+    Rails.logger.info('Entity ID exists')
+    render :new
+  end
+
+private
+
+  def component_by_klass_name(params)
+    component_id = params[component_key(params)]
+    component_name = component_name_from_params(params)
+    klass_component(component_name).find_by_id(component_id)
+  end
+
+  def service_params
+    key = component_key(params)
+    params.require(:service)
+          .permit(:name, :entity_id)
+          .merge("#{key}": params[key])
+  end
+end

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -1,8 +1,6 @@
 class Component < Aggregate
   self.abstract_class = true
 
-  has_many :certificates
-  has_many :services
   has_many :signing_certificates,
            -> { where(usage: CONSTANTS::SIGNING) }, class_name: 'Certificate'
   has_many :encryption_certificates,

--- a/app/models/concerns/component_concern.rb
+++ b/app/models/concerns/component_concern.rb
@@ -4,8 +4,4 @@ module ComponentConcern
   def klass_component(name)
     name.safe_constantize
   end
-
-  def view_component_type(vsp)
-    vsp ? CONSTANTS::VSP_SHORT : CONSTANTS::SP_SHORT
-  end
 end

--- a/app/models/msa_component.rb
+++ b/app/models/msa_component.rb
@@ -1,3 +1,4 @@
 class MsaComponent < Component
   has_many :certificates, as: :component
+  has_many :services
 end

--- a/app/models/new_msa_component_event.rb
+++ b/app/models/new_msa_component_event.rb
@@ -26,6 +26,5 @@ private
 
   def msa_has_entity_id
     errors.add(:entity_id, 'id is required for MSA component') unless entity_id.present?
-    entity_id.present?
   end
 end

--- a/app/models/new_service_event.rb
+++ b/app/models/new_service_event.rb
@@ -1,6 +1,7 @@
 class NewServiceEvent < AggregatedEvent
   belongs_to_aggregate :service
   data_attributes :entity_id, :sp_component_id, :msa_component_id, :name
+  validates_presence_of :entity_id, message: 'ID is required'
 
   def build_service
     Service.new

--- a/app/models/new_service_event.rb
+++ b/app/models/new_service_event.rb
@@ -2,6 +2,7 @@ class NewServiceEvent < AggregatedEvent
   belongs_to_aggregate :service
   data_attributes :entity_id, :sp_component_id, :msa_component_id, :name
   validates_presence_of :entity_id, message: 'ID is required'
+  validate :name_is_present
 
   def build_service
     Service.new

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -1,6 +1,4 @@
 class Service < Aggregate
   belongs_to :sp_component, optional: true
   belongs_to :msa_component, optional: true
-
-  validates_presence_of :entity_id
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -1,5 +1,5 @@
 class Service < Aggregate
-  belongs_to :component
+  belongs_to :sp_component, optional: true
   belongs_to :msa_component, optional: true
 
   validates_presence_of :entity_id

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -1,4 +1,5 @@
 class Service < Aggregate
   belongs_to :sp_component, optional: true
   belongs_to :msa_component, optional: true
+  validates_uniqueness_of :entity_id
 end

--- a/app/models/sp_component.rb
+++ b/app/models/sp_component.rb
@@ -1,4 +1,5 @@
 class SpComponent < Component
   has_many :certificates, as: :component
+  has_many :services
   include ComponentConcern
 end

--- a/app/models/sp_component.rb
+++ b/app/models/sp_component.rb
@@ -1,5 +1,8 @@
 class SpComponent < Component
   has_many :certificates, as: :component
   has_many :services
-  include ComponentConcern
+
+  def view_component_type(vsp)
+    vsp ? CONSTANTS::VSP_SHORT : CONSTANTS::SP_SHORT
+  end
 end

--- a/app/views/msa_components/_all_msa_components.html.erb
+++ b/app/views/msa_components/_all_msa_components.html.erb
@@ -9,7 +9,7 @@
       </tr>
     </thead>
     <tbody class="govuk-table__body">
-      <% for component in @msa_components.reverse %>
+      <% @msa_components.reverse.each do |component| %>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell" scope="row"><%= component.name %></td>
           <td class="govuk-table__cell"><%= component.entity_id %></td>

--- a/app/views/msa_components/show.html.erb
+++ b/app/views/msa_components/show.html.erb
@@ -64,3 +64,12 @@
     </div>
   </div>
 <% end %>
+
+<% if @component.services.present? %>
+  <%= render "services/list/services_table" %>
+<% end %>
+
+<%= link_to 'Add service',
+    polymorphic_url([:new, @component, :service], component: @component),
+    class: 'govuk-button' %>
+

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -1,0 +1,22 @@
+<h1 class="govuk-heading-xl">Services</h1>
+
+<% if @services.present? %>
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="col">Name</th>
+        <th class="govuk-table__header" scope="col">Entity ID</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      <% for service in @services.reverse %>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell" scope="row"><%= service.name %></td>
+          <td class="govuk-table__cell"><%= service.entity_id %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>
+
+<%= link_to 'Add new service', new_service_path, class: "govuk-button govuk-button--start", role:"button", draggable:"false" %>

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -9,7 +9,7 @@
       </tr>
     </thead>
     <tbody class="govuk-table__body">
-      <% for service in @services.reverse %>
+      <% @services.reverse do |service| %>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell" scope="row"><%= service.name %></td>
           <td class="govuk-table__cell"><%= service.entity_id %></td>

--- a/app/views/services/list/_services_table.html.erb
+++ b/app/views/services/list/_services_table.html.erb
@@ -1,0 +1,36 @@
+<div class="govuk-accordion" data-module="accordion" id="accordion-default">
+  <div class="govuk-accordion__section ">
+    <div class="govuk-accordion__section-header">
+      <h2 class="govuk-accordion__section-heading">
+        <span class="govuk-accordion__section-button" id="all-services-accordian">
+          All services
+        </span>
+      </h2>
+    </div>
+    <div id="accordion-default-content-3" class="govuk-accordion__section-content"
+      aria-labelledby="accordion-default-heading-3">
+
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header">ID</th>
+            <th class="govuk-table__header">Name</th>
+            <th class="govuk-table__header">Entity ID</th>
+            <th class="govuk-table__header">Last updated</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <% @component.services.each do |service| %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell"><%= service.id %></td>
+              <td class="govuk-table__cell"><%= service.name %></td>
+              <td class="govuk-table__cell"><%= service.entity_id %></td>
+              <td class="govuk-table__cell"><%= format_date_time(service.updated_at) %></td>
+            </tr>
+          <%end %>
+        </tbody>
+      </table>
+
+    </div>
+  </div>
+</div>

--- a/app/views/services/list/_services_table.html.erb
+++ b/app/views/services/list/_services_table.html.erb
@@ -27,7 +27,7 @@
               <td class="govuk-table__cell"><%= service.entity_id %></td>
               <td class="govuk-table__cell"><%= format_date_time(service.updated_at) %></td>
             </tr>
-          <%end %>
+          <% end %>
         </tbody>
       </table>
 

--- a/app/views/services/new.html.erb
+++ b/app/views/services/new.html.erb
@@ -1,0 +1,23 @@
+<fieldset class="govuk-fieldset">
+  <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+    <h1 class="govuk-fieldset__heading">Add a Service</h1>
+  </legend>
+
+  <%= error_messages_for(@service&.errors) %>
+  <%= form_for @service,
+      url: polymorphic_url([@component, :services], component: @component),
+      as: :service do |f| %>
+    <div class="govuk-form-group">
+      <h3 class="govuk-heading-m">Service name</h3>
+      <%= f.text_field :name, class: 'govuk-input' %>
+    </div>
+    <div class="govuk-form-group <%= 'govuk-form-group--error' if @service.errors.key?(:entity_id) %>">
+      <h3 class="govuk-heading-m">Service Entity ID</h3>
+      <%=error_message_on(f.object.errors, :entity_id) %>
+      <%= f.text_field :entity_id, class: 'govuk-input' %>
+    </div>
+    <div class="govuk-form-group">
+        <%=f.submit "Create service", class: "govuk-button" %>
+    </div>
+  <% end %>
+</fieldset>

--- a/app/views/services/new.html.erb
+++ b/app/views/services/new.html.erb
@@ -7,8 +7,9 @@
   <%= form_for @service,
       url: polymorphic_url([@component, :services], component: @component),
       as: :service do |f| %>
-    <div class="govuk-form-group">
+    <div class="govuk-form-group <%= 'govuk-form-group--error' if @service.errors.key?(:name) %>">
       <h3 class="govuk-heading-m">Service name</h3>
+      <%=error_message_on(f.object.errors, :name) %>
       <%= f.text_field :name, class: 'govuk-input' %>
     </div>
     <div class="govuk-form-group <%= 'govuk-form-group--error' if @service.errors.key?(:entity_id) %>">

--- a/app/views/services/new.html.erb
+++ b/app/views/services/new.html.erb
@@ -3,16 +3,16 @@
     <h1 class="govuk-fieldset__heading">Add a Service</h1>
   </legend>
 
-  <%= error_messages_for(@service&.errors) %>
-  <%= form_for @service,
+  <%= error_messages_for(@service_event&.errors) %>
+  <%= form_for @service_event,
       url: polymorphic_url([@component, :services], component: @component),
       as: :service do |f| %>
-    <div class="govuk-form-group <%= 'govuk-form-group--error' if @service.errors.key?(:name) %>">
+    <div class="govuk-form-group <%= 'govuk-form-group--error' if @service_event.errors.key?(:name) %>">
       <h3 class="govuk-heading-m">Service name</h3>
       <%=error_message_on(f.object.errors, :name) %>
       <%= f.text_field :name, class: 'govuk-input' %>
     </div>
-    <div class="govuk-form-group <%= 'govuk-form-group--error' if @service.errors.key?(:entity_id) %>">
+    <div class="govuk-form-group <%= 'govuk-form-group--error' if @service_event.errors.key?(:entity_id) %>">
       <h3 class="govuk-heading-m">Service Entity ID</h3>
       <%=error_message_on(f.object.errors, :entity_id) %>
       <%= f.text_field :entity_id, class: 'govuk-input' %>

--- a/app/views/sp_components/_all_sp_components.html.erb
+++ b/app/views/sp_components/_all_sp_components.html.erb
@@ -9,7 +9,7 @@
       </tr>
     </thead>
     <tbody class="govuk-table__body">
-      <% for component in @sp_components.reverse %>
+      <% @sp_components.reverse.each do |component| %>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell" scope="row"><%= component.name %></td>
           <td class="govuk-table__cell">

--- a/app/views/sp_components/show.html.erb
+++ b/app/views/sp_components/show.html.erb
@@ -64,3 +64,11 @@
     </div>
   </div>
 <% end %>
+
+<% if @component.services.present? %>
+  <%= render "services/list/services_table" %>
+<% end %>
+
+<%= link_to 'Add service',
+    polymorphic_url([:new, @component, :service], component: @component),
+    class: 'govuk-button' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
 
   root 'components#index'
   resources :sp_components, path: 'sp-components' do
+    resources :services
     resources :certificates do
       member do
         patch 'enable'
@@ -12,6 +13,7 @@ Rails.application.routes.draw do
   end
 
   resources :msa_components, path: 'msa-components' do
+    resources :services
     resources :certificates do
       member do
         patch 'enable'

--- a/db/migrate/20190607154410_correct_services_table_columns.rb
+++ b/db/migrate/20190607154410_correct_services_table_columns.rb
@@ -1,0 +1,5 @@
+class CorrectServicesTableColumns < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :services, :component_id, :sp_component_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_06_104643) do
+ActiveRecord::Schema.define(version: 2019_06_07_154410) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -66,7 +66,7 @@ ActiveRecord::Schema.define(version: 2019_06_06_104643) do
   create_table "services", force: :cascade do |t|
     t.string "entity_id", null: false
     t.string "name"
-    t.integer "component_id"
+    t.integer "sp_component_id"
     t.integer "msa_component_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/factories/service.rb
+++ b/spec/factories/service.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :service do
     entity_id { 'https://not-a-real-entity-id' }
     name  { SecureRandom.alphanumeric }
-    component { }
+    sp_component { }
     msa_component { }
   end
 end

--- a/spec/models/msa_component.rb
+++ b/spec/models/msa_component.rb
@@ -1,2 +1,0 @@
-class MsaComponent < Component
-end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe Service, type: :model do
 
     it 'should be able to have an sp and msa component' do
       service.msa_component = msa_component
-
       expect(service).to be_valid
       expect(service).to be_persisted
     end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -2,8 +2,17 @@ require 'rails_helper'
 
 RSpec.describe Service, type: :model do
   context 'adding components to a service' do
+    let(:sp_component) { create(:sp_component) }
+    let(:msa_component) { create(:msa_component) }
+    let(:service) { create(:service, sp_component: sp_component) }
+
     it 'should create a new service correctly' do
-      service = create(:service, component: create(:sp_component))
+      expect(service).to be_valid
+      expect(service).to be_persisted
+    end
+
+    it 'should be able to have an sp and msa component' do
+      service.msa_component = msa_component
 
       expect(service).to be_valid
       expect(service).to be_persisted

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,6 +10,8 @@ require 'rspec/rails'
 # Load shared examples
 Dir[Rails.root.join("spec/models/shared_examples/**/*.rb")].each { |f| require f }
 
+Dir[Rails.root.join("spec/system/shared_examples/**/*.rb")].each { |f| require f }
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end

--- a/spec/system/shared_examples/new_component_service.rb
+++ b/spec/system/shared_examples/new_component_service.rb
@@ -35,5 +35,19 @@ RSpec.shared_examples "new component page" do |component_name|
 
       expect(page).to have_content 'Name can\'t be blank'
     end
+
+    it 'when entity id is not unique' do
+      visit polymorphic_url([:new, component, :service], component: component)
+      fill_in 'service_name', with: service_name
+      fill_in 'service_entity_id', with: service_entity_id
+      click_button 'Create service'
+
+      visit polymorphic_url([:new, component, :service], component: component)
+      fill_in 'service_name', with: service_name
+      fill_in 'service_entity_id', with: service_entity_id
+      click_button 'Create service'
+
+      expect(page).to have_content 'Entity has already been taken'
+    end
   end
 end

--- a/spec/system/shared_examples/new_component_service.rb
+++ b/spec/system/shared_examples/new_component_service.rb
@@ -1,0 +1,39 @@
+require 'auth_test_helper'
+RSpec.shared_examples "new component page" do |component_name|
+  before(:each) { stub_auth }
+
+  let(:service_name) { 'Here to serve'}
+  let(:service_entity_id) { 'service-entity-id'}
+  let(:component) { create(component_name) }
+
+  context 'creation of service is successful' do
+    it 'when required input is specified' do
+      visit polymorphic_url([:new, component, :service], component: component)
+      fill_in 'service_name', with: service_name
+      fill_in 'service_entity_id', with: service_entity_id
+      click_button 'Create service'
+
+      expect(current_url).to eql polymorphic_url(component)
+      expect(page).to have_content(service_name)
+      expect(page).to have_content(service_entity_id)
+    end
+  end
+
+  context 'creation fails' do
+    it 'when entity id is not specified' do
+      visit polymorphic_url([:new, component, :service], component: component)
+      fill_in 'service_name', with: service_name
+      click_button 'Create service'
+
+      expect(page).to have_content 'Entity ID is required'
+    end
+
+    it 'when name is not specified' do
+      visit polymorphic_url([:new, component, :service], component: component)
+      fill_in 'service_entity_id', with: service_entity_id
+      click_button 'Create service'
+
+      expect(page).to have_content 'Name can\'t be blank'
+    end
+  end
+end

--- a/spec/system/visit_msa_service_new_spec.rb
+++ b/spec/system/visit_msa_service_new_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+require 'auth_test_helper'
+
+RSpec.describe 'New MSA Component Page', type: :system do
+  before(:each) { stub_auth }
+
+  let(:component) { create(:msa_component) }
+  let(:service_name) { 'Here to serve'}
+  let(:service_entity_id) { 'service-entity-id'}
+
+  context 'creation of service is successful' do
+    it 'when required input is specified' do
+      visit new_msa_component_service_path(component.id)
+      fill_in 'service_name', with: service_name
+      fill_in 'service_entity_id', with: service_entity_id
+      click_button 'Create service'
+
+      expect(current_path).to eql msa_component_path(component.id)
+      expect(page).to have_content(service_name)
+      expect(page).to have_content(service_entity_id)
+    end
+  end
+
+  context 'creation fails without entity id' do
+    it 'when entity id is not specified' do
+      visit new_msa_component_service_path(component.id)
+      fill_in 'service_name', with: service_name
+      click_button 'Create service'
+
+      expect(page).to have_content 'Entity ID is required'
+    end
+  end
+end

--- a/spec/system/visit_msa_service_new_spec.rb
+++ b/spec/system/visit_msa_service_new_spec.rb
@@ -1,33 +1,5 @@
 require 'rails_helper'
-require 'auth_test_helper'
 
 RSpec.describe 'New MSA Component Page', type: :system do
-  before(:each) { stub_auth }
-
-  let(:component) { create(:msa_component) }
-  let(:service_name) { 'Here to serve'}
-  let(:service_entity_id) { 'service-entity-id'}
-
-  context 'creation of service is successful' do
-    it 'when required input is specified' do
-      visit new_msa_component_service_path(component.id)
-      fill_in 'service_name', with: service_name
-      fill_in 'service_entity_id', with: service_entity_id
-      click_button 'Create service'
-
-      expect(current_path).to eql msa_component_path(component.id)
-      expect(page).to have_content(service_name)
-      expect(page).to have_content(service_entity_id)
-    end
-  end
-
-  context 'creation fails without entity id' do
-    it 'when entity id is not specified' do
-      visit new_msa_component_service_path(component.id)
-      fill_in 'service_name', with: service_name
-      click_button 'Create service'
-
-      expect(page).to have_content 'Entity ID is required'
-    end
-  end
+  include_examples 'new component page', :msa_component
 end

--- a/spec/system/visit_sp_service_new_spec.rb
+++ b/spec/system/visit_sp_service_new_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+require 'auth_test_helper'
+
+RSpec.describe 'New SP Component Page', type: :system do
+  before(:each) { stub_auth }
+
+  let(:component) { create(:sp_component) }
+  let(:service_name) { 'Here to serve'}
+  let(:service_entity_id) { 'service-entity-id'}
+
+  context 'creation of service is successful' do
+    it 'when required input is specified' do
+      visit new_sp_component_service_path(component.id)
+      fill_in 'service_name', with: service_name
+      fill_in 'service_entity_id', with: service_entity_id
+      click_button 'Create service'
+
+      expect(current_path).to eql sp_component_path(component.id)
+      expect(page).to have_content(service_name)
+      expect(page).to have_content(service_entity_id)
+    end
+  end
+
+  context 'creation fails without entity id' do
+    it 'when entity id is not specified' do
+      visit new_sp_component_service_path(component.id)
+      fill_in 'service_name', with: service_name
+      click_button 'Create service'
+
+      expect(page).to have_content 'Entity ID is required'
+    end
+  end
+end

--- a/spec/system/visit_sp_service_new_spec.rb
+++ b/spec/system/visit_sp_service_new_spec.rb
@@ -1,33 +1,5 @@
 require 'rails_helper'
-require 'auth_test_helper'
 
 RSpec.describe 'New SP Component Page', type: :system do
-  before(:each) { stub_auth }
-
-  let(:component) { create(:sp_component) }
-  let(:service_name) { 'Here to serve'}
-  let(:service_entity_id) { 'service-entity-id'}
-
-  context 'creation of service is successful' do
-    it 'when required input is specified' do
-      visit new_sp_component_service_path(component.id)
-      fill_in 'service_name', with: service_name
-      fill_in 'service_entity_id', with: service_entity_id
-      click_button 'Create service'
-
-      expect(current_path).to eql sp_component_path(component.id)
-      expect(page).to have_content(service_name)
-      expect(page).to have_content(service_entity_id)
-    end
-  end
-
-  context 'creation fails without entity id' do
-    it 'when entity id is not specified' do
-      visit new_sp_component_service_path(component.id)
-      fill_in 'service_name', with: service_name
-      click_button 'Create service'
-
-      expect(page).to have_content 'Entity ID is required'
-    end
-  end
+  include_examples 'new component page', :sp_component
 end


### PR DESCRIPTION
## What

Review after:

- [x] https://github.com/alphagov/verify-self-service/pull/55

This adds the views and controller for interacting with Services. Users can now add Connected Services to a component.

The Service previously had a connection to the older Component model which is now abstract, so the `component_id` column was renamed to `sp_component_id` in order to bring it into line with the recent model changes.

### (SP or MSA) Component page

<img width="998" alt="Screen Shot 2019-06-10 at 13 46 21" src="https://user-images.githubusercontent.com/3466862/59196289-24c0bb80-8b86-11e9-89dc-055520bbaaff.png">

## Adding a new service

<img width="993" alt="Screen Shot 2019-06-10 at 13 45 59" src="https://user-images.githubusercontent.com/3466862/59196300-2b4f3300-8b86-11e9-9cb6-3c46bf420d11.png">

## Why

What is a component without services? It's like Alexander without his elephants . . .

https://trello.com/c/VL3EbxHV/424-add-connected-service-component-relationship-through-the-front-end

Co-authored-by: Rosa Fox <rosa.fox@digital.cabinet-office.gov.uk>