### PR TITLE
Improve the auth flow and force new users to change password

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,7 @@ class ApplicationController < ActionController::Base
 protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_in, keys: %i[totp_code])
+    devise_parameter_sanitizer.permit(:sign_in, keys: %i[totp_code new_password])
   end
 
   # Sets the current user into a named Thread location so that it can be accessed by models and observers

--- a/app/models/remote_authenticatable.rb
+++ b/app/models/remote_authenticatable.rb
@@ -84,7 +84,7 @@ module Devise
         self.phone_number = user_attributes['phone_number']
         self.access_token = access_token
         self.roles = user_attributes['custom:roles']
-        self.permissions = UserRolePermissions.new(user_attributes['custom:roles'], params[:email])
+        self.permissions = UserRolePermissions.new(user_attributes['custom:roles'], user_attributes['email'])
         self.full_name = "#{user_attributes['given_name']} #{user_attributes['family_name']}"
         self.given_name = user_attributes['given_name']
         self.family_name = user_attributes['family_name']

--- a/app/models/remote_authenticatable.rb
+++ b/app/models/remote_authenticatable.rb
@@ -17,17 +17,17 @@ module Devise
         else
           resp = initiate_auth(params[:email], params[:password])
         end
-        return process_response(resp, params) if resp.present?
+        return process_response(resp) if resp.present?
 
         raise StandardError("No Response Back from AWS to process")
       end
 
-      def process_response(resp, params)
+      def process_response(resp)
         if resp.challenge_name.present?
-          create_challenge_flow(resp, params)
+          create_challenge_flow(resp)
         else
-            # Get User Information
-          auth_complete(resp, params)
+          # Get User Information
+          auth_complete(resp)
         end
         self
       end
@@ -67,19 +67,18 @@ module Devise
         )
       end
 
-      def create_challenge_flow(resp, params)
+      def create_challenge_flow(resp)
         self.challenge_name = resp[:challenge_name]
         self.cognito_session_id = resp[:session]
         self.challenge_parameters = resp[:challenge_parameters]
-        self.email = params[:email]
         self
       end
 
-      def auth_complete(resp, params)
+      def auth_complete(resp)
         access_token = resp[:authentication_result][:access_token]
         aws_user = get_user_info(access_token)
         user_attributes = get_user_attributes(aws_user)
-        self.login_id = params[:email]
+        self.login_id = user_attributes['email']
         self.user_id = aws_user.username
         self.email = user_attributes['email']
         self.phone_number = user_attributes['phone_number']

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User
   # create getter and setter methods internally for the fields below
   attr_accessor :email, :access_token, :challenge_name, :cognito_session_id,
                 :challenge_parameters, :roles, :full_name, :family_name, :given_name,
-                :phone_number, :user_id, :login_id, :password, :totp_code, :permissions
+                :phone_number, :user_id, :login_id, :password, :new_password, :totp_code, :permissions
 
   #required by Devise
   define_model_callbacks :validation

--- a/app/views/devise/sessions/_mfa_form.erb
+++ b/app/views/devise/sessions/_mfa_form.erb
@@ -6,5 +6,5 @@
 <div class="govuk-form-group">
   <%= f.label :totp_code, class: "govuk-label" %>
   <%= f.text_field :totp_code, autofocus: true, class: "govuk-input" %>
-  <%= f.hidden_field :email, value: session[:username] %>
+  <%= f.hidden_field :email, value: { email: false } %>
 </div>

--- a/app/views/devise/sessions/_mfa_form.erb
+++ b/app/views/devise/sessions/_mfa_form.erb
@@ -1,7 +1,6 @@
-<h2 class="govuk-heading-l">Log in - One Time Password Request</h2>
+<h2 class="govuk-heading-l"><%= t('login.mfa_heading') %></h2>
 
-<p class="govuk-body-l">Please enter your one time code from
-<%= session[:challenge_parameters]["FRIENDLY_DEVICE_NAME"] %>.</p>
+<p class="govuk-body-l"><%= t('login.mfa_heading', device_name: session[:challenge_parameters]["FRIENDLY_DEVICE_NAME"]) %></p>
 
 <div class="govuk-form-group">
   <%= f.label :totp_code, class: "govuk-label" %>

--- a/app/views/devise/sessions/_new_password_required_form.erb
+++ b/app/views/devise/sessions/_new_password_required_form.erb
@@ -1,0 +1,9 @@
+<h2 class="govuk-heading-l">Set up your new password</h2>
+
+<p class="govuk-body-l">This is first time you're logging in, please set your password.</p>
+
+<div class="govuk-form-group">
+  <%= f.label :new_password, class: "govuk-label" %>
+  <%= f.password_field :new_password, autofocus: true, class: "govuk-input" %>
+  <%= f.hidden_field :email, value: session[:username] %>
+</div>

--- a/app/views/devise/sessions/_new_password_required_form.erb
+++ b/app/views/devise/sessions/_new_password_required_form.erb
@@ -1,6 +1,6 @@
-<h2 class="govuk-heading-l">Set up your new password</h2>
+<h2 class="govuk-heading-l"><%= t('login.new_password_heading') %></h2>
 
-<p class="govuk-body-l">This is first time you're logging in, please set your password.</p>
+<p class="govuk-body-l"><%= t('login.new_password_description') %></p>
 
 <div class="govuk-form-group">
   <%= f.label :new_password, class: "govuk-label" %>

--- a/app/views/devise/sessions/_new_password_required_form.erb
+++ b/app/views/devise/sessions/_new_password_required_form.erb
@@ -5,5 +5,5 @@
 <div class="govuk-form-group">
   <%= f.label :new_password, class: "govuk-label" %>
   <%= f.password_field :new_password, autofocus: true, class: "govuk-input" %>
-  <%= f.hidden_field :email, value: session[:username] %>
+  <%= f.hidden_field :email, value: { email: false } %>
 </div>

--- a/app/views/devise/sessions/_sign_in_form.erb
+++ b/app/views/devise/sessions/_sign_in_form.erb
@@ -1,4 +1,4 @@
-<h2 class="govuk-heading-l">Log in</h2>
+<h2 class="govuk-heading-l"><%= t('login.heading') %></h2>
 
 <div class="govuk-form-group">
   <%= f.label :email, class: "govuk-label" %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,11 +1,12 @@
  <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <% if session[:challenge_name].present? %>
+  <% if session[:challenge_name] == "SOFTWARE_TOKEN_MFA" %>
       <%= render "mfa_form", f:f %>
+  <% elsif session[:challenge_name] == "NEW_PASSWORD_REQUIRED" %>
+      <%= render "new_password_required_form", f:f %>
   <% else %>
       <%= render "sign_in_form", f:f %>
   <% end %>
     <div class="actions">
-      <%= button_tag "Reset", type: :reset, class: "govuk-button--warning govuk-button", data: { module: "govuk-button" } %>
       <%= f.submit "Log in", class: "govuk-button", data: { module: "govuk-button" } %>
     </div>
 <% end %>

--- a/app/views/profile/show.html.erb
+++ b/app/views/profile/show.html.erb
@@ -7,7 +7,6 @@
   <p class="govuk-body"><%= t 'profile.id' %><%= @user.user_id %></p>
   <p class="govuk-body"><%= t 'profile.given_name' %><%= @user.given_name %></p>
   <p class="govuk-body"><%= t 'profile.family_name' %><%= @user.family_name %></p>
-  <p class="govuk-body"><%= t 'profile.organisation' %><%= @user.organisation %></p>
   <p class="govuk-body"><%= t 'profile.roles' %><%= @user.roles %></p>
   <p class="govuk-body"><%= t 'profile.email' %><%= @user.email %></p>
   <p class="govuk-body"><%= t 'profile.phone' %><%= @user.phone_number %></p>

--- a/config/initializers/remote_authenticatable.rb
+++ b/config/initializers/remote_authenticatable.rb
@@ -46,11 +46,9 @@ module Devise
         session[:challenge_name] = resource.challenge_name
         session[:cognito_session_id] = resource.cognito_session_id
         session[:challenge_parameters] = resource.challenge_parameters
-        session[:username] = resource.email
       end
 
       def populate_auth_params(auth_params)
-        auth_params[:email] = session[:username]
         auth_params[:cognito_session_id] = session[:cognito_session_id]
         auth_params[:challenge_name] = session[:challenge_name]
         auth_params[:challenge_parameters] = session[:challenge_parameters]
@@ -63,7 +61,6 @@ module Devise
         session.delete(:challenge_name)
         session.delete(:cognito_session_id)
         session.delete(:challenge_parameters)
-        session.delete(:username)
       end
     end
   end

--- a/config/initializers/remote_authenticatable.rb
+++ b/config/initializers/remote_authenticatable.rb
@@ -13,8 +13,8 @@ module Devise
           begin
             if validate(resource)
               resource = resource.remote_authentication(auth_params)
-              if resource.access_token.nil?
-                populate_session_for_2fa(resource)
+              if resource.challenge_name
+                populate_session_for_auth_challenge(resource)
                 redirect!(Rails.application.routes.url_helpers.new_user_session_path)
               else
                 clean_up_session
@@ -42,7 +42,7 @@ module Devise
 
       private
 
-      def populate_session_for_2fa(resource)
+      def populate_session_for_auth_challenge(resource)
         session[:challenge_name] = resource.challenge_name
         session[:cognito_session_id] = resource.cognito_session_id
         session[:challenge_parameters] = resource.challenge_parameters

--- a/config/initializers/services.rb
+++ b/config/initializers/services.rb
@@ -31,7 +31,6 @@ def stub_client
       { name: 'sub', value: '00000000-0000-0000-0000-000000000000' },
       { name: 'custom:roles', value: 'test' },
       { name: 'email_verified', value: 'true' },
-      { name: 'custom:organisation', value: 'Dummy Org' },
       { name: 'phone_number_verified', value: 'true' },
       { name: 'phone_number', value: '+447000000000' },
       { name: 'given_name', value: 'Test' },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,12 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
+  login:
+    heading: Log in
+    mfa_heading: Log in - One Time Password Request 
+    mfa_description: "Please enter your one time code from %{device_name}."
+    new_password_heading: Set up your new password
+    new_password_description: This is first time you're logging in, please set your password.
   certificates:
     caption: "%{heading}"
     header_id: ID

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,7 +52,6 @@ en:
     id: "User ID: "
     given_name: "Given Name: "
     family_name: "Family Name: "
-    organisation: "Organisation: "
     roles: "Roles: "
     email: "E-mail address: "
     phone: "Phone number: "

--- a/spec/controllers/session_controller_spec.rb
+++ b/spec/controllers/session_controller_spec.rb
@@ -40,4 +40,36 @@ RSpec.describe SessionsController, type: :controller do
     expect(session[:cognito_session_id]).to be_nil
     expect(session[:challenge_parameters]).to be_nil
   end
+
+  it 'Redirect to new password set-up when the user is using a temporary password' do
+    strategy = Devise::Strategies::RemoteAuthenticatable.new(nil)
+    allow(request).to receive(:headers).and_return(user: 'name')
+    cognito_session_id = SecureRandom.uuid
+    username = 'test@test.com'
+    challenge_name = 'NEW_PASSWORD_REQUIRED'
+    SelfService.service(:cognito_client).stub_responses(:initiate_auth, challenge_name: challenge_name, session: cognito_session_id, challenge_parameters: { 'FRIENDLY_DEVICE_NAME' => 'Authy' })
+    @request.env['devise.mapping'] = Devise.mappings[:user]
+    post :create, params: { user: { email: username, password: 'validpass' } }
+    expect(response).to have_http_status(:redirect)
+    expect(session[:cognito_session_id]).to eq(cognito_session_id)
+    expect(session[:challenge_name]).to eq(challenge_name)
+    expect(subject).to redirect_to(new_user_session_path)
+  end
+
+  it 'Return to index if users successfully responds to TOTP request' do
+    strategy = Devise::Strategies::RemoteAuthenticatable.new(nil)
+    SelfService.service(:cognito_client).stub_responses(:respond_to_auth_challenge, authentication_result: { access_token: 'valid-token' })
+    allow(request).to receive(:headers).and_return(user: 'name')
+    allow(strategy).to receive(:params).at_least(:once).and_return(user: 'name')
+    session[:challenge_name] = 'NEW_PASSWORD_REQUIRED'
+    session[:cognito_session_id] = SecureRandom.uuid
+    session[:challenge_parameters] = { 'FRIENDLY_DEVICE_NAME' => 'Authy', 'USER_ID_FOR_SRP' => '0000-0000' }
+    @request.env['devise.mapping'] = Devise.mappings[:user]
+    post :create, params: { user: { email: 'test@test.com', new_password: 'mynewpassword' } }
+    expect(response).to have_http_status(:redirect)
+    expect(subject).to redirect_to(root_path)
+    expect(session[:challenge_name]).to be_nil
+    expect(session[:cognito_session_id]).to be_nil
+    expect(session[:challenge_parameters]).to be_nil
+  end
 end

--- a/spec/controllers/session_controller_spec.rb
+++ b/spec/controllers/session_controller_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe SessionsController, type: :controller do
     post :create, params: { user: { email: username, password: 'validpass' } }
     expect(response).to have_http_status(:redirect)
     expect(session[:cognito_session_id]).to eq(cognito_session_id)
-    expect(session[:username]).to eq(username)
     expect(session[:challenge_name]).to eq(challenge_name)
     expect(subject).to redirect_to(new_user_session_path)
   end
@@ -33,7 +32,6 @@ RSpec.describe SessionsController, type: :controller do
     session[:challenge_name] = 'SOFTWARE_TOKEN_MFA'
     session[:cognito_session_id] = SecureRandom.uuid
     session[:challenge_parameters] = { 'FRIENDLY_DEVICE_NAME' => 'Authy', 'USER_ID_FOR_SRP' => '0000-0000' }
-    session[:username] = 'test@test.com'
     @request.env['devise.mapping'] = Devise.mappings[:user]
     post :create, params: { user: { email: 'test@test.com', totp_code: '999999' } }
     expect(response).to have_http_status(:redirect)
@@ -41,6 +39,5 @@ RSpec.describe SessionsController, type: :controller do
     expect(session[:challenge_name]).to be_nil
     expect(session[:cognito_session_id]).to be_nil
     expect(session[:challenge_parameters]).to be_nil
-    expect(session[:username]).to be_nil
   end
 end

--- a/spec/controllers/session_controller_spec.rb
+++ b/spec/controllers/session_controller_spec.rb
@@ -27,12 +27,12 @@ RSpec.describe SessionsController, type: :controller do
 
   it 'Return to index if users successfully responds to TOTP request' do
     strategy = Devise::Strategies::RemoteAuthenticatable.new(nil)
-    SelfService.service(:cognito_client).stub_responses(:respond_to_auth_challenge, challenge_name: nil, authentication_result: { access_token: 'valid-token' })
+    SelfService.service(:cognito_client).stub_responses(:respond_to_auth_challenge, authentication_result: { access_token: 'valid-token' })
     allow(request).to receive(:headers).and_return(user: 'name')
     allow(strategy).to receive(:params).at_least(:once).and_return(user: 'name')
-    session[:challenge_name] = 'MFA'
+    session[:challenge_name] = 'SOFTWARE_TOKEN_MFA'
     session[:cognito_session_id] = SecureRandom.uuid
-    session[:challenge_parameters] = { 'FRIENDLY_DEVICE_NAME' => 'Authy' }
+    session[:challenge_parameters] = { 'FRIENDLY_DEVICE_NAME' => 'Authy', 'USER_ID_FOR_SRP' => '0000-0000' }
     session[:username] = 'test@test.com'
     @request.env['devise.mapping'] = Devise.mappings[:user]
     post :create, params: { user: { email: 'test@test.com', totp_code: '999999' } }

--- a/spec/controllers/session_controller_spec.rb
+++ b/spec/controllers/session_controller_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe SessionsController, type: :controller do
     expect(subject).to redirect_to(new_user_session_path)
   end
 
-  it 'Return to index if users successfully responds to TOTP request' do
+  it 'Return to index if users successfully set their new password' do
     strategy = Devise::Strategies::RemoteAuthenticatable.new(nil)
     SelfService.service(:cognito_client).stub_responses(:respond_to_auth_challenge, authentication_result: { access_token: 'valid-token' })
     allow(request).to receive(:headers).and_return(user: 'name')

--- a/spec/system/visit_sign_in_spec.rb
+++ b/spec/system/visit_sign_in_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe 'Sign in', type: :system do
     expect(current_path).to eql root_path
     expect(page).to have_content 'Signed in successfully.'
     # Ensure session is cleaned up from flow
-    expect(page.get_rack_session.has_key?(:username)).to eql false
     expect(page.get_rack_session.has_key?(:cognito_session_id)).to eql false
     expect(page.get_rack_session.has_key?(:challenge_name)).to eql false
     expect(page.get_rack_session.has_key?(:challenge_parameters)).to eql false

--- a/spec/system/visit_sign_in_spec.rb
+++ b/spec/system/visit_sign_in_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Sign in', type: :system do
   end
 
   scenario 'user can sign in with valid credentials' do
-    SelfService.service(:cognito_client).stub_responses(:initiate_auth, { challenge_name: nil, authentication_result: {access_token: "valid-token" }})
+    SelfService.service(:cognito_client).stub_responses(:initiate_auth, { authentication_result: {access_token: "valid-token" }})
 
     user = FactoryBot.create(:user)
     sign_in(user.email, user.password)
@@ -21,8 +21,8 @@ RSpec.describe 'Sign in', type: :system do
   end
 
   scenario 'user can sign in with valid 2FA credentials' do
-    SelfService.service(:cognito_client).stub_responses(:initiate_auth, { challenge_name: "SOFTWARE_TOKEN_MFA", session: SecureRandom.uuid, challenge_parameters: { "FRIENDLY_DEVICE_NAME" => 'Authy' }})
-    SelfService.service(:cognito_client).stub_responses(:respond_to_auth_challenge, { challenge_name: nil, authentication_result: {access_token: "valid-token" }})
+    SelfService.service(:cognito_client).stub_responses(:initiate_auth, { challenge_name: "SOFTWARE_TOKEN_MFA", session: SecureRandom.uuid, challenge_parameters: { 'FRIENDLY_DEVICE_NAME' => 'Authy', 'USER_ID_FOR_SRP' => '0000-0000' }})
+    SelfService.service(:cognito_client).stub_responses(:respond_to_auth_challenge, { authentication_result: {access_token: 'valid-token' }})
 
     user = FactoryBot.create(:user)
     sign_in(user.email, user.password)
@@ -41,7 +41,7 @@ RSpec.describe 'Sign in', type: :system do
   end
 
   scenario 'user cant sign in with wrong 2FA credentials' do
-    SelfService.service(:cognito_client).stub_responses(:initiate_auth, { challenge_name: "SOFTWARE_TOKEN_MFA", session: SecureRandom.uuid, challenge_parameters: { "FRIENDLY_DEVICE_NAME" => 'Authy' }})
+    SelfService.service(:cognito_client).stub_responses(:initiate_auth, { challenge_name: "SOFTWARE_TOKEN_MFA", session: SecureRandom.uuid, challenge_parameters: { "FRIENDLY_DEVICE_NAME" => 'Authy', 'USER_ID_FOR_SRP' => '0000-0000' }})
     SelfService.service(:cognito_client).stub_responses(:respond_to_auth_challenge, Aws::CognitoIdentityProvider::Errors::CodeMismatchException.new(nil, "Stub Response"))
 
     user = FactoryBot.create(:user)


### PR DESCRIPTION
_(please review commit by commit)_

- Removed traces of organisation attribute, as we don't use it
- Made the auth_challenge logic more generic
- Added support for NEW_PASSWORD_REQUIRED for new users logging in first time (new logic and view)
- Cleaned a few things up by removing unnecessary logic and complexity around passing user email using hidden forms 
- Stopped using the hidden field to pass back to Cognito but instead using the Cognito-provided value
- Removed the reset button
- Moved the login content to locales