### PR TITLE
Create group in cognito

### DIFF
--- a/app/controllers/admin/teams_controller.rb
+++ b/app/controllers/admin/teams_controller.rb
@@ -12,10 +12,12 @@ class Admin::TeamsController < ApplicationController
     team_event = NewTeamEvent.create(team_params)
     @team = team_event.team
     if @team.valid? && team_event.valid?
+      flash.now[:success] = "#{@team.name} #{t('team.new.success')}."
       redirect_to admin_teams_path
     else
       @team.errors.merge!(team_event.errors)
       Rails.logger.info(@team.errors.full_messages)
+      flash.now[:errors] = "#{@team.name} #{t('team.errors.errored')} - #{@team.errors.full_messages.join(',')}."
       render :new
     end
   end

--- a/app/models/new_team_event.rb
+++ b/app/models/new_team_event.rb
@@ -1,14 +1,42 @@
 class NewTeamEvent < AggregatedEvent
   belongs_to_aggregate :team
-  data_attributes :name
+  data_attributes :name, :team_alias
 
-  validate :name_is_present
+  validate :name_is_present, :create_cognito_group
 
   def build_team
     Team.new
   end
 
   def attributes_to_apply
-    { name: name, created_at: created_at }
+    {
+      name: name,
+      team_alias: team_alias,
+      created_at: created_at
+    }
+  end
+
+  def create_cognito_group
+    return if name.blank?
+
+    SelfService.service(:cognito_client).create_group(
+      group_name: team_alias,
+      description: name,
+      user_pool_id: Rails.application.secrets.cognito_user_pool_id
+    )
+  rescue Aws::CognitoIdentityProvider::Errors::InvalidParameterException => e
+    Rails.logger.error("#{I18n.t('team.errors.invalid')} -> #{e.message}"))
+    errors.add(:team, I18n.t('team.errors.invalid'))
+  rescue Aws::CognitoIdentityProvider::Errors::ServiceError => e
+    Rails.logger.error("#{I18n.t('team.errors.failed')} -> #{e.message}")
+    errors.add(:team, I18n.t('team.errors.failed'))
+  end
+
+  def team_alias
+    @team_alias ||= begin
+      unless name.blank?
+        name.delete(' ').strip.match(TEAMS::GROUP_NAME_REGEX)[0] # rubocop:disable Lint/SafeNavigationChain
+      end
+    end
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,8 +35,8 @@
         </div>
         <div class="govuk-header__content">
 
-          <a href="#" class="govuk-header__link govuk-header__link--service-name">
-            <%= t 'layout.application.service_name' %>
+          <a href="#">
+            <%= link_to t('layout.application.service_name'), root_path, class: "govuk-header__link govuk-header__link--service-name" %>
           </a>
 
           <button type="button" role="button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation" data-module="govuk-button"><%= t 'layout.application.menu' %></button>
@@ -69,10 +69,10 @@
             </strong>
           </div>
         <% end %>
-        <%= content_for?(:main) ? yield(:main) : yield %>  
+        <%= content_for?(:main) ? yield(:main) : yield %>
       </main>
     </div>
-      
+
     <footer class="govuk-footer " role="contentinfo">
       <div class="govuk-width-container ">
         <div class="govuk-footer__meta">
@@ -92,7 +92,7 @@
         </div>
       </div>
     </footer>
-      
+
     <script>window.GOVUKFrontend.initAll()</script>
   </body>
 </html>

--- a/config/initializers/constants/teams.rb
+++ b/config/initializers/constants/teams.rb
@@ -1,0 +1,3 @@
+module TEAMS
+  GROUP_NAME_REGEX = /[\p{L}\p{M}\p{S}\p{N}\p{P}]+/.freeze
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,7 +35,7 @@ en:
     error_name_not_unique: Name has already been taken
   login:
     heading: Log in
-    mfa_heading: Log in - One Time Password Request 
+    mfa_heading: Log in - One Time Password Request
     mfa_description: Please enter your one time code from your authenticator app
     new_password_heading: Set up your new password
     new_password_description: This is first time you're logging in, please set your password.
@@ -44,7 +44,7 @@ en:
     no_qr: Unable to scan the QR code?
     no_qr_instructions: "Insert the code below in the authenticator app instead:"
     success: You have been successfully enroled to MFA, please login now
-    errors: 
+    errors:
       generic_error: "There was an error, please try again"
   users:
     title: Team members
@@ -129,6 +129,11 @@ en:
       heading: Add a team
       team_name_field: Team name
       create_team: Create team
+      success: created successfully
+    errors:
+      errored: errored
+      invalid: Invalid team name
+      failed: Failed to create team
 
 
 
@@ -159,4 +164,4 @@ en:
     view_components: View components
     associate_team: Associate team
     edit:
-      heading: Associate team to 
+      heading: Associate team to

--- a/db/migrate/20190807134744_add_team_alias_to_teams.rb
+++ b/db/migrate/20190807134744_add_team_alias_to_teams.rb
@@ -1,0 +1,5 @@
+class AddTeamAliasToTeams < ActiveRecord::Migration[5.2]
+  def change
+    add_column :teams, :team_alias, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_31_143550) do
+ActiveRecord::Schema.define(version: 2019_08_07_134744) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -91,6 +91,7 @@ ActiveRecord::Schema.define(version: 2019_07_31_143550) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "team_alias"
     t.index ["name"], name: "index_teams_on_name", unique: true
   end
 

--- a/spec/controllers/admin/teams_controller_spec.rb
+++ b/spec/controllers/admin/teams_controller_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 RSpec.describe Admin::TeamsController, type: :controller do
-  include AuthSupport
-  
+  include AuthSupport, CognitoSupport
+
   before(:each) do
     stub_auth
   end
-  
+
   describe "GET #index" do
     it "returns http success" do
       get :index
@@ -17,6 +17,42 @@ RSpec.describe Admin::TeamsController, type: :controller do
     it "returns http success" do
       get :new
       expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe 'POST #create' do
+    let(:team_name) { 'super-awesome-team' }
+
+    it 'successfully creates a group in cognito' do
+      Rails.application.secrets.cognito_user_pool_id = 'dummy'
+      stub_cognito_response(
+        method: :create_group,
+        payload: {
+          group: {
+            group_name: team_name,
+            user_pool_id: Rails.application.secrets.cognito_user_pool_id,
+            description: team_name
+          }
+        }
+      )
+      post :create, params: { team: { name: team_name } }
+
+      expect(subject).to redirect_to(admin_teams_path)
+      expect(flash.now[:errors]).to be_nil
+      expect(flash.now[:success]).not_to be_nil
+    end
+
+    it 'fails to create a group in cognito' do
+      Rails.application.secrets.cognito_user_pool_id = 'dummy'
+      stub_cognito_response(
+        method: :create_group,
+        payload: Aws::CognitoIdentityProvider::Errors::InvalidParameterException.new(nil, nil, {})
+      )
+      post :create, params: { team: { name: 'not a valid team name' } }
+
+      expect(response).to have_http_status(:success)
+      expect(flash.now[:errors]).not_to be_nil
+      expect(flash.now[:success]).to be_nil
     end
   end
 end

--- a/spec/models/new_team_event_spec.rb
+++ b/spec/models/new_team_event_spec.rb
@@ -1,15 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe NewTeamEvent, type: :model do
+  include CognitoSupport
+
   context 'on successful creation' do
     it 'is valid and persisted' do
-      team_event = create(:new_team_event)
+      stub_cognito_response(method: :create_group)
+      team_event = create(:new_team_event, name: 'The O Father')
       expect(team_event).to be_valid
       expect(team_event).to be_persisted
     end
 
     it 'has team event' do
-      team_event = create(:new_team_event)
+      stub_cognito_response(method: :create_group)
+      team_event = create(:new_team_event, name: 'J Snoop')
       expect(team_event).to eq NewTeamEvent.last
     end
   end

--- a/spec/support/cognito_support.rb
+++ b/spec/support/cognito_support.rb
@@ -1,0 +1,5 @@
+module CognitoSupport
+  def stub_cognito_response(method:, payload: {})
+    SelfService.service(:cognito_client).stub_responses(method, payload)
+  end
+end

--- a/spec/system/visit_team_new_spec.rb
+++ b/spec/system/visit_team_new_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe 'New Team Page', type: :system do
+  include CognitoSupport
+
   before(:each) do
     login_user
   end
@@ -36,6 +38,34 @@ RSpec.describe 'New Team Page', type: :system do
 
       expect(page).to have_content t('team.new.heading')
       expect(page).to have_content t('common.error_name_not_unique')
+    end
+  end
+
+  context 'failed to create cognito group' do
+    it 'shows correct error message with invalid group name' do
+      stub_cognito_response(
+        method: :create_group,
+        payload: Aws::CognitoIdentityProvider::Errors::InvalidParameterException.new(nil, nil, {})
+      )
+      visit new_admin_team_path
+      fill_in 'team_name', with: team_name
+      click_button t('team.new.create_team')
+
+      expect(page).to have_content t('team.new.heading')
+      expect(page).to have_content t('team.errors.invalid')
+    end
+
+    it 'shows general failed to create message on error' do
+      stub_cognito_response(
+        method: :create_group,
+        payload: Aws::CognitoIdentityProvider::Errors::ServiceError.new(nil, nil, {})
+      )
+      visit new_admin_team_path
+      fill_in 'team_name', with: team_name
+      click_button t('team.new.create_team')
+
+      expect(page).to have_content t('team.new.heading')
+      expect(page).to have_content t('team.errors.failed')
     end
   end
 end


### PR DESCRIPTION
[Create group in cognito](https://trello.com/c/MqjCqcyS/578-create-a-group-in-cognito-when-a-team-is-created)
What
In Associate components with teams we introduced Teams. We now need to reflect the teams in Cognito as groups.

Why
So we can control user access effectively and securely.