### PR TITLE
3e3ArKCb: Create a dockerfile to run self-service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,16 +3,18 @@ FROM ruby:2.6.2
 ADD Gemfile Gemfile
 ADD Gemfile.lock Gemfile.lock
 
+EXPOSE 3000
+
+ENV RAILS_LOG_TO_STDOUT true
+
 RUN bundle install
 
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && apt-get install -y nodejs
 
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
- && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
- && apt-get update -qq \
- && apt-get install -y yarn
+ADD . /verify-self-service/
 
-RUN apt-get install -y firefox-esr
+WORKDIR /verify-self-service
 
-# Puma needs these dockerignored dirs to write to
-RUN mkdir -p log tmp
+CMD bundle exec puma -p 3000
+
+

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -1,0 +1,18 @@
+FROM ruby:2.6.2
+
+ADD Gemfile Gemfile
+ADD Gemfile.lock Gemfile.lock
+
+RUN bundle install
+
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && apt-get install -y nodejs
+
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+ && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+ && apt-get update -qq \
+ && apt-get install -y yarn
+
+RUN apt-get install -y firefox-esr
+
+# Puma needs these dockerignored dirs to write to
+RUN mkdir -p log tmp


### PR DESCRIPTION
This will be used on Fargate.
Also renamed the testing Dockerfile to `test.Dockerfile` which is still used for
acceptance tests.