### PR TITLE
HrPL2H6a: Allow users to enrol to MFA

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ gem 'aws-sdk-cognitoidentityprovider'
 
 gem 'devise'
 gem 'pundit'
+gem 'rqrcode'
 gem 'request_store'
 
 gem 'email_validator'

--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ gem 'aws-sdk-cognitoidentityprovider'
 
 gem 'devise'
 gem 'pundit'
+gem 'request_store'
 
 gem 'email_validator'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,6 +208,8 @@ GEM
     rb-inotify (0.10.0)
       ffi (~> 1.0)
     regexp_parser (1.5.1)
+    request_store (1.4.1)
+      rack (>= 1.4)
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -322,6 +324,7 @@ DEPENDENCIES
   rack_session_access
   rails (~> 5.2.2)
   rails-controller-testing
+  request_store
   rspec-rails
   sass-rails (~> 5.0)
   selenium-webdriver

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,7 @@ GEM
       xpath (~> 3.2)
     childprocess (1.0.1)
       rake (< 13.0)
+    chunky_png (1.3.11)
     coderay (1.1.2)
     colorize (0.8.1)
     concurrent-ruby (1.1.5)
@@ -213,6 +214,8 @@ GEM
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    rqrcode (0.10.1)
+      chunky_png (~> 1.0)
     rspec-core (3.8.2)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.4)
@@ -325,6 +328,7 @@ DEPENDENCIES
   rails (~> 5.2.2)
   rails-controller-testing
   request_store
+  rqrcode
   rspec-rails
   sass-rails (~> 5.0)
   selenium-webdriver

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,3 +18,4 @@
 
  @import "components";
  @import "events";
+ @import "mfa_enrolment";

--- a/app/assets/stylesheets/mfa_enrolment.scss
+++ b/app/assets/stylesheets/mfa_enrolment.scss
@@ -1,0 +1,3 @@
+.mfa-qr-code {
+  text-align: center
+}

--- a/app/controllers/mfa_controller.rb
+++ b/app/controllers/mfa_controller.rb
@@ -1,0 +1,55 @@
+require 'rqrcode'
+require 'erb'
+
+class MfaController < ApplicationController
+  include ERB::Util
+  skip_before_action :authenticate_user!
+  skip_before_action :set_user
+
+  before_action :enrolment_only
+
+  def index
+    @form = MfaEnrolmentForm.new({})
+    generate_new_qr
+  end
+
+  def enrol
+    @form = MfaEnrolmentForm.new(params[:mfa_enrolment_form] || {})
+    begin
+      SelfService.service(:cognito_client).verify_software_token(
+        access_token: session[:access_token],
+        user_code: @form.code
+      )
+    rescue Aws::CognitoIdentityProvider::Errors::ServiceError => e
+      Rails.logger.error e
+      flash.now[:error] = t('mfa_enrolment.errors.generic_error')
+      generate_new_qr
+      return render :index, status: :bad_request
+    end
+    SelfService.service(:cognito_client).set_user_mfa_preference(
+      access_token: session[:access_token],
+      software_token_mfa_settings: {
+        enabled: true,
+        preferred_mfa: true
+      }
+    )
+    flash.now[:success] = t('mfa_enrolment.success')
+    redirect_to root_path
+  end
+
+private
+
+  def generate_new_qr
+    associate = SelfService.service(:cognito_client).associate_software_token(access_token: session[:access_token])
+    @secret_code = associate.secret_code
+    issuer = "GOV.UK Verify Admin Tool"
+    issuer += " (#{Rails.env})" unless Rails.env.production?
+    encoded_issuer = url_encode(issuer)
+    qrcode = RQRCode::QRCode.new("otpauth://totp/#{encoded_issuer}:#{url_encode(session[:email])}?secret=#{@secret_code}&issuer=#{encoded_issuer}")
+    @secret_code_svg = qrcode.as_svg(module_size: 3)
+  end
+
+  def enrolment_only
+    redirect_to root_path if user_signed_in? || session[:access_token].nil?
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,3 @@
-require 'securerandom'
-
 class UsersController < ApplicationController
   layout "main_layout"
 
@@ -12,47 +10,55 @@ class UsersController < ApplicationController
   def new
     @form = InviteUserForm.new(params['invite_user_form'] || {})
     if @form.valid?
-      begin
-        temporary_password = SecureRandom.alphanumeric(8) + ('!'..'/').to_a.sample
-        invite = SelfService.service(:cognito_client).admin_create_user(
-          temporary_password: temporary_password,
-          user_attributes: [
-            {
-              name: 'email',
-              value: @form.email
-            },
-            {
-              name: 'given_name',
-              value: @form.given_name
-            },
-            {
-              name: 'family_name',
-              value: @form.family_name
-            },
-            {
-              name: 'custom:roles',
-              value: @form.roles.join(",")
-            }
-          ],
-          username: @form.email,
-          user_pool_id: Rails.application.secrets.cognito_user_pool_id
-        )
-        #TODO: Add team, mfa ... to the event
-        UserInvitedEvent.create(data: { user_id: invite.user.username, roles: @form.roles.join(",") }) if invite.dig(:user, :username)
-
-        #TODO: Enroll user to MFA
-      rescue Aws::CognitoIdentityProvider::Errors::AliasExistsException,
-             Aws::CognitoIdentityProvider::Errors::UsernameExistsException => e
-        flash.now[:errors] = t('users.invite.errors.already_exists')
-      rescue StandardError => e
-        flash.now[:errors] = t('users.invite.errors.generic_error')
-      end
-      Rails.logger.error e if e
-      flash.now[:success] = t('users.invite.success') unless e
-      render :invite
+      invite_user
     else
       flash.now[:errors] = @form.errors.full_messages.join(', ')
       render :invite, status: :bad_request
+    end
+  end
+
+private
+
+  def invite_user
+    temporary_password = ('a'..'z').to_a.sample(3) + ('A'..'Z').to_a.sample(3) + ('0'..'9').to_a.sample(3) + ('!'..'/').to_a.sample(1)
+    begin
+      invite = SelfService.service(:cognito_client).admin_create_user(
+        temporary_password: temporary_password.join(''),
+        user_attributes: [
+          {
+            name: 'email',
+            value: @form.email
+          },
+          {
+            name: 'given_name',
+            value: @form.given_name
+          },
+          {
+            name: 'family_name',
+            value: @form.family_name
+          },
+          {
+            name: 'custom:roles',
+            value: @form.roles.join(",")
+          }
+        ],
+        username: @form.email,
+        user_pool_id: Rails.application.secrets.cognito_user_pool_id
+      )
+    rescue Aws::CognitoIdentityProvider::Errors::AliasExistsException,
+           Aws::CognitoIdentityProvider::Errors::UsernameExistsException => e
+      flash.now[:errors] = t('users.invite.errors.already_exists')
+    rescue StandardError => e
+      flash.now[:errors] = t('users.invite.errors.generic_error')
+    end
+
+    if e
+      Rails.logger.error e
+      render :invite, status: :bad_request
+    else
+      UserInvitedEvent.create(data: { user_id: invite.user.username, roles: @form.roles.join(",") })
+      flash.now[:success] = t('users.invite.success')
+      redirect_to users_path
     end
   end
 end

--- a/app/helpers/user_info.rb
+++ b/app/helpers/user_info.rb
@@ -1,9 +1,9 @@
 module UserInfo
   def current_user
-    Thread.current[:user]
+    RequestStore.store[:user]
   end
 
   def self.current_user=(user)
-    Thread.current[:user] = user
+    RequestStore.store[:user] = user
   end
 end

--- a/app/models/invite_user_form.rb
+++ b/app/models/invite_user_form.rb
@@ -1,10 +1,9 @@
 class InviteUserForm
   include ActiveModel::Model
 
-  attr_reader :email, :given_name, :family_name, :mfa, :roles, :team
+  attr_reader :email, :given_name, :family_name, :roles, :team
 
-  validates_presence_of :email, :given_name, :family_name, :mfa, :roles
-  validates_inclusion_of :mfa, in: %w[SOFTWARE_TOKEN_MFA]
+  validates_presence_of :email, :given_name, :family_name, :roles
 
   validate :email_is_valid, :validate_roles
 
@@ -12,7 +11,6 @@ class InviteUserForm
     @email = hash[:email]
     @given_name = hash[:given_name]
     @family_name = hash[:family_name]
-    @mfa = hash[:mfa]
     @roles = hash[:roles]
   end
 

--- a/app/models/mfa_enrolment_form.rb
+++ b/app/models/mfa_enrolment_form.rb
@@ -1,0 +1,11 @@
+class MfaEnrolmentForm
+  include ActiveModel::Model
+
+  attr_reader :code
+
+  validates_presence_of :code
+
+  def initialize(hash)
+    @code = hash[:code]
+  end
+end

--- a/app/models/remote_authenticatable.rb
+++ b/app/models/remote_authenticatable.rb
@@ -49,9 +49,7 @@ module Devise
         when 'NEW_PASSWORD_REQUIRED'
           challenge_responses = {
             "USERNAME": params[:challenge_parameters]['USER_ID_FOR_SRP'],
-            "NEW_PASSWORD": params[:new_password],
-            "userAttributes.given_name": "Tester", #temporary until we can create users with name
-            "userAttributes.family_name": "Testerator"
+            "NEW_PASSWORD": params[:new_password]
           }
         when 'SOFTWARE_TOKEN_MFA'
           challenge_responses = {
@@ -88,6 +86,7 @@ module Devise
         self.full_name = "#{user_attributes['given_name']} #{user_attributes['family_name']}"
         self.given_name = user_attributes['given_name']
         self.family_name = user_attributes['family_name']
+        self.mfa = aws_user.preferred_mfa_setting
         self
       end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User
   extend Devise::Models
 
   # create getter and setter methods internally for the fields below
-  attr_accessor :email, :access_token, :challenge_name, :cognito_session_id,
+  attr_accessor :email, :access_token, :challenge_name, :cognito_session_id, :mfa,
                 :challenge_parameters, :roles, :full_name, :family_name, :given_name,
                 :phone_number, :user_id, :login_id, :password, :new_password, :totp_code, :permissions
 

--- a/app/views/devise/sessions/_mfa_form.erb
+++ b/app/views/devise/sessions/_mfa_form.erb
@@ -1,6 +1,6 @@
 <h2 class="govuk-heading-l"><%= t('login.mfa_heading') %></h2>
 
-<p class="govuk-body-l"><%= t('login.mfa_heading', device_name: session[:challenge_parameters]["FRIENDLY_DEVICE_NAME"]) %></p>
+<p class="govuk-body-l"><%= t('login.mfa_heading') %></p>
 
 <div class="govuk-form-group">
   <%= f.label :totp_code, class: "govuk-label" %>

--- a/app/views/mfa/index.html.erb
+++ b/app/views/mfa/index.html.erb
@@ -1,0 +1,36 @@
+<h1 class="govuk-heading-xl"><%= t('mfa_enrolment.heading') %></h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-half">
+    <%= form_for @form, url: enrol_to_mfa_path, class: 'govuk-form-group' do |f| %>
+
+      <div class="govuk-form-group">
+        <%= f.label :code, class: "govuk-label" %>
+        <%= f.text_field :code, class: "govuk-input" %>
+      </div>
+      
+      <div class="actions">
+        <%= f.submit 'Confirm', class: "govuk-button", data: { module: "govuk-button" } %>
+      </div>
+
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-half">
+    <div class="mfa-qr-code">
+      <%= raw(@secret_code_svg) %>
+    </div>
+  </div>
+</div>
+<details class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      <%= t('mfa_enrolment.no_qr') %>
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    <%= t('mfa_enrolment.no_qr_instructions') %>
+    <pre><%= @secret_code %></pre>
+  </div>
+</details>
+

--- a/app/views/users/invite.erb
+++ b/app/views/users/invite.erb
@@ -17,17 +17,6 @@
     <%= f.text_field :family_name, class: "govuk-input" %>
   </div>
 
-  <div class="govuk-radios govuk-radios--inline">
-    <div class="govuk-radios__item">
-      <%= f.radio_button :mfa, 'SOFTWARE_TOKEN_MFA', checked: true, class: 'govuk-radios__input'  %>
-      <%= f.label :mfa, 'SOFTWARE_TOKEN_MFA', class: 'govuk-label govuk-radios__label' %>
-    </div>
-    <div class="govuk-radios__item">
-      <%= f.radio_button :mfa, 'SMS', disabled: true, class: 'govuk-radios__input'  %>
-      <%= f.label :mfa, 'SMS', class: 'govuk-label govuk-radios__label' %>
-    </div>
-  </div>
-
   <div class="govuk-form-group">
   <fieldset class="govuk-fieldset">
     <div class="govuk-checkboxes">

--- a/config/initializers/remote_authenticatable.rb
+++ b/config/initializers/remote_authenticatable.rb
@@ -16,6 +16,9 @@ module Devise
               if resource.challenge_name
                 populate_session_for_auth_challenge(resource)
                 redirect!(Rails.application.routes.url_helpers.new_user_session_path)
+              elsif resource.mfa.nil?
+                populate_session_for_mfa_enrolment(resource)
+                redirect!(Rails.application.routes.url_helpers.mfa_enrolment_path)
               else
                 clean_up_session
                 UserSignInEvent.create(user_id: resource.user_id)
@@ -48,6 +51,11 @@ module Devise
         session[:challenge_parameters] = resource.challenge_parameters
       end
 
+      def populate_session_for_mfa_enrolment(resource)
+        session[:access_token] = resource.access_token
+        session[:email] = resource.email
+      end
+
       def populate_auth_params(auth_params)
         auth_params[:cognito_session_id] = session[:cognito_session_id]
         auth_params[:challenge_name] = session[:challenge_name]
@@ -61,6 +69,8 @@ module Devise
         session.delete(:challenge_name)
         session.delete(:cognito_session_id)
         session.delete(:challenge_parameters)
+        session.delete(:email)
+        session.delete(:access_token)
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,6 +39,13 @@ en:
     mfa_description: Please enter your one time code from your authenticator app
     new_password_heading: Set up your new password
     new_password_description: This is first time you're logging in, please set your password.
+  mfa_enrolment:
+    heading: Set up your MFA
+    no_qr: Unable to scan the QR code?
+    no_qr_instructions: "Insert the code below in the authenticator app instead:"
+    success: You have been successfully enroled to MFA, please login now
+    errors: 
+      generic_error: "There was an error, please try again"
   users:
     title: Team members
     invite_button: Invite a new user

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,7 +36,7 @@ en:
   login:
     heading: Log in
     mfa_heading: Log in - One Time Password Request 
-    mfa_description: "Please enter your one time code from %{device_name}."
+    mfa_description: Please enter your one time code from your authenticator app
     new_password_heading: Set up your new password
     new_password_description: This is first time you're logging in, please set your password.
   users:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,9 @@ Rails.application.routes.draw do
   get '/users/invite', to: 'users#invite', as: :invite_user
   post '/users/invite', to: 'users#new', as: :invite_new_user
 
+  get '/mfa-enrolment', to: 'mfa#index', as: :mfa_enrolment
+  post '/mfa-enrolment', to: 'mfa#enrol', as: :enrol_to_mfa
+
   if %w(test development).include? Rails.env
     # Dashboard
     get 'profile', to: 'profile#show'

--- a/spec/controllers/mfa_controller_spec.rb
+++ b/spec/controllers/mfa_controller_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe MfaController, type: :controller do
+  include AuthSupport
+
+  describe '#index' do
+    it 'renders the page when asked to enrol to MFA' do
+      SelfService.service(:cognito_client).stub_responses(:associate_software_token, { secret_code: 'abcdefgh' })
+      session[:email] = 'test@test.test'
+      session[:access_token] = 'valid-access-token'
+      get :index
+      expect(response).to have_http_status(:success)
+      expect(subject).to render_template(:index)
+    end
+
+    it 'redirects when the user has an invalid session' do
+      get :index
+      expect(response).to have_http_status(:redirect)
+      expect(subject).to redirect_to(root_path)
+    end
+
+    it 'redirects when the user is already logged in' do
+      user_stub_auth
+      session[:access_token] = 'valid-access-token'
+      get :index
+      expect(response).to have_http_status(:redirect)
+      expect(subject).to redirect_to(root_path)
+    end
+  end
+
+  describe '#enrol' do
+    it 'is success when successfully enrolled' do
+      SelfService.service(:cognito_client).stub_responses(:verify_software_token, {})
+      SelfService.service(:cognito_client).stub_responses(:set_user_mfa_preference, {})
+      session[:email] = 'test@test.test'
+      session[:access_token] = "valid-access-token"
+      post :enrol, params: { mfa_enrolment_form: { code: 12345 }}
+      expect(response).to have_http_status(:redirect)
+      expect(subject).to redirect_to(root_path)
+      expect(flash.now[:success]).not_to be_nil
+    end
+
+    it 'returns error when the there is an exception' do
+      SelfService.service(:cognito_client).stub_responses(:verify_software_token, Aws::CognitoIdentityProvider::Errors::CodeMismatchException.new(nil, nil))
+      session[:email] = 'test@test.test'
+      session[:access_token] = "valid-access-token"
+      post :enrol, params: { mfa_enrolment_form: { code: 12345 }}
+      expect(response).to have_http_status(:bad_request)
+      expect(subject).to render_template(:index)
+      expect(flash.now[:success]).to be_nil
+      expect(flash.now[:error]).not_to be_nil
+    end
+  end
+end

--- a/spec/controllers/session_controller_spec.rb
+++ b/spec/controllers/session_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe SessionsController, type: :controller do
     cognito_session_id = SecureRandom.uuid
     username = 'test@test.com'
     challenge_name = 'SOFTWARE_TOKEN_MFA'
-    SelfService.service(:cognito_client).stub_responses(:initiate_auth, challenge_name: challenge_name, session: cognito_session_id, challenge_parameters: { 'FRIENDLY_DEVICE_NAME' => 'Authy' })
+    SelfService.service(:cognito_client).stub_responses(:initiate_auth, challenge_name: challenge_name, session: cognito_session_id, challenge_parameters: { })
     @request.env['devise.mapping'] = Devise.mappings[:user]
     post :create, params: { user: { email: username, password: 'validpass' } }
     expect(response).to have_http_status(:redirect)
@@ -31,7 +31,7 @@ RSpec.describe SessionsController, type: :controller do
     allow(strategy).to receive(:params).at_least(:once).and_return(user: 'name')
     session[:challenge_name] = 'SOFTWARE_TOKEN_MFA'
     session[:cognito_session_id] = SecureRandom.uuid
-    session[:challenge_parameters] = { 'FRIENDLY_DEVICE_NAME' => 'Authy', 'USER_ID_FOR_SRP' => '0000-0000' }
+    session[:challenge_parameters] = { 'USER_ID_FOR_SRP' => '0000-0000' }
     @request.env['devise.mapping'] = Devise.mappings[:user]
     post :create, params: { user: { email: 'test@test.com', totp_code: '999999' } }
     expect(response).to have_http_status(:redirect)
@@ -47,7 +47,7 @@ RSpec.describe SessionsController, type: :controller do
     cognito_session_id = SecureRandom.uuid
     username = 'test@test.com'
     challenge_name = 'NEW_PASSWORD_REQUIRED'
-    SelfService.service(:cognito_client).stub_responses(:initiate_auth, challenge_name: challenge_name, session: cognito_session_id, challenge_parameters: { 'FRIENDLY_DEVICE_NAME' => 'Authy' })
+    SelfService.service(:cognito_client).stub_responses(:initiate_auth, challenge_name: challenge_name, session: cognito_session_id, challenge_parameters: { })
     @request.env['devise.mapping'] = Devise.mappings[:user]
     post :create, params: { user: { email: username, password: 'validpass' } }
     expect(response).to have_http_status(:redirect)
@@ -63,7 +63,7 @@ RSpec.describe SessionsController, type: :controller do
     allow(strategy).to receive(:params).at_least(:once).and_return(user: 'name')
     session[:challenge_name] = 'NEW_PASSWORD_REQUIRED'
     session[:cognito_session_id] = SecureRandom.uuid
-    session[:challenge_parameters] = { 'FRIENDLY_DEVICE_NAME' => 'Authy', 'USER_ID_FOR_SRP' => '0000-0000' }
+    session[:challenge_parameters] = { 'USER_ID_FOR_SRP' => '0000-0000' }
     @request.env['devise.mapping'] = Devise.mappings[:user]
     post :create, params: { user: { email: 'test@test.com', new_password: 'mynewpassword' } }
     expect(response).to have_http_status(:redirect)

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -33,11 +33,11 @@ RSpec.describe UsersController, type: :controller do
             email: 'test@test.test', 
             given_name: 'First Name', 
             family_name: 'Surname', 
-            mfa: 'SOFTWARE_TOKEN_MFA',
             roles: [ROLE::USER_MANAGER, ROLE::CERTIFICATE_MANAGER]
           }
       }
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(:redirect)
+      expect(subject).to redirect_to(users_path)
       expect(flash.now[:errors]).to be_nil
       expect(flash.now[:success]).not_to be_nil
     end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,7 +4,8 @@ FactoryBot.define do
     family_name  { "Doe" }
     email { "test@test.test" }
     password { "validpassword" }
-    permissions { UserRolePermissions.new("", nil) }
+    roles { ROLE::USER_MANAGER }
+    permissions { UserRolePermissions.new(ROLE::USER_MANAGER, nil) }
   end
 
   factory :certificate_manager_user, class: User do

--- a/spec/models/invite_user_form_spec.rb
+++ b/spec/models/invite_user_form_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe InviteUserForm, type: :model do
 
   it 'is valid with valid attributes' do
-    expect(InviteUserForm.new({email: 'test@test.test', given_name: 'First Name', family_name: 'Surname', mfa: 'SOFTWARE_TOKEN_MFA', roles: [ROLE::CERTIFICATE_MANAGER] })).to be_valid
+    expect(InviteUserForm.new({email: 'test@test.test', given_name: 'First Name', family_name: 'Surname', roles: [ROLE::CERTIFICATE_MANAGER] })).to be_valid
   end
 
   it 'is not valid with non-valid attributes' do
@@ -11,19 +11,10 @@ RSpec.describe InviteUserForm, type: :model do
   end
 
   it 'is not valid with non-existent roles' do
-    expect(InviteUserForm.new({email: 'test@test.test', given_name: 'First Name', family_name: 'Surname', mfa: 'SOFTWARE_TOKEN_MFA', roles: [ROLE::CERTIFICATE_MANAGER, 'blah'] })).to_not be_valid
+    expect(InviteUserForm.new({email: 'test@test.test', given_name: 'First Name', family_name: 'Surname', roles: [ROLE::CERTIFICATE_MANAGER, 'blah'] })).to_not be_valid
   end
 
   it 'is not valid with a valid email' do
-    expect(InviteUserForm.new({email: 'notanemailaddress', given_name: 'First Name', family_name: 'Surname', mfa: 'SOFTWARE_TOKEN_MFA' })).to_not be_valid
+    expect(InviteUserForm.new({email: 'notanemailaddress', given_name: 'First Name', family_name: 'Surname' })).to_not be_valid
   end
-
-  it 'is not valid without an MFA' do
-    expect(InviteUserForm.new({email: 'test@test.test', given_name: 'First Name', family_name: 'Surname' })).to_not be_valid
-  end
-
-  it 'is not valid without a valid MFA' do
-    expect(InviteUserForm.new({email: 'test@test.test', given_name: 'First Name', family_name: 'Surname', mfa: 'NON_EXISTENT_METHOD' })).to_not be_valid
-  end
-
 end

--- a/spec/models/mfa_enrolment_form_spec.rb
+++ b/spec/models/mfa_enrolment_form_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe MfaEnrolmentForm, type: :model do
+
+  it 'is valid with valid attributes' do
+    expect(MfaEnrolmentForm.new({ code: 'abcdefg' })).to be_valid
+  end
+
+  it 'is not valid with no params' do
+    expect(MfaEnrolmentForm.new({})).to_not be_valid
+  end
+end

--- a/spec/models/new_sp_component_event_spec.rb
+++ b/spec/models/new_sp_component_event_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe NewSpComponentEvent, type: :model do
       user_id = SecureRandom.uuid
       user = User.new
       user.user_id = user_id
-      Thread.current[:user] = user
+      RequestStore.store[:user] = user
       event = NewSpComponentEvent.create(name: 'New SP component', component_type: COMPONENT_TYPE::SP)
 
       expect(event.user_id).to eql user_id

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -73,4 +73,8 @@ RSpec.configure do |config|
   config.include Warden::Test::Helpers
   config.include Devise::Test::ControllerHelpers, :type => :controller
   config.include AbstractController::Translation
+
+  config.before(:each, :type => :controller) do
+    RequestStore.clear!
+  end
 end

--- a/spec/system/sign_out_spec.rb
+++ b/spec/system/sign_out_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 RSpec.describe 'Sign out', type: :system do
   scenario 'user can sign out' do
-    SelfService.service(:cognito_client).stub_responses(:initiate_auth, { challenge_name: nil, authentication_result: {access_token: "valid-token" }})
+    SelfService.service(:cognito_client).stub_responses(:initiate_auth, { authentication_result: {access_token: "valid-token" }})
 
     user = FactoryBot.create(:user)
     sign_in(user.email, user.password)

--- a/spec/system/visit_mfa_enrolment_spec.rb
+++ b/spec/system/visit_mfa_enrolment_spec.rb
@@ -1,0 +1,88 @@
+require 'rails_helper'
+require 'rqrcode'
+require 'erb'
+
+RSpec.describe 'MFA enrolment', type: :system do
+  include ERB::Util
+  context 'is successful' do
+    let(:secret_code_value) { 'secret-code-value'}
+    let(:user_email) { 'mfa@test.com'}
+    let(:qr_issuer) { url_encode("GOV.UK Verify Admin Tool (test)") }
+    let(:qr_code_object) {
+      RQRCode::QRCode.new("otpauth://totp/#{qr_issuer}:#{url_encode(user_email)}?secret=#{secret_code_value}&issuer=#{qr_issuer}")
+    }
+    scenario 'user is forced to enrol to MFA if not set up for it' do
+      SelfService.service(:cognito_client).stub_responses(:associate_software_token, { secret_code: secret_code_value })
+      SelfService.service(:cognito_client).stub_responses(:verify_software_token, {})
+      SelfService.service(:cognito_client).stub_responses(:get_user, { username: '00000000-0000-0000-0000-000000000000', user_attributes:
+        [
+          { name: 'sub', value: '00000000-0000-0000-0000-000000000000' },
+          { name: 'custom:roles', value: 'usermgr' },
+          { name: 'email_verified', value: 'true' },
+          { name: 'phone_number_verified', value: 'true' },
+          { name: 'phone_number', value: '+447000000000' },
+          { name: 'given_name', value: 'Test' },
+          { name: 'family_name', value: 'User' },
+          { name: 'email', value: user_email }
+        ],
+      preferred_mfa_setting: nil,
+      user_mfa_setting_list: [] })
+  
+      user = FactoryBot.create(:user)
+      sign_in(user.email, user.password)
+      expect(current_path).to eql mfa_enrolment_path
+      expect(page).to have_content 'Set up your MFA'
+      expect(page).to have_content secret_code_value
+
+      expect(page).to have_selector(".mfa-qr-code svg")
+      # Couldn't make Capybara to read the SVG properly to compare, so comparing on size instead
+      qr_code_size = qr_code_object.as_svg(module_size: 3).scan(/(?=rect)/).count
+      expect(page.all(:css, '.mfa-qr-code svg rect').length).to eq qr_code_size
+
+      fill_in "mfa_enrolment_form_code", with: "999999"
+      click_button("commit")
+      expect(current_path).not_to eql mfa_enrolment_path
+    end
+  end
+
+  context 'is unsuccessful' do
+    let(:secret_code_value) { 'secret-code-value'}
+    let(:user_email) { 'mfa@test.com'}
+    let(:qr_issuer) { url_encode("GOV.UK Verify Admin Tool (test)") }
+    let(:qr_code_object) {
+      RQRCode::QRCode.new("otpauth://totp/#{qr_issuer}:#{url_encode(user_email)}?secret=#{secret_code_value}&issuer=#{qr_issuer}")
+    }
+    scenario 'user gets an error when the MFA code is not valid' do
+      SelfService.service(:cognito_client).stub_responses(:associate_software_token, { secret_code: secret_code_value })
+      SelfService.service(:cognito_client).stub_responses(:get_user, { username: '00000000-0000-0000-0000-000000000000', user_attributes:
+        [
+          { name: 'sub', value: '00000000-0000-0000-0000-000000000000' },
+          { name: 'custom:roles', value: 'usermgr' },
+          { name: 'email_verified', value: 'true' },
+          { name: 'phone_number_verified', value: 'true' },
+          { name: 'phone_number', value: '+447000000000' },
+          { name: 'given_name', value: 'Test' },
+          { name: 'family_name', value: 'User' },
+          { name: 'email', value: user_email }
+        ],
+      preferred_mfa_setting: nil,
+      user_mfa_setting_list: [] })
+
+      SelfService.service(:cognito_client).stub_responses(:verify_software_token, Aws::CognitoIdentityProvider::Errors::CodeMismatchException.new(nil, nil))
+  
+      user = FactoryBot.create(:user)
+      sign_in(user.email, user.password)
+      expect(current_path).to eql mfa_enrolment_path
+      expect(page).to have_content 'Set up your MFA'
+      expect(page).to have_content secret_code_value
+
+      fill_in "mfa_enrolment_form_code", with: "000000"
+      click_button("commit")
+      expect(current_path).to eql mfa_enrolment_path
+      expect(page).to have_content 'There was an error, please try again'
+    end
+  end
+
+  
+
+end

--- a/spec/system/visit_sign_in_spec.rb
+++ b/spec/system/visit_sign_in_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Sign in', type: :system do
   end
 
   scenario 'user can sign in with valid 2FA credentials' do
-    SelfService.service(:cognito_client).stub_responses(:initiate_auth, { challenge_name: "SOFTWARE_TOKEN_MFA", session: SecureRandom.uuid, challenge_parameters: { 'FRIENDLY_DEVICE_NAME' => 'Authy', 'USER_ID_FOR_SRP' => '0000-0000' }})
+    SelfService.service(:cognito_client).stub_responses(:initiate_auth, { challenge_name: "SOFTWARE_TOKEN_MFA", session: SecureRandom.uuid, challenge_parameters: { 'USER_ID_FOR_SRP' => '0000-0000' }})
     SelfService.service(:cognito_client).stub_responses(:respond_to_auth_challenge, { authentication_result: {access_token: 'valid-token' }})
 
     user = FactoryBot.create(:user)
@@ -40,7 +40,7 @@ RSpec.describe 'Sign in', type: :system do
   end
 
   scenario 'user cant sign in with wrong 2FA credentials' do
-    SelfService.service(:cognito_client).stub_responses(:initiate_auth, { challenge_name: "SOFTWARE_TOKEN_MFA", session: SecureRandom.uuid, challenge_parameters: { "FRIENDLY_DEVICE_NAME" => 'Authy', 'USER_ID_FOR_SRP' => '0000-0000' }})
+    SelfService.service(:cognito_client).stub_responses(:initiate_auth, { challenge_name: "SOFTWARE_TOKEN_MFA", session: SecureRandom.uuid, challenge_parameters: { 'USER_ID_FOR_SRP' => '0000-0000' }})
     SelfService.service(:cognito_client).stub_responses(:respond_to_auth_challenge, Aws::CognitoIdentityProvider::Errors::CodeMismatchException.new(nil, "Stub Response"))
 
     user = FactoryBot.create(:user)
@@ -80,7 +80,7 @@ RSpec.describe 'Sign in', type: :system do
   end
 
   scenario 'user is forced to change their temporary password' do
-    SelfService.service(:cognito_client).stub_responses(:initiate_auth, { challenge_name: "NEW_PASSWORD_REQUIRED", session: SecureRandom.uuid, challenge_parameters: { 'FRIENDLY_DEVICE_NAME' => 'Authy', 'USER_ID_FOR_SRP' => '0000-0000' }})
+    SelfService.service(:cognito_client).stub_responses(:initiate_auth, { challenge_name: "NEW_PASSWORD_REQUIRED", session: SecureRandom.uuid, challenge_parameters: { 'USER_ID_FOR_SRP' => '0000-0000' }})
     SelfService.service(:cognito_client).stub_responses(:respond_to_auth_challenge, { authentication_result: {access_token: 'valid-token' }})
 
     user = FactoryBot.create(:user)

--- a/spec/system/visit_sign_in_spec.rb
+++ b/spec/system/visit_sign_in_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Sign in', type: :system do
+
   scenario 'user cannot sign in if not registered' do
     SelfService.service(:cognito_client).stub_responses(:initiate_auth, Aws::CognitoIdentityProvider::Errors::UserNotFoundException.new(nil, "Stub Response"))
     
@@ -12,6 +13,19 @@ RSpec.describe 'Sign in', type: :system do
 
   scenario 'user can sign in with valid credentials' do
     SelfService.service(:cognito_client).stub_responses(:initiate_auth, { authentication_result: {access_token: "valid-token" }})
+    SelfService.service(:cognito_client).stub_responses(:get_user, { username: '00000000-0000-0000-0000-000000000000', user_attributes:
+      [
+        { name: 'sub', value: '00000000-0000-0000-0000-000000000000' },
+        { name: 'custom:roles', value: 'test' },
+        { name: 'email_verified', value: 'true' },
+        { name: 'phone_number_verified', value: 'true' },
+        { name: 'phone_number', value: '+447000000000' },
+        { name: 'given_name', value: 'Test' },
+        { name: 'family_name', value: 'User' },
+        { name: 'email', value: 'test@test.test' }
+      ],
+    preferred_mfa_setting: 'SOFTWARE_TOKEN_MFA',
+    user_mfa_setting_list: ['SOFTWARE_TOKEN_MFA'] })
 
     user = FactoryBot.create(:user)
     sign_in(user.email, user.password)


### PR DESCRIPTION
apologies for the size, it's best to be review commit by commit

This PR consists of (see the individual commits for more details):
- Some PR leftover refactors on the UsersController
- Removed the use of the Thread and replaced with RequestStore
- Removed references to `friendly name` for MFA

- Introduced the mfa-enrolment step for users without MFA set-up