### PR TITLE
BAU: Fix assets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ADD . /verify-self-service/
 
 WORKDIR /verify-self-service
 
-RUN bundle exec rake assets:precompile
+RUN bundle exec rake assets:precompile assets:undigest_assets
 
 CMD bundle exec puma -p 8080
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,7 +27,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  # config.assets.compile = false
 
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 

--- a/lib/tasks/undigest_assets.rake
+++ b/lib/tasks/undigest_assets.rake
@@ -1,0 +1,15 @@
+namespace :assets do 
+    task 'undigest_assets' do
+      assets = Dir.glob(File.join(Rails.root, 'public/assets/**/*'))
+      regex = /(-{1}[a-z0-9]{32}*\.{1}){1}/
+      assets.each do |file|
+        next if File.directory?(file) || file !~ regex
+  
+        source = file.split('/')
+        source.push(source.pop.gsub(regex, '.'))
+  
+        non_digested = File.join(source)
+        File.rename(file, non_digested)
+      end
+    end
+  end


### PR DESCRIPTION
We need to make sure the assets hosted in S3 have the same name, therefore when compiling, we need to make sure they don't have the digest appended to their filename.