### PR TITLE
Precompile assets in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,13 @@ RUN bundle install
 
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && apt-get install -y nodejs
 
+RUN npm install yarn -g
+
 ADD . /verify-self-service/
 
 WORKDIR /verify-self-service
+
+RUN bundle exec rake assets:precompile
 
 CMD bundle exec puma -p 8080
 


### PR DESCRIPTION
The app is failing to load the sign in page because the assets are not being compiled when the Docker image is built.

Co-authored-by: Jakub Miarka <jakub.miarka@digital.cabinet-office.gov.uk>