### PR TITLE
BAU: Meaningful constants

### DIFF
--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -9,11 +9,11 @@ class Certificate < Aggregate
   end
 
   def encryption?
-    usage == CONSTANTS::ENCRYPTION
+    usage == CERTIFICATE_USAGE::ENCRYPTION
   end
 
   def signing?
-    usage == CONSTANTS::SIGNING
+    usage == CERTIFICATE_USAGE::SIGNING
   end
 
   def x509

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -3,23 +3,23 @@ class Component < Aggregate
 
   has_many :signing_certificates,
            -> {
-             where(usage: CONSTANTS::SIGNING)
+             where(usage: CERTIFICATE_USAGE::SIGNING)
            }, class_name: 'Certificate', as: :component
   has_many :encryption_certificates,
            -> {
-             where(usage: CONSTANTS::ENCRYPTION).order(created_at: 'desc')
+             where(usage: CERTIFICATE_USAGE::ENCRYPTION).order(created_at: 'desc')
            }, class_name: 'Certificate', as: :component
   has_many :enabled_signing_certificates,
            -> {
-             where(usage: CONSTANTS::SIGNING, enabled: true)
+             where(usage: CERTIFICATE_USAGE::SIGNING, enabled: true)
            }, class_name: 'Certificate', as: :component
   has_many :disabled_signing_certificates,
            -> {
-             where(usage: CONSTANTS::SIGNING, enabled: false)
+             where(usage: CERTIFICATE_USAGE::SIGNING, enabled: false)
            }, class_name: 'Certificate', as: :component
 
   belongs_to :encryption_certificate,
-             -> { where(usage: CONSTANTS::ENCRYPTION) }, class_name: 'Certificate', optional: true
+             -> { where(usage: CERTIFICATE_USAGE::ENCRYPTION) }, class_name: 'Certificate', optional: true
 
   def self.to_service_metadata(event_id, published_at = Time.now)
     service_providers = SpComponent.all_components_for_metadata

--- a/app/models/new_msa_component_event.rb
+++ b/app/models/new_msa_component_event.rb
@@ -12,7 +12,7 @@ class NewMsaComponentEvent < AggregatedEvent
   def attributes_to_apply
     {
       name: name,
-      component_type: CONSTANTS::MSA,
+      component_type: COMPONENT_TYPE::MSA,
       entity_id: entity_id,
       created_at: created_at
     }

--- a/app/models/new_sp_component_event.rb
+++ b/app/models/new_sp_component_event.rb
@@ -5,7 +5,7 @@ class NewSpComponentEvent < AggregatedEvent
   validate :name_is_present
   validate :component_is_new, on: :create
   validates_inclusion_of :component_type,
-                         in: [CONSTANTS::SP, CONSTANTS::VSP],
+                         in: [COMPONENT_TYPE::SP, COMPONENT_TYPE::VSP],
                          message: "must be either VSP or SP"
 
 
@@ -16,8 +16,8 @@ class NewSpComponentEvent < AggregatedEvent
   def attributes_to_apply
     {
       name: name,
-      component_type: CONSTANTS::SP,
-      vsp: component_type == CONSTANTS::VSP,
+      component_type: COMPONENT_TYPE::SP,
+      vsp: component_type == COMPONENT_TYPE::VSP,
       created_at: created_at
     }
   end

--- a/app/models/sp_component.rb
+++ b/app/models/sp_component.rb
@@ -3,7 +3,7 @@ class SpComponent < Component
   has_many :services
 
   def view_component_type(vsp)
-    vsp ? CONSTANTS::VSP_SHORT : CONSTANTS::SP_SHORT
+    vsp ? COMPONENT_TYPE::VSP_SHORT : COMPONENT_TYPE::SP_SHORT
   end
 
 private

--- a/app/models/upload_certificate_event.rb
+++ b/app/models/upload_certificate_event.rb
@@ -14,7 +14,7 @@ class UploadCertificateEvent < AggregatedEvent
 
   component_is_persisted :component
 
-  validates_inclusion_of :usage, in: [CONSTANTS::SIGNING, CONSTANTS::ENCRYPTION]
+  validates_inclusion_of :usage, in: [CERTIFICATE_USAGE::SIGNING, CERTIFICATE_USAGE::ENCRYPTION]
 
   def build_certificate
     Certificate.new

--- a/app/views/certificates/new.html.erb
+++ b/app/views/certificates/new.html.erb
@@ -4,7 +4,7 @@
   </legend>
 
   <%= error_messages_for(@upload&.errors) %>
-  <% if @upload.data['component_type'] == CONSTANTS::MSA %>
+  <% if @upload.data['component_type'] == COMPONENT_TYPE::MSA %>
     <%= render 'certificates/new/msa_cert' %>
   <% else %>
     <%= render 'certificates/new/sp_cert' %>

--- a/app/views/certificates/new/_msa_cert.html.erb
+++ b/app/views/certificates/new/_msa_cert.html.erb
@@ -5,12 +5,12 @@
     <%=error_message_on(f.object.errors, :usage) %>
     <div class="govuk-radios govuk-radios--inline">
       <div class="govuk-radios__item ">
-        <%= f.radio_button :usage, CONSTANTS::SIGNING, class: 'govuk-radios__input'  %>
-        <%= f.label :usage, CONSTANTS::SIGNING, class: 'govuk-label govuk-radios__label' %>
+        <%= f.radio_button :usage, CERTIFICATE_USAGE::SIGNING, class: 'govuk-radios__input'  %>
+        <%= f.label :usage, CERTIFICATE_USAGE::SIGNING, class: 'govuk-label govuk-radios__label' %>
       </div>
       <div class="govuk-radios__item">
-        <%= f.radio_button :usage, CONSTANTS::ENCRYPTION, class: 'govuk-radios__input'  %>
-        <%= f.label :usage, CONSTANTS::ENCRYPTION, class: 'govuk-label govuk-radios__label' %>
+        <%= f.radio_button :usage, CERTIFICATE_USAGE::ENCRYPTION, class: 'govuk-radios__input'  %>
+        <%= f.label :usage, CERTIFICATE_USAGE::ENCRYPTION, class: 'govuk-label govuk-radios__label' %>
       </div>
     </div>
   </div>

--- a/app/views/certificates/new/_sp_cert.html.erb
+++ b/app/views/certificates/new/_sp_cert.html.erb
@@ -5,12 +5,12 @@
     <%=error_message_on(f.object.errors, :usage) %>
     <div class="govuk-radios govuk-radios--inline">
       <div class="govuk-radios__item ">
-        <%= f.radio_button :usage, CONSTANTS::SIGNING, class: 'govuk-radios__input'  %>
-        <%= f.label :usage, CONSTANTS::SIGNING, class: 'govuk-label govuk-radios__label' %>
+        <%= f.radio_button :usage, CERTIFICATE_USAGE::SIGNING, class: 'govuk-radios__input'  %>
+        <%= f.label :usage, CERTIFICATE_USAGE::SIGNING, class: 'govuk-label govuk-radios__label' %>
       </div>
       <div class="govuk-radios__item">
-        <%= f.radio_button :usage, CONSTANTS::ENCRYPTION, class: 'govuk-radios__input'  %>
-        <%= f.label :usage, CONSTANTS::ENCRYPTION, class: 'govuk-label govuk-radios__label' %>
+        <%= f.radio_button :usage, CERTIFICATE_USAGE::ENCRYPTION, class: 'govuk-radios__input'  %>
+        <%= f.label :usage, CERTIFICATE_USAGE::ENCRYPTION, class: 'govuk-label govuk-radios__label' %>
       </div>
     </div>
   </div>

--- a/app/views/sp_components/new.html.erb
+++ b/app/views/sp_components/new.html.erb
@@ -16,12 +16,12 @@
       <%=error_message_on(f.object.errors, :component_type) %>
       <div class="govuk-radios govuk-radios--inline">
         <div class="govuk-radios__item ">
-          <%= f.radio_button :component_type, CONSTANTS::VSP, class: 'govuk-radios__input'  %>
-          <%= f.label :component_type, CONSTANTS::VSP_SHORT, class: 'govuk-label govuk-radios__label' %>
+          <%= f.radio_button :component_type, COMPONENT_TYPE::VSP, class: 'govuk-radios__input'  %>
+          <%= f.label :component_type, COMPONENT_TYPE::VSP_SHORT, class: 'govuk-label govuk-radios__label' %>
         </div>
         <div class="govuk-radios__item">
-          <%= f.radio_button :component_type, CONSTANTS::SP, class: 'govuk-radios__input'  %>
-          <%= f.label :component_type, CONSTANTS::SP_SHORT, class: 'govuk-label govuk-radios__label' %>
+          <%= f.radio_button :component_type, COMPONENT_TYPE::SP, class: 'govuk-radios__input'  %>
+          <%= f.label :component_type, COMPONENT_TYPE::SP_SHORT, class: 'govuk-label govuk-radios__label' %>
         </div>
       </div>
     </div>

--- a/config/initializers/constants/certificate_usage.rb
+++ b/config/initializers/constants/certificate_usage.rb
@@ -1,0 +1,4 @@
+module CERTIFICATE_USAGE
+  SIGNING = 'signing'.freeze
+  ENCRYPTION = 'encryption'.freeze
+end

--- a/config/initializers/constants/component_type.rb
+++ b/config/initializers/constants/component_type.rb
@@ -1,9 +1,7 @@
-module CONSTANTS
-  SIGNING = 'signing'.freeze
-  ENCRYPTION = 'encryption'.freeze
+module COMPONENT_TYPE
   SP = 'SpComponent'.freeze
   SP_SHORT = 'SP'.freeze
-  MSA = 'MsaComponent'.freeze
   VSP = 'VspComponent'.freeze
   VSP_SHORT = 'VSP'.freeze
+  MSA = 'MsaComponent'.freeze
 end

--- a/spec/factories/components.rb
+++ b/spec/factories/components.rb
@@ -1,10 +1,10 @@
 FactoryBot.define do
   factory :sp_component do
-    component_type { CONSTANTS::SP }
+    component_type { COMPONENT_TYPE::SP }
   end
 
   factory :msa_component do
-    component_type { CONSTANTS::MSA }
+    component_type { COMPONENT_TYPE::MSA }
     entity_id { 'https://test-entity-id'}
   end
 end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :new_sp_component_event do
     name { SecureRandom.alphanumeric }
-    component_type { CONSTANTS::SP }
+    component_type { COMPONENT_TYPE::SP }
   end
 
   factory :new_msa_component_event do

--- a/spec/models/certificate_spec.rb
+++ b/spec/models/certificate_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe Certificate, type: :model do
   let(:component) { NewMsaComponentEvent.create(component_params).msa_component }
 
   it 'is valid with valid attributes' do
-    expect(Certificate.new(usage: CONSTANTS::SIGNING, value: good_cert_value, component: component)).to be_valid
-    expect(Certificate.new(usage: CONSTANTS::ENCRYPTION, value: good_cert_value, component: component)).to be_valid
+    expect(Certificate.new(usage: CERTIFICATE_USAGE::SIGNING, value: good_cert_value, component: component)).to be_valid
+    expect(Certificate.new(usage: CERTIFICATE_USAGE::ENCRYPTION, value: good_cert_value, component: component)).to be_valid
   end
 
   it 'is not valid with non-valid attributes' do
@@ -23,19 +23,19 @@ RSpec.describe Certificate, type: :model do
 
   it 'is not valid without a usage and/or value' do
     expect(Certificate.new(usage: nil, value: good_cert_value, component: component)).to_not be_valid
-    expect(Certificate.new(usage: CONSTANTS::SIGNING, value: nil, component: component)).to_not be_valid
+    expect(Certificate.new(usage: CERTIFICATE_USAGE::SIGNING, value: nil, component: component)).to_not be_valid
     expect(Certificate.new(usage: nil, value: nil, component: component)).to_not be_valid
   end
 
   it 'has events' do
-    event = UploadCertificateEvent.create!(usage: CONSTANTS::SIGNING, value: good_cert_value, component: component)
+    event = UploadCertificateEvent.create!(usage: CERTIFICATE_USAGE::SIGNING, value: good_cert_value, component: component)
     certificate = event.certificate
     expect([certificate.events.last]).to eql [event]
   end
 
   it 'holds valid metadata' do
     cert = Base64.encode64(good_cert_value)
-    certificate = Certificate.new(usage: CONSTANTS::SIGNING, value: cert, component: component)
+    certificate = Certificate.new(usage: CERTIFICATE_USAGE::SIGNING, value: cert, component: component)
     subject = certificate.x509.subject.to_s
     expect(certificate).not_to be_nil
     expect(certificate.to_metadata).to include(name: subject, value: cert)

--- a/spec/models/component_spec.rb
+++ b/spec/models/component_spec.rb
@@ -13,35 +13,35 @@ RSpec.describe Component, type: :model do
     let(:root) { PKI.new }
     let!(:upload_signing_certificate_event_1) do
       UploadCertificateEvent.create(
-        usage: CONSTANTS::SIGNING,
+        usage: CERTIFICATE_USAGE::SIGNING,
         value: root.generate_encoded_cert(expires_in: 2.months),
         component: msa_component,
       )
     end
     let!(:upload_signing_certificate_event_2) do
       UploadCertificateEvent.create(
-        usage: CONSTANTS::SIGNING,
+        usage: CERTIFICATE_USAGE::SIGNING,
         value: root.generate_encoded_cert(expires_in: 2.months),
         component: msa_component,
       )
     end
     let!(:upload_signing_certificate_event_3) do
       UploadCertificateEvent.create(
-        usage: CONSTANTS::SIGNING,
+        usage: CERTIFICATE_USAGE::SIGNING,
         value: root.generate_encoded_cert(expires_in: 2.months),
         component: sp_component,
       )
     end
     let!(:upload_signing_certificate_event_4) do
       UploadCertificateEvent.create(
-        usage: CONSTANTS::SIGNING,
+        usage: CERTIFICATE_USAGE::SIGNING,
         value: root.generate_encoded_cert(expires_in: 2.months),
         component: sp_component,
       )
     end
     let!(:upload_encryption_event_1) do
       event = UploadCertificateEvent.create(
-        usage: CONSTANTS::ENCRYPTION,
+        usage: CERTIFICATE_USAGE::ENCRYPTION,
         value: root.generate_encoded_cert(expires_in: 2.months),
         component: msa_component,
       )
@@ -53,7 +53,7 @@ RSpec.describe Component, type: :model do
     end
     let!(:upload_encryption_event_2) do
       event = UploadCertificateEvent.create(
-        usage: CONSTANTS::ENCRYPTION,
+        usage: CERTIFICATE_USAGE::ENCRYPTION,
         value: root.generate_encoded_cert(expires_in: 2.months),
         component: sp_component,
       )

--- a/spec/models/disable_signing_certificate_event_spec.rb
+++ b/spec/models/disable_signing_certificate_event_spec.rb
@@ -5,24 +5,24 @@ RSpec.describe DisableSigningCertificateEvent, type: :model do
   root = PKI.new
   good_cert_value = root.generate_encoded_cert(expires_in: 2.months)
   expired_cert_value = root.generate_encoded_cert(expires_in: -2.months)
-  component_params = { component_type: CONSTANTS::SP, name: 'Test Service Provider' }
+  component_params = { component_type: COMPONENT_TYPE::SP, name: 'Test Service Provider' }
   component = NewSpComponentEvent.create(component_params).sp_component
 
   let(:signing_certificate) do
     UploadCertificateEvent.create(
-      usage: CONSTANTS::SIGNING, value: good_cert_value, component: component
+      usage: CERTIFICATE_USAGE::SIGNING, value: good_cert_value, component: component
     ).certificate
   end
 
   let(:expired_signing_certificate) do
     UploadCertificateEvent.create(
-      usage: CONSTANTS::SIGNING, value: expired_cert_value, component: component
+      usage: CERTIFICATE_USAGE::SIGNING, value: expired_cert_value, component: component
     ).certificate
   end
 
   let(:encryption_certificate) do
     UploadCertificateEvent.create(
-      usage: CONSTANTS::ENCRYPTION, value: good_cert_value, component: component
+      usage: CERTIFICATE_USAGE::ENCRYPTION, value: good_cert_value, component: component
     ).certificate
   end
 
@@ -55,7 +55,7 @@ RSpec.describe DisableSigningCertificateEvent, type: :model do
       certificate: encryption_certificate
     )
     cert = event.certificate
-    expect(cert.usage).to eq(CONSTANTS::ENCRYPTION)
+    expect(cert.usage).to eq(CERTIFICATE_USAGE::ENCRYPTION)
     expect(event).not_to be_persisted
   end
 

--- a/spec/models/enable_signing_certificate_event_spec.rb
+++ b/spec/models/enable_signing_certificate_event_spec.rb
@@ -6,24 +6,24 @@ RSpec.describe EnableSigningCertificateEvent, type: :model do
   root = PKI.new
   good_cert_value = root.generate_encoded_cert(expires_in: 2.months)
   expired_cert_value = root.generate_encoded_cert(expires_in: -2.months)
-  component_params = { component_type: CONSTANTS::SP, name: 'Test Service Provider' }
+  component_params = { component_type: COMPONENT_TYPE::SP, name: 'Test Service Provider' }
   component = NewSpComponentEvent.create(component_params).sp_component
 
   let(:signing_certificate) do
     UploadCertificateEvent.create(
-      usage: CONSTANTS::SIGNING, value: good_cert_value, component: component
+      usage: CERTIFICATE_USAGE::SIGNING, value: good_cert_value, component: component
     ).certificate
   end
 
   let(:expired_signing_certificate) do
     UploadCertificateEvent.create(
-      usage: CONSTANTS::SIGNING, value: expired_cert_value, component: component
+      usage: CERTIFICATE_USAGE::SIGNING, value: expired_cert_value, component: component
     ).certificate
   end
 
   let(:encryption_certificate) do
     UploadCertificateEvent.create(
-      usage: CONSTANTS::ENCRYPTION, value: good_cert_value, component: component
+      usage: CERTIFICATE_USAGE::ENCRYPTION, value: good_cert_value, component: component
     ).certificate
   end
 
@@ -67,7 +67,7 @@ RSpec.describe EnableSigningCertificateEvent, type: :model do
       certificate: encryption_certificate
     )
     cert = event.certificate
-    expect(cert.usage).to eq(CONSTANTS::ENCRYPTION)
+    expect(cert.usage).to eq(CERTIFICATE_USAGE::ENCRYPTION)
     expect(event).not_to be_persisted
   end
 

--- a/spec/models/new_sp_component_event_spec.rb
+++ b/spec/models/new_sp_component_event_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 RSpec.describe NewSpComponentEvent, type: :model do
 
   include_examples 'has data attributes', NewSpComponentEvent, %i[name component_type]
-  include_examples 'is aggregated', NewSpComponentEvent, name: 'New SP component', component_type: CONSTANTS::SP
-  include_examples 'is a creation event', NewSpComponentEvent, name: 'New component', component_type: CONSTANTS::SP
+  include_examples 'is aggregated', NewSpComponentEvent, name: 'New SP component', component_type: COMPONENT_TYPE::SP
+  include_examples 'is a creation event', NewSpComponentEvent, name: 'New component', component_type: COMPONENT_TYPE::SP
 
   context 'name' do
     it 'must be provided' do

--- a/spec/models/replace_encryption_certificate_event_spec.rb
+++ b/spec/models/replace_encryption_certificate_event_spec.rb
@@ -15,12 +15,12 @@ RSpec.describe ReplaceEncryptionCertificateEvent, type: :model do
   let(:root) { PKI.new }
   let(:x509_cert) { root.generate_encoded_cert(expires_in: 9.months) }
   let(:upload_encryption_cert) do
-    UploadCertificateEvent.create( usage: CONSTANTS::ENCRYPTION, value: x509_cert, component: component).certificate
+    UploadCertificateEvent.create( usage: CERTIFICATE_USAGE::ENCRYPTION, value: x509_cert, component: component).certificate
   end
 
   def certificate_created_with(params = {})
     defaults = {
-      usage: CONSTANTS::ENCRYPTION,
+      usage: CERTIFICATE_USAGE::ENCRYPTION,
       value: x509_cert,
       component: component
     }
@@ -53,7 +53,7 @@ RSpec.describe ReplaceEncryptionCertificateEvent, type: :model do
 
   it 'replace current encryption certificate with another' do
     new_encryption_certificate = UploadCertificateEvent.create(
-      usage: CONSTANTS::ENCRYPTION,
+      usage: CERTIFICATE_USAGE::ENCRYPTION,
       value: x509_cert,
       component: component,
     ).certificate

--- a/spec/models/upload_certificate_event_spec.rb
+++ b/spec/models/upload_certificate_event_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe UploadCertificateEvent, type: :model do
   component_params = { name: 'fake_name', entity_id: entity_id }
   component = NewMsaComponentEvent.create(component_params).msa_component
   include_examples 'has data attributes', UploadCertificateEvent, %i[usage value component_id component_type]
-  include_examples 'is aggregated', UploadCertificateEvent, usage: CONSTANTS::SIGNING, value: good_cert_value, component_id: component.id, component_type: component.component_type
-  include_examples 'is a creation event', UploadCertificateEvent, usage: CONSTANTS::SIGNING, value: good_cert_value, component_id: component.id, component_type: component.component_type
+  include_examples 'is aggregated', UploadCertificateEvent, usage: CERTIFICATE_USAGE::SIGNING, value: good_cert_value, component_id: component.id, component_type: component.component_type
+  include_examples 'is a creation event', UploadCertificateEvent, usage: CERTIFICATE_USAGE::SIGNING, value: good_cert_value, component_id: component.id, component_type: component.component_type
 
   context '#value' do
     it 'must be present' do
@@ -24,7 +24,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
     let(:root) { PKI.new }
 
     it 'must error with invalid x509 certificate' do
-      event = UploadCertificateEvent.create(usage: CONSTANTS::SIGNING, value: 'Not a valid certificate', component: component)
+      event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: 'Not a valid certificate', component: component)
       expect(event).to_not be_valid
       expect(event.errors[:certificate]).to eql ['is not a valid x509 certificate']
     end
@@ -32,7 +32,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
     it 'must allow base64 encoded DER format x509 certificate' do
       cert = root.generate_encoded_cert(expires_in: 2.months)
 
-      event = UploadCertificateEvent.create(usage: CONSTANTS::SIGNING, value: cert, component: component)
+      event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert, component: component)
       expect(event.certificate.value).to eql(cert)
       expect(event).to be_valid
       expect(event.errors[:certificate]).to be_empty
@@ -41,7 +41,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
     it 'must allow PEM format x509 certificate and be stored as base64 encoded DER' do
       cert = root.generate_signed_cert(expires_in: 2.months)
 
-      event = UploadCertificateEvent.create(usage: CONSTANTS::SIGNING, value: cert.to_pem, component: component)
+      event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert.to_pem, component: component)
       expect(event.certificate.value).to eql(Base64.strict_encode64(cert.to_der))
       expect(event).to be_valid
       expect(event.errors[:certificate]).to be_empty
@@ -50,7 +50,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
     it 'must not be expired' do
       cert = root.generate_encoded_cert(expires_in: -1.months)
 
-      event = UploadCertificateEvent.create(usage: CONSTANTS::SIGNING, value: cert, component: component)
+      event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert, component: component)
       expect(event).to_not be_valid
       expect(event.errors[:certificate]).to eql ['has expired']
     end
@@ -58,7 +58,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
     it 'must not expire within 1 month' do
       cert = root.generate_encoded_cert(expires_in: 15.days)
 
-      event = UploadCertificateEvent.create(usage: CONSTANTS::SIGNING, value: cert, component: component)
+      event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert, component: component)
       expect(event).to_not be_valid
       expect(event.errors[:certificate]).to eql ['expires too soon']
     end
@@ -66,7 +66,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
     it 'must expire within 1 year' do
       cert = root.generate_encoded_cert(expires_in: 2.years)
 
-      event = UploadCertificateEvent.create(usage: CONSTANTS::SIGNING, value: cert, component: component)
+      event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert, component: component)
       expect(event).to_not be_valid
       expect(event.errors[:certificate]).to eql ['valid for too long']
     end
@@ -74,7 +74,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
     it 'must be RSA' do
       cert = root.generate_signed_ec_cert(6.months)
 
-      event = UploadCertificateEvent.create(usage: CONSTANTS::SIGNING, value: cert.to_pem, component: component)
+      event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert.to_pem, component: component)
       expect(event).to_not be_valid
       expect(event.errors[:certificate]).to eql ['in not RSA']
     end
@@ -82,7 +82,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
     it 'must be at least 2048 bits' do
       cert = root.generate_signed_rsa_cert_and_key(size: 1024)[0]
 
-      event = UploadCertificateEvent.create(usage: CONSTANTS::SIGNING, value: cert.to_pem, component: component)
+      event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert.to_pem, component: component)
       expect(event).to_not be_valid
       expect(event.errors[:certificate]).to eql ['key size is less than 2048']
     end
@@ -102,13 +102,13 @@ RSpec.describe UploadCertificateEvent, type: :model do
     end
 
     it 'happy when signing' do
-      event = UploadCertificateEvent.create(usage: CONSTANTS::SIGNING, component: component)
+      event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, component: component)
       expect(event).to_not be_valid
       expect(event.errors[:usage]).to be_empty
     end
 
     it 'happy when encryption' do
-      event = UploadCertificateEvent.create(usage: CONSTANTS::ENCRYPTION, component: component)
+      event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::ENCRYPTION, component: component)
       expect(event).to_not be_valid
       expect(event.errors[:usage]).to be_empty
     end
@@ -129,7 +129,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
   context '#component=' do
     it 'will set component_id and component_type when called during ::create' do
       event = UploadCertificateEvent.create(
-        usage: CONSTANTS::SIGNING,
+        usage: CERTIFICATE_USAGE::SIGNING,
         component_id: component.id,
         component_type: component.component_type
       )
@@ -164,7 +164,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
 
   context '#trigger_publish_event' do
     it 'is triggered on creation' do
-      event = UploadCertificateEvent.create!(usage: CONSTANTS::SIGNING, value: good_cert_value, component: component)
+      event = UploadCertificateEvent.create!(usage: CERTIFICATE_USAGE::SIGNING, value: good_cert_value, component: component)
       publish_event = PublishServicesMetadataEvent.last
       expect(event.id).to_not be_nil
       expect(event.id).to eql publish_event.event_id

--- a/spec/support/component_support.rb
+++ b/spec/support/component_support.rb
@@ -1,6 +1,6 @@
 module ComponentSupport
   def component_by_type(component_type)
-    if component_type == CONSTANTS::SP
+    if component_type == COMPONENT_TYPE::SP
       create(:new_sp_component_event).sp_component
     else
       create(:new_msa_component_event).msa_component
@@ -8,7 +8,7 @@ module ComponentSupport
   end
 
   def alternative_component(component_type)
-    if component_type == CONSTANTS::MSA
+    if component_type == COMPONENT_TYPE::MSA
       create(:new_sp_component_event).sp_component
     else
       create(:new_msa_component_event).msa_component

--- a/spec/system/shared_examples/show_component_page.rb
+++ b/spec/system/shared_examples/show_component_page.rb
@@ -10,19 +10,19 @@ RSpec.shared_examples "show component page" do |component_type|
   let(:root) { PKI.new }
   let(:upload_certs) do
     UploadCertificateEvent.create(
-      usage: CONSTANTS::SIGNING,
+      usage: CERTIFICATE_USAGE::SIGNING,
       value: root.generate_encoded_cert(expires_in: 2.months),
       component: component
     ).certificate
     UploadCertificateEvent.create(
-      usage: CONSTANTS::SIGNING,
+      usage: CERTIFICATE_USAGE::SIGNING,
       value: root.generate_encoded_cert(expires_in: 2.months),
       component: component
     ).certificate
   end
   let(:upload_encryption_cert) do
     encryption_cert = UploadCertificateEvent.create(
-      usage: CONSTANTS::ENCRYPTION,
+      usage: CERTIFICATE_USAGE::ENCRYPTION,
       value: root.generate_encoded_cert(expires_in: 2.months),
       component: component
     ).certificate
@@ -101,7 +101,7 @@ RSpec.shared_examples "show component page" do |component_type|
     it 'can replace encryption certificate with a different one' do
       upload_encryption_cert
       new_cert = UploadCertificateEvent.create(
-        usage: CONSTANTS::ENCRYPTION,
+        usage: CERTIFICATE_USAGE::ENCRYPTION,
         value: root.generate_encoded_cert(expires_in: 2.months),
         component: component
       ).certificate
@@ -116,7 +116,7 @@ RSpec.shared_examples "show component page" do |component_type|
     it 'will not replace encryption certificate with an invalid certificate' do
       upload_encryption_cert
       invalid_cert = Certificate.create(
-        usage: CONSTANTS::ENCRYPTION, value: "invalid", component: component
+        usage: CERTIFICATE_USAGE::ENCRYPTION, value: "invalid", component: component
       )
       visit polymorphic_url(component)
 

--- a/spec/system/user_visits_events_page_spec.rb
+++ b/spec/system/user_visits_events_page_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe 'the events page', type: :system do
     good_cert_2 = root.generate_encoded_cert(expires_in: 2.months)
     good_cert_3 = root.generate_encoded_cert(expires_in: 2.months)
 
-    UploadCertificateEvent.create(usage: CONSTANTS::SIGNING, value: good_cert_1, component: component)
-    UploadCertificateEvent.create(usage: CONSTANTS::SIGNING, value: good_cert_2, component: component)
-    UploadCertificateEvent.create(usage: CONSTANTS::SIGNING, value: good_cert_3, component: component)
+    UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: good_cert_1, component: component)
+    UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: good_cert_2, component: component)
+    UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: good_cert_3, component: component)
 
     visit events_path
     expect(page).to have_content good_cert_1
@@ -29,7 +29,7 @@ RSpec.describe 'the events page', type: :system do
 
   it 'is paginated' do
     55.times.each do
-      UploadCertificateEvent.create(usage: CONSTANTS::SIGNING, value: root.generate_encoded_cert(expires_in: 2.months), component: component)
+      UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: root.generate_encoded_cert(expires_in: 2.months), component: component)
     end
 
     visit events_path

--- a/spec/system/visit_msa_component_show_spec.rb
+++ b/spec/system/visit_msa_component_show_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe 'New MSA Component Page', type: :system do
-  include_examples 'show component page', CONSTANTS::MSA
+  include_examples 'show component page', COMPONENT_TYPE::MSA
 end

--- a/spec/system/visit_sp_component_show_spec.rb
+++ b/spec/system/visit_sp_component_show_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe 'New SP Component Page', type: :system do
-  include_examples 'show component page', CONSTANTS::SP
+  include_examples 'show component page', COMPONENT_TYPE::SP
 end


### PR DESCRIPTION
Split the CONSTANT module to the named modules to better reflect the meaning
and get rid of the `CONSTANTS` keyword.