### PR TITLE
lv78wFsR: Sanitise certs when storing them

### DIFF
--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -1,4 +1,5 @@
 class Certificate < Aggregate
+  include CertificateConcern
   validates_inclusion_of :usage, in: %w[signing encryption]
   validates_presence_of :usage, :value, :component
   belongs_to :component, polymorphic: true
@@ -16,8 +17,6 @@ class Certificate < Aggregate
   end
 
   def x509
-    OpenSSL::X509::Certificate.new(value)
-  rescue # rubocop:disable Style/RescueStandardError
-    OpenSSL::X509::Certificate.new(Base64.decode64(value))
+    to_x509(value)
   end
 end

--- a/app/models/concerns/certificate_concern.rb
+++ b/app/models/concerns/certificate_concern.rb
@@ -1,0 +1,9 @@
+module CertificateConcern
+  extend ActiveSupport::Concern
+
+  def to_x509(value)
+    OpenSSL::X509::Certificate.new(value)
+  rescue # rubocop:disable Style/RescueStandardError
+    OpenSSL::X509::Certificate.new(Base64.decode64(value))
+  end
+end

--- a/config/initializers/validators/certificate_validator.rb
+++ b/config/initializers/validators/certificate_validator.rb
@@ -1,4 +1,5 @@
 ActiveRecord::Base.class_eval do
+  include CertificateConcern
 
   def self.value_is_present(value)
     validate :value, :value_is_present
@@ -24,21 +25,11 @@ ActiveRecord::Base.class_eval do
     certificate_key_is_supported
   end
 
-  def convert_value_to_x509_certificate
-    OpenSSL::X509::Certificate.new(value)
-  rescue
-    OpenSSL::X509::Certificate.new(Base64.decode64(value))
-  end
-
   def x509_certificate
-    convert_value_to_x509_certificate
+    to_x509(value)
   rescue
     errors.add(:certificate, 'is not a valid x509 certificate')
     nil
-  end
-
-  def convert_value_to_inline_der
-    Base64.strict_encode64(@x509.to_der)
   end
 
   def certificate_has_appropriate_not_after

--- a/spec/models/upload_certificate_event_spec.rb
+++ b/spec/models/upload_certificate_event_spec.rb
@@ -33,14 +33,16 @@ RSpec.describe UploadCertificateEvent, type: :model do
       cert = root.generate_encoded_cert(expires_in: 2.months)
 
       event = UploadCertificateEvent.create(usage: CONSTANTS::SIGNING, value: cert, component: component)
+      expect(event.certificate.value).to eql(cert)
       expect(event).to be_valid
       expect(event.errors[:certificate]).to be_empty
     end
 
-    it 'must allow PEM format x509 certificate' do
+    it 'must allow PEM format x509 certificate and be stored as base64 encoded DER' do
       cert = root.generate_signed_cert(expires_in: 2.months)
 
       event = UploadCertificateEvent.create(usage: CONSTANTS::SIGNING, value: cert.to_pem, component: component)
+      expect(event.certificate.value).to eql(Base64.strict_encode64(cert.to_der))
       expect(event).to be_valid
       expect(event.errors[:certificate]).to be_empty
     end


### PR DESCRIPTION
The uploaded certs were stored as whatever the input was. This change makes sure
they are always saved as base64 encoded DERs to maintain the consistency.

Co-Authored-By: Brendan Butler <brendan.butler@digital.cabinet-office.gov.uk>