### PR TITLE
Added session expiry and inactivity expiry

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,8 +15,8 @@ protected
   def check_max_session_time
     return false if current_user.nil?
 
-    timeout = Rails.configuration.session_expiry_in_minutes
-    sign_out_user if Time.parse(current_user.session_start_time) + timeout.minutes < Time.now
+    timeout = Rails.configuration.session_expiry
+    sign_out_user if Time.parse(current_user.session_start_time) + timeout < Time.now
   end
 
   def configure_permitted_parameters
@@ -38,7 +38,7 @@ protected
 private
 
   def sign_out_user
-    UserSignOutEvent.create(user_id: warden.user.user_id)
+    UserTimeoutEvent.create(user_id: warden.user.user_id)
     Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name)
     yield if block_given?
     redirect_to root_path

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,6 +14,7 @@ protected
 
   def check_max_session_time
     return false if current_user.nil?
+
     time_out = Rails.application.secrets.session_expiry_in_minutes.nil? ? 60 : Rails.application.secrets.session_expiry_in_minutes.to_i
     sign_out_user if Time.parse(current_user.current_sign_in_at) + time_out.minutes < Time.now
   end
@@ -34,11 +35,11 @@ protected
     redirect_to root_path
   end
 
-  private
+private
 
   def sign_out_user
     UserSignOutEvent.create(user_id: warden.user.user_id)
-    signed_out = (Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name))
+    Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name)
     yield if block_given?
     redirect_to root_path
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,7 +15,7 @@ protected
   def check_max_session_time
     return false if current_user.nil?
 
-    timeout = Rails.application.secrets.session_expiry_in_minutes.nil? ? 60 : Rails.application.secrets.session_expiry_in_minutes.to_i
+    timeout = Rails.configuration.session_expiry_in_minutes
     sign_out_user if Time.parse(current_user.session_start_time) + timeout.minutes < Time.now
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,8 +15,8 @@ protected
   def check_max_session_time
     return false if current_user.nil?
 
-    time_out = Rails.application.secrets.session_expiry_in_minutes.nil? ? 60 : Rails.application.secrets.session_expiry_in_minutes.to_i
-    sign_out_user if Time.parse(current_user.current_sign_in_at) + time_out.minutes < Time.now
+    timeout = Rails.application.secrets.session_expiry_in_minutes.nil? ? 60 : Rails.application.secrets.session_expiry_in_minutes.to_i
+    sign_out_user if Time.parse(current_user.session_start_time) + timeout.minutes < Time.now
   end
 
   def configure_permitted_parameters

--- a/app/models/remote_authenticatable.rb
+++ b/app/models/remote_authenticatable.rb
@@ -87,6 +87,8 @@ module Devise
         self.given_name = user_attributes['given_name']
         self.family_name = user_attributes['family_name']
         self.mfa = aws_user.preferred_mfa_setting
+        self.current_sign_in_at = Time.now
+        self.last_sign_in_at = Time.now
         self
       end
 
@@ -130,6 +132,8 @@ module Devise
           resource.full_name = "#{data['given_name']} #{data['family_name']}"
           resource.given_name = data['given_name']
           resource.family_name = data['family_name']
+          resource.current_sign_in_at = data['current_sign_in_at']
+          resource.last_sign_in_at = data['last_sign_in_at']
           resource
         end
 
@@ -149,7 +153,9 @@ module Devise
               user_id: record.user_id,
               roles: record.roles,
               given_name: record.given_name,
-              family_name: record.family_name
+              family_name: record.family_name,
+              current_sign_in_at: record.current_sign_in_at,
+              last_sign_in_at: record.last_sign_in_at
             },
             # Used for salt in serialize_from_session, causes error if missing
             nil

--- a/app/models/remote_authenticatable.rb
+++ b/app/models/remote_authenticatable.rb
@@ -87,6 +87,8 @@ module Devise
         self.given_name = user_attributes['given_name']
         self.family_name = user_attributes['family_name']
         self.mfa = aws_user.preferred_mfa_setting
+        # session_start_time will be serialised to a string so
+        # lets be explicit about setting it as a string here.
         self.session_start_time = Time.now.to_s
         self
       end

--- a/app/models/remote_authenticatable.rb
+++ b/app/models/remote_authenticatable.rb
@@ -87,8 +87,8 @@ module Devise
         self.given_name = user_attributes['given_name']
         self.family_name = user_attributes['family_name']
         self.mfa = aws_user.preferred_mfa_setting
-        self.current_sign_in_at = Time.now
-        self.last_sign_in_at = Time.now
+        self.current_sign_in_at = Time.now.to_s
+        self.last_sign_in_at = Time.now.to_s
         self
       end
 

--- a/app/models/remote_authenticatable.rb
+++ b/app/models/remote_authenticatable.rb
@@ -87,8 +87,7 @@ module Devise
         self.given_name = user_attributes['given_name']
         self.family_name = user_attributes['family_name']
         self.mfa = aws_user.preferred_mfa_setting
-        self.current_sign_in_at = Time.now.to_s
-        self.last_sign_in_at = Time.now.to_s
+        self.session_start_time = Time.now.to_s
         self
       end
 
@@ -132,8 +131,7 @@ module Devise
           resource.full_name = "#{data['given_name']} #{data['family_name']}"
           resource.given_name = data['given_name']
           resource.family_name = data['family_name']
-          resource.current_sign_in_at = data['current_sign_in_at']
-          resource.last_sign_in_at = data['last_sign_in_at']
+          resource.session_start_time = data['session_start_time']
           resource
         end
 
@@ -154,8 +152,7 @@ module Devise
               roles: record.roles,
               given_name: record.given_name,
               family_name: record.family_name,
-              current_sign_in_at: record.current_sign_in_at,
-              last_sign_in_at: record.last_sign_in_at
+              session_start_time: record.session_start_time
             },
             # Used for salt in serialize_from_session, causes error if missing
             nil

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,9 +8,10 @@ class User
   extend Devise::Models
 
   # create getter and setter methods internally for the fields below
-  attr_accessor :email, :access_token, :challenge_name, :cognito_session_id, :mfa,
-                :challenge_parameters, :roles, :full_name, :family_name, :given_name,
-                :phone_number, :user_id, :login_id, :password, :new_password, :totp_code, :permissions
+  attr_accessor :email, :access_token, :challenge_name, :cognito_session_id,
+                :mfa, :challenge_parameters, :roles, :full_name, :family_name,
+                :given_name, :phone_number, :user_id, :login_id, :password, :new_password,
+                :totp_code, :permissions, :current_sign_in_at, :last_sign_in_at
 
   #required by Devise
   define_model_callbacks :validation
@@ -25,5 +26,9 @@ class User
 
   def attributes
     super.merge(roles: nil, permissions: nil)
+  end
+
+  def to_hash
+    instance_variables.map { |var| [var.to_s.delete('@'), instance_variable_get(var)] }.to_h
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,7 @@ class User
   attr_accessor :email, :access_token, :challenge_name, :cognito_session_id,
                 :mfa, :challenge_parameters, :roles, :full_name, :family_name,
                 :given_name, :phone_number, :user_id, :login_id, :password, :new_password,
-                :totp_code, :permissions, :current_sign_in_at, :last_sign_in_at
+                :totp_code, :permissions, :session_start_time
 
   #required by Devise
   define_model_callbacks :validation

--- a/app/models/user_timeout_event.rb
+++ b/app/models/user_timeout_event.rb
@@ -1,0 +1,2 @@
+class UserTimeoutEvent < Event
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,5 +35,10 @@ module VerifySelfService
 
     config.i18n.default_locale = :en
 
+    # User will be timed out after 90 minutes regardless of activity
+    config.session_expiry = 90.minutes
+
+    # User will be timed out after 15 minutes of inactivity
+    config.session_inactivity = 15.minutes
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -15,13 +15,6 @@ Rails.application.configure do
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
 
-  # User will be timed out after 90 minutes regardless of activity
-  config.session_expiry_in_minutes = 90
-
-  # User will be timed out after 15 minutes of inactivity
-  config.session_inactivity_in_minutes = 1
-
-
   if Rails.root.join('tmp', 'caching-dev.txt').exist?
     config.action_controller.perform_caching = true
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -14,11 +14,17 @@ Rails.application.configure do
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
-  
-  
+
+  # User will be timed out after 90 minutes regardless of activity
+  config.session_expiry_in_minutes = 90
+
+  # User will be timed out after 15 minutes of inactivity
+  config.session_inactivity_in_minutes = 1
+
+
   if Rails.root.join('tmp', 'caching-dev.txt').exist?
     config.action_controller.perform_caching = true
-    
+
     config.cache_store = :memory_store
 
     config.public_file_server.headers = {

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -14,6 +14,12 @@ Rails.application.configure do
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
 
+  # User will be timed out after 90 minutes regardless of activity
+  config.session_expiry_in_minutes = 90
+
+  # User will be timed out after 15 minutes of inactivity
+  config.session_inactivity_in_minutes = 15
+
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
   # config.require_master_key = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -15,10 +15,10 @@ Rails.application.configure do
   config.action_controller.perform_caching = true
 
   # User will be timed out after 90 minutes regardless of activity
-  config.session_expiry_in_minutes = 90
+  # config.session_expiry = 90.minutes
 
   # User will be timed out after 15 minutes of inactivity
-  config.session_inactivity_in_minutes = 15
+  # config.session_inactivity = 15.minutes
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -41,12 +41,6 @@ Rails.application.configure do
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
-  # User will be timed out after 90 minutes regardless of activity
-  config.session_expiry_in_minutes = 90
-
-  # User will be timed out after 15 minutes of inactivity
-  config.session_inactivity_in_minutes = 15
-
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -41,9 +41,14 @@ Rails.application.configure do
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
+  # User will be timed out after 90 minutes regardless of activity
+  config.session_expiry_in_minutes = 90
+
+  # User will be timed out after 15 minutes of inactivity
+  config.session_inactivity_in_minutes = 15
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
   config.middleware.use RackSessionAccess::Middleware
- 
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -182,9 +182,8 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  # config.timeout_in = 30.minutes
-  inactivity_expiry = Rails.configuration.session_inactivity_in_minutes
-  config.timeout_in = inactivity_expiry.minutes
+  # config.timeout_in = 30.minutes 
+  config.timeout_in = Rails.configuration.session_inactivity
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -183,6 +183,8 @@ Devise.setup do |config|
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
   # config.timeout_in = 30.minutes
+  inactivity_expiry = Rails.application.secrets.session_inactivity_in_minutes.nil? ? 15 : Rails.application.secrets.session_inactivity_in_minutes.to_i
+  config.timeout_in = inactivity_expiry.minutes
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -183,7 +183,7 @@ Devise.setup do |config|
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
   # config.timeout_in = 30.minutes
-  inactivity_expiry = Rails.application.secrets.session_inactivity_in_minutes.nil? ? 15 : Rails.application.secrets.session_inactivity_in_minutes.to_i
+  inactivity_expiry = Rails.configuration.session_inactivity_in_minutes
   config.timeout_in = inactivity_expiry.minutes
 
   # ==> Configuration for :lockable

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -4,6 +4,8 @@ default: &default
     cognito_aws_secret_access_key: <%= ENV["COGNITO_AWS_SECRET_ACCESS_KEY"] %>
     cognito_client_id: <%= ENV["AWS_COGNITO_CLIENT_ID"] %>
     cognito_user_pool_id: <%= ENV["AWS_COGNITO_USER_POOL_ID"] %>
+    session_expiry_in_minutes: <%= ENV["SESSION_EXPIRY_IN_MINUTES"] %>
+    session_inactivity_in_minutes: <%= ENV["SESSION_INACTIVITY_IN_MINUTES"] %>
 
 # Make the rest of your groups inherit from default
 development:

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -4,8 +4,6 @@ default: &default
     cognito_aws_secret_access_key: <%= ENV["COGNITO_AWS_SECRET_ACCESS_KEY"] %>
     cognito_client_id: <%= ENV["AWS_COGNITO_CLIENT_ID"] %>
     cognito_user_pool_id: <%= ENV["AWS_COGNITO_USER_POOL_ID"] %>
-    session_expiry_in_minutes: <%= ENV["SESSION_EXPIRY_IN_MINUTES"] %>
-    session_inactivity_in_minutes: <%= ENV["SESSION_INACTIVITY_IN_MINUTES"] %>
 
 # Make the rest of your groups inherit from default
 development:

--- a/spec/controllers/profile_controller_spec.rb
+++ b/spec/controllers/profile_controller_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe ProfileController, type: :controller do
     it "get profile if have user" do
       @request.env["devise.mapping"] = Devise.mappings[:user]
       user = FactoryBot.create(:user)
+      allow(request.env['warden']).to receive(:authenticate!).and_return(@user)
+      allow(controller).to receive(:current_user).and_return(@user)
       sign_in user
       get :show
       expect(response.status).to eq(200)

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,6 +5,8 @@ FactoryBot.define do
     email { "test@test.test" }
     password { "validpassword" }
     roles { ROLE::USER_MANAGER }
+    current_sign_in_at { Time.now.to_s }
+    last_sign_in_at { Time.now.to_s }
     permissions { UserRolePermissions.new(ROLE::USER_MANAGER, nil) }
   end
 
@@ -14,6 +16,8 @@ FactoryBot.define do
     email { "test.test@digital.cabinet-office.gov.uk" }
     password { "validpassword" }
     roles { ROLE::GDS }
+    current_sign_in_at { Time.now.to_s }
+    last_sign_in_at { Time.now.to_s }
     permissions { UserRolePermissions.new(ROLE::GDS, "test.test@digital.cabinet-office.gov.uk") }
   end
 
@@ -23,6 +27,8 @@ FactoryBot.define do
     email { "test@test.test" }
     password { "validpassword" }
     roles { ROLE::CERTIFICATE_MANAGER }
+    current_sign_in_at { Time.now.to_s }
+    last_sign_in_at { Time.now.to_s }
     permissions { UserRolePermissions.new(ROLE::CERTIFICATE_MANAGER, nil) }
   end
 
@@ -32,6 +38,8 @@ FactoryBot.define do
     email { "test@test.test" }
     password { "validpassword" }
     roles { ROLE::USER_MANAGER }
+    current_sign_in_at { Time.now.to_s }
+    last_sign_in_at { Time.now.to_s }
     permissions { UserRolePermissions.new(ROLE::USER_MANAGER, nil) }
   end
 
@@ -41,6 +49,8 @@ FactoryBot.define do
     email { "test@test.test" }
     password { "validpassword" }
     roles { ROLE::COMPONENT_MANAGER }
+    current_sign_in_at { Time.now.to_s }
+    last_sign_in_at { Time.now.to_s }
     permissions { UserRolePermissions.new(ROLE::COMPONENT_MANAGER, nil) }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,8 +5,7 @@ FactoryBot.define do
     email { "test@test.test" }
     password { "validpassword" }
     roles { ROLE::USER_MANAGER }
-    current_sign_in_at { Time.now.to_s }
-    last_sign_in_at { Time.now.to_s }
+    session_start_time { Time.now.to_s }
     permissions { UserRolePermissions.new(ROLE::USER_MANAGER, nil) }
   end
 
@@ -16,8 +15,7 @@ FactoryBot.define do
     email { "test.test@digital.cabinet-office.gov.uk" }
     password { "validpassword" }
     roles { ROLE::GDS }
-    current_sign_in_at { Time.now.to_s }
-    last_sign_in_at { Time.now.to_s }
+    session_start_time { Time.now.to_s }
     permissions { UserRolePermissions.new(ROLE::GDS, "test.test@digital.cabinet-office.gov.uk") }
   end
 
@@ -27,8 +25,7 @@ FactoryBot.define do
     email { "test@test.test" }
     password { "validpassword" }
     roles { ROLE::CERTIFICATE_MANAGER }
-    current_sign_in_at { Time.now.to_s }
-    last_sign_in_at { Time.now.to_s }
+    session_start_time { Time.now.to_s }
     permissions { UserRolePermissions.new(ROLE::CERTIFICATE_MANAGER, nil) }
   end
 
@@ -38,8 +35,7 @@ FactoryBot.define do
     email { "test@test.test" }
     password { "validpassword" }
     roles { ROLE::USER_MANAGER }
-    current_sign_in_at { Time.now.to_s }
-    last_sign_in_at { Time.now.to_s }
+    session_start_time { Time.now.to_s }
     permissions { UserRolePermissions.new(ROLE::USER_MANAGER, nil) }
   end
 
@@ -49,8 +45,7 @@ FactoryBot.define do
     email { "test@test.test" }
     password { "validpassword" }
     roles { ROLE::COMPONENT_MANAGER }
-    current_sign_in_at { Time.now.to_s }
-    last_sign_in_at { Time.now.to_s }
+    session_start_time { Time.now.to_s }
     permissions { UserRolePermissions.new(ROLE::COMPONENT_MANAGER, nil) }
   end
 end

--- a/spec/support/time_helpers.rb
+++ b/spec/support/time_helpers.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include ActiveSupport::Testing::TimeHelpers
+end

--- a/spec/system/sign_out_spec.rb
+++ b/spec/system/sign_out_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe 'Sign out', type: :system do
     travel_to Time.now + 16.minutes
     visit(profile_path)
     expect(current_path).to eql new_user_session_path
+    expect(page).to have_content 'Your session expired. Please sign in again to continue.'
   end
 
   scenario 'user signed out after length of time' do
@@ -59,6 +60,7 @@ RSpec.describe 'Sign out', type: :system do
     travel_to Time.now + 16.minutes
     visit(profile_path)
     expect(current_path).to eql new_user_session_path
+    expect(page).to have_content 'Your session expired. Please sign in again to continue.'
   end
 
   scenario 'user gets to path before expiry' do

--- a/spec/system/sign_out_spec.rb
+++ b/spec/system/sign_out_spec.rb
@@ -1,7 +1,25 @@
 require 'rails_helper'
+
+def cognito_stubs
+  SelfService.service(:cognito_client).stub_responses(:initiate_auth, { authentication_result: {access_token: "valid-token" }})
+  SelfService.service(:cognito_client).stub_responses(:get_user, { username: '00000000-0000-0000-0000-000000000000', user_attributes:
+    [
+      { name: 'sub', value: '00000000-0000-0000-0000-000000000000' },
+      { name: 'custom:roles', value: 'test' },
+      { name: 'email_verified', value: 'true' },
+      { name: 'phone_number_verified', value: 'true' },
+      { name: 'phone_number', value: '+447000000000' },
+      { name: 'given_name', value: 'Test' },
+      { name: 'family_name', value: 'User' },
+      { name: 'email', value: 'test@test.test' }
+    ],
+  preferred_mfa_setting: 'SOFTWARE_TOKEN_MFA',
+  user_mfa_setting_list: ['SOFTWARE_TOKEN_MFA'] })
+end
+
 RSpec.describe 'Sign out', type: :system do
   scenario 'user can sign out' do
-    SelfService.service(:cognito_client).stub_responses(:initiate_auth, { authentication_result: {access_token: "valid-token" }})
+    cognito_stubs
 
     user = FactoryBot.create(:user)
     sign_in(user.email, user.password)
@@ -13,44 +31,21 @@ RSpec.describe 'Sign out', type: :system do
   end
 
   scenario 'user signed out after inactiviy' do
-    SelfService.service(:cognito_client).stub_responses(:initiate_auth, { authentication_result: {access_token: "valid-token" }})
-    SelfService.service(:cognito_client).stub_responses(:get_user, { username: '00000000-0000-0000-0000-000000000000', user_attributes:
-      [
-        { name: 'sub', value: '00000000-0000-0000-0000-000000000000' },
-        { name: 'custom:roles', value: 'test' },
-        { name: 'email_verified', value: 'true' },
-        { name: 'phone_number_verified', value: 'true' },
-        { name: 'phone_number', value: '+447000000000' },
-        { name: 'given_name', value: 'Test' },
-        { name: 'family_name', value: 'User' },
-        { name: 'email', value: 'test@test.test' }
-      ],
-    preferred_mfa_setting: 'SOFTWARE_TOKEN_MFA',
-    user_mfa_setting_list: ['SOFTWARE_TOKEN_MFA'] })
+    Rails.configuration.session_expiry_in_minutes = 90.minutes
+    Rails.configuration.session_inactivity_in_minutes = 15.minutes
+    cognito_stubs
 
     user = FactoryBot.create(:user)
     sign_in(user.email, user.password)
     travel_to Time.now + 16.minutes
     visit(profile_path)
     expect(current_path).to eql new_user_session_path
-    expect(page).to have_content 'Your session expired. Please sign in again to continue.'
   end
 
   scenario 'user signed out after length of time' do
-    SelfService.service(:cognito_client).stub_responses(:initiate_auth, { authentication_result: {access_token: "valid-token" }})
-    SelfService.service(:cognito_client).stub_responses(:get_user, { username: '00000000-0000-0000-0000-000000000000', user_attributes:
-      [
-        { name: 'sub', value: '00000000-0000-0000-0000-000000000000' },
-        { name: 'custom:roles', value: 'test' },
-        { name: 'email_verified', value: 'true' },
-        { name: 'phone_number_verified', value: 'true' },
-        { name: 'phone_number', value: '+447000000000' },
-        { name: 'given_name', value: 'Test' },
-        { name: 'family_name', value: 'User' },
-        { name: 'email', value: 'test@test.test' }
-      ],
-    preferred_mfa_setting: 'SOFTWARE_TOKEN_MFA',
-    user_mfa_setting_list: ['SOFTWARE_TOKEN_MFA'] })
+    Rails.configuration.session_expiry = 15.minutes
+    Rails.configuration.session_inactivity = 60.minutes
+    cognito_stubs
 
     user = FactoryBot.create(:user)
     sign_in(user.email, user.password)
@@ -64,20 +59,8 @@ RSpec.describe 'Sign out', type: :system do
   end
 
   scenario 'user gets to path before expiry' do
-    SelfService.service(:cognito_client).stub_responses(:initiate_auth, { authentication_result: {access_token: "valid-token" }})
-    SelfService.service(:cognito_client).stub_responses(:get_user, { username: '00000000-0000-0000-0000-000000000000', user_attributes:
-      [
-        { name: 'sub', value: '00000000-0000-0000-0000-000000000000' },
-        { name: 'custom:roles', value: 'test' },
-        { name: 'email_verified', value: 'true' },
-        { name: 'phone_number_verified', value: 'true' },
-        { name: 'phone_number', value: '+447000000000' },
-        { name: 'given_name', value: 'Test' },
-        { name: 'family_name', value: 'User' },
-        { name: 'email', value: 'test@test.test' }
-      ],
-    preferred_mfa_setting: 'SOFTWARE_TOKEN_MFA',
-    user_mfa_setting_list: ['SOFTWARE_TOKEN_MFA'] })
+    cognito_stubs
+    Rails.configuration.session_inactivity_in_minutes = 15.minutes
 
     user = FactoryBot.create(:user)
     sign_in(user.email, user.password)

--- a/spec/system/sign_out_spec.rb
+++ b/spec/system/sign_out_spec.rb
@@ -11,4 +11,78 @@ RSpec.describe 'Sign out', type: :system do
     expect(current_path).to eql new_user_session_path
     expect(page).to have_content 'You need to sign in or sign up before continuing.'
   end
+
+  scenario 'user signed out after inactiviy' do
+    SelfService.service(:cognito_client).stub_responses(:initiate_auth, { authentication_result: {access_token: "valid-token" }})
+    SelfService.service(:cognito_client).stub_responses(:get_user, { username: '00000000-0000-0000-0000-000000000000', user_attributes:
+      [
+        { name: 'sub', value: '00000000-0000-0000-0000-000000000000' },
+        { name: 'custom:roles', value: 'test' },
+        { name: 'email_verified', value: 'true' },
+        { name: 'phone_number_verified', value: 'true' },
+        { name: 'phone_number', value: '+447000000000' },
+        { name: 'given_name', value: 'Test' },
+        { name: 'family_name', value: 'User' },
+        { name: 'email', value: 'test@test.test' }
+      ],
+    preferred_mfa_setting: 'SOFTWARE_TOKEN_MFA',
+    user_mfa_setting_list: ['SOFTWARE_TOKEN_MFA'] })
+
+    user = FactoryBot.create(:user)
+    sign_in(user.email, user.password)
+    travel_to Time.now + 16.minutes
+    visit(profile_path)
+    expect(current_path).to eql new_user_session_path
+  end
+
+  scenario 'user signed out after length of time' do
+    Rails.application.secrets.session_inactivity_in_minutes = 90
+    Rails.application.secrets.session_expiry_in_minutes = 15
+    SelfService.service(:cognito_client).stub_responses(:initiate_auth, { authentication_result: {access_token: "valid-token" }})
+    SelfService.service(:cognito_client).stub_responses(:get_user, { username: '00000000-0000-0000-0000-000000000000', user_attributes:
+      [
+        { name: 'sub', value: '00000000-0000-0000-0000-000000000000' },
+        { name: 'custom:roles', value: 'test' },
+        { name: 'email_verified', value: 'true' },
+        { name: 'phone_number_verified', value: 'true' },
+        { name: 'phone_number', value: '+447000000000' },
+        { name: 'given_name', value: 'Test' },
+        { name: 'family_name', value: 'User' },
+        { name: 'email', value: 'test@test.test' }
+      ],
+    preferred_mfa_setting: 'SOFTWARE_TOKEN_MFA',
+    user_mfa_setting_list: ['SOFTWARE_TOKEN_MFA'] })
+
+    user = FactoryBot.create(:user)
+    sign_in(user.email, user.password)
+    travel_to Time.now + 14.minutes
+    visit(profile_path)
+    expect(current_path).to eql profile_path
+    travel_to Time.now + 16.minutes
+    visit(profile_path)
+    expect(current_path).to eql new_user_session_path
+  end
+
+  scenario 'user gets to path before expiry' do
+    SelfService.service(:cognito_client).stub_responses(:initiate_auth, { authentication_result: {access_token: "valid-token" }})
+    SelfService.service(:cognito_client).stub_responses(:get_user, { username: '00000000-0000-0000-0000-000000000000', user_attributes:
+      [
+        { name: 'sub', value: '00000000-0000-0000-0000-000000000000' },
+        { name: 'custom:roles', value: 'test' },
+        { name: 'email_verified', value: 'true' },
+        { name: 'phone_number_verified', value: 'true' },
+        { name: 'phone_number', value: '+447000000000' },
+        { name: 'given_name', value: 'Test' },
+        { name: 'family_name', value: 'User' },
+        { name: 'email', value: 'test@test.test' }
+      ],
+    preferred_mfa_setting: 'SOFTWARE_TOKEN_MFA',
+    user_mfa_setting_list: ['SOFTWARE_TOKEN_MFA'] })
+
+    user = FactoryBot.create(:user)
+    sign_in(user.email, user.password)
+    travel_to Time.now + 14.minutes
+    visit(profile_path)
+    expect(current_path).to eql profile_path
+  end
 end

--- a/spec/system/sign_out_spec.rb
+++ b/spec/system/sign_out_spec.rb
@@ -36,8 +36,6 @@ RSpec.describe 'Sign out', type: :system do
   end
 
   scenario 'user signed out after length of time' do
-    Rails.application.secrets.session_inactivity_in_minutes = 90
-    Rails.application.secrets.session_expiry_in_minutes = 15
     SelfService.service(:cognito_client).stub_responses(:initiate_auth, { authentication_result: {access_token: "valid-token" }})
     SelfService.service(:cognito_client).stub_responses(:get_user, { username: '00000000-0000-0000-0000-000000000000', user_attributes:
       [


### PR DESCRIPTION
### What
Implement both the idle and absolute timeouts.
- The idle timeout should be 15 minutes (the session should be invalidated if the last activity was 15 minutes or more ago)
- The absolute timeout should be 90 minutes (the user needs to re-authenticate after 90 minutes of their initial login, regardless of their activity)
The values above should be configurable.

### Why
To comply with security standards and recommendations we should implement session timeouts - both idle and absolute timeouts. This will prevent potential hijackers from using existing sessions or gaining unauthorized access.