### PR TITLE
NtRhoDQ0: Update metadata schema to include services

### DIFF
--- a/app/models/msa_component.rb
+++ b/app/models/msa_component.rb
@@ -1,4 +1,10 @@
 class MsaComponent < Component
   has_many :certificates, as: :component
   has_many :services
+
+private
+
+  def additional_metadata
+    { entity_id: entity_id }
+  end
 end

--- a/app/models/sp_component.rb
+++ b/app/models/sp_component.rb
@@ -5,4 +5,10 @@ class SpComponent < Component
   def view_component_type(vsp)
     vsp ? CONSTANTS::VSP_SHORT : CONSTANTS::SP_SHORT
   end
+
+private
+
+  def additional_metadata
+    { id: id }
+  end
 end


### PR DESCRIPTION
- Metadata now also includes `connected_services` to adhere to: https://github.com/alphagov/verify-hub/blob/master/hub/config/src/test/resources/remote-test-config.json

Co-authored-by: Brendan Butler <brendan.butler@digital.cabinet-office.gov.uk>