### PR TITLE
BAU: Fix the staging deployment

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,8 +39,6 @@ Rails.application.routes.draw do
   get '/mfa-enrolment', to: 'mfa#index', as: :mfa_enrolment
   post '/mfa-enrolment', to: 'mfa#enrol', as: :enrol_to_mfa
 
-  if %w(test development).include? Rails.env
-    # Dashboard
-    get 'profile', to: 'profile#show'
-  end
+  get 'profile', to: 'profile#show'
+
 end


### PR DESCRIPTION
The production build is broken as we restrict the `profile_path` to non-prod environment.
However, we started linking to the page from the main layout:
https://github.com/alphagov/verify-self-service/blob/fb3cd583cf1cd5eed195b1c4e21020730316baaa/app/views/layouts/application.html.erb#L57 meaning it now breaks.
I'm removing the route constraints as there's nothing sensitive at this moment.