### PR TITLE
Add additional config for S3 file upload

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -8,11 +8,13 @@ local:
 
 # Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 amazon:
-   service: S3
-   access_key_id: <%= Rails.application.secrets.aws_access_key_id %>
-   secret_access_key: <%= Rails.application.secrets.aws_secret_access_key %>
-   region: <%=Rails.application.secrets.aws_region %>
-   bucket: <%=Rails.application.secrets.aws_bucket %>
+  service: S3
+  access_key_id: <%= Rails.application.secrets.aws_access_key_id %>
+  secret_access_key: <%= Rails.application.secrets.aws_secret_access_key %>
+  region: <%=Rails.application.secrets.aws_region %>
+  bucket: <%=Rails.application.secrets.aws_bucket %>
+  upload:
+    server_side_encryption: AES256
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:


### PR DESCRIPTION
The bucket requires `server_side_encryption` header to be sent in the upload request so add this to the amazon config section.

https://trello.com/c/3VTpnx6M/466-create-user-and-roles-for-s3-access-in-staging

Co-authored-by: Jakub Miarka <jakub.miarka@digital.cabinet-office.gov.uk>