### PR TITLE
BAU: Fix db migrations

### DIFF
--- a/db/migrate/20190711143928_devise_create_users.rb
+++ b/db/migrate/20190711143928_devise_create_users.rb
@@ -9,7 +9,7 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.2]
 
       ## Recoverable
       # t.string   :reset_password_token
-      t.datetime :reset_password_sent_at
+      # t.datetime :reset_password_sent_at
 
       # Please note - we are keeping these fields in for reference.
       # When we come to implement these features we will need to create a new migration that includes these fields, rather than uncommenting these.
@@ -37,7 +37,7 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.2]
     end
 
     add_index :users, :email,                unique: true
-    add_index :users, :reset_password_token, unique: true
+    # add_index :users, :reset_password_token, unique: true
     # add_index :users, :confirmation_token,   unique: true
     # add_index :users, :unlock_token,         unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -85,13 +85,9 @@ ActiveRecord::Schema.define(version: 2019_07_11_143928) do
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
 end


### PR DESCRIPTION
- Tiny PR to fix the migrations on the pipeline as `add_index :users, :reset_password_token` fails due to `reset_password_token` being commented out.