### PR TITLE
Correctly publish metadata

### DIFF
--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -1,6 +1,6 @@
 class Certificate < Aggregate
   validates_inclusion_of :usage, in: %w[signing encryption]
-  validates_presence_of :usage, :value, :component_id, :component_type
+  validates_presence_of :usage, :value, :component
   belongs_to :component, polymorphic: true
 
   def to_metadata

--- a/app/models/publish_services_metadata_event.rb
+++ b/app/models/publish_services_metadata_event.rb
@@ -11,7 +11,7 @@ class PublishServicesMetadataEvent < Event
   after_create :upload
 
   def populate_data_attributes
-    @metadata = services_metadata
+    metadata = services_metadata
     assign_attributes(services_metadata: metadata)
   end
 

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :new_sp_component_event do
+    name { SecureRandom.alphanumeric }
+    component_type { CONSTANTS::SP }
+  end
+
+  factory :new_msa_component_event do
+    name { SecureRandom.alphanumeric }
+    entity_id { 'https://test-entity-id' }
+  end
+end


### PR DESCRIPTION
We had previously made an incorrect assumption about the publishing of
the metadata. It should always be a the latest metadata for all
components regardless of type.

The component_spec should now show a complete example of the published
metadata structure.

Also removed some tests from component_spec which were already being
tested in other specs.