### PR TITLE
BAU: Fix missing translations

### DIFF
--- a/app/views/msa_components/_all_msa_components.html.erb
+++ b/app/views/msa_components/_all_msa_components.html.erb
@@ -17,7 +17,7 @@
           <td class="govuk-table__cell"><%= component.team&.name %></td>
           <td class="govuk-table__cell">
             <%= link_to t('components.view_link'), msa_component_path(component) , class: 'govuk-button'  %>
-            <%= link_to t('components.associate_team'), edit_msa_component_path(component), class: 'govuk-button' %>
+            <%= link_to t('team.associate_team'), edit_msa_component_path(component), class: 'govuk-button' %>
           </td>
         </tr>
       <% end %>

--- a/app/views/msa_components/edit.html.erb
+++ b/app/views/msa_components/edit.html.erb
@@ -13,6 +13,6 @@
     %>
   </div>
   <div class="govuk-form-group">
-    <%=f.submit t('admin.associate_team'), class: "govuk-button" %>
+    <%=f.submit t('team.associate_team'), class: "govuk-button" %>
  </div>
 <%end %>

--- a/app/views/sp_components/_all_sp_components.html.erb
+++ b/app/views/sp_components/_all_sp_components.html.erb
@@ -19,7 +19,7 @@
           <td class="govuk-table__cell" scope="row"><%= component.team&.name %></td>
           <td class="govuk-table__cell">
             <%= link_to t('components.view_link'), sp_component_path(component), class: 'govuk-button' %>
-            <%= link_to t('associate_team'), edit_sp_component_path(component), class: 'govuk-button' %>
+            <%= link_to t('team.associate_team'), edit_sp_component_path(component), class: 'govuk-button' %>
           </td>
         </tr>
       <% end %>

--- a/app/views/sp_components/edit.html.erb
+++ b/app/views/sp_components/edit.html.erb
@@ -13,6 +13,6 @@
     %>
   </div>
   <div class="govuk-form-group">
-    <%=f.submit t('admin.associate_team'), class: "govuk-button" %>
+    <%=f.submit t('team.associate_team'), class: "govuk-button" %>
  </div>
 <%end %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -42,7 +42,7 @@ Rails.application.configure do
   config.active_support.deprecation = :stderr
 
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = true
 
   config.middleware.use RackSessionAccess::Middleware
  

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,6 +62,7 @@ en:
   certificates:
     caption: "%{heading}"
     header_id: ID
+    header_name: Name
     header_usage: Usage
     header_enabled: Enabled
     header_last_updated: Last updated
@@ -131,6 +132,7 @@ en:
     heading: All teams
     name: Name
     add_team: Add new team
+    associate_team: Associate team
     new:
       heading: Add a team
       team_name_field: Team name
@@ -168,6 +170,5 @@ en:
   admin:
     title: Admin
     view_components: View components
-    associate_team: Associate team
     edit:
       heading: Associate team to

--- a/spec/system/visit_msa_component_edit_spec.rb
+++ b/spec/system/visit_msa_component_edit_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Edit MSA Component Page', type: :system do
       create_teams
       visit edit_msa_component_path(msa_component)
       select(team.name, from: 'component[team_id]')
-      click_button t('admin.associate_team')
+      click_button t('team.associate_team')
 
       expect(MsaComponent.last.team_id).to eq team.id
     end
@@ -26,7 +26,7 @@ RSpec.describe 'Edit MSA Component Page', type: :system do
       visit edit_msa_component_path(msa_component)
       select(team.name, from: 'component[team_id]')
       select('Select', from: 'component[team_id]')
-      click_button t('admin.associate_team')
+      click_button t('team.associate_team')
 
       expect(MsaComponent.last.team_id).to be_nil
     end

--- a/spec/system/visit_sp_component_edit_spec.rb
+++ b/spec/system/visit_sp_component_edit_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Edit SP Component Page', type: :system do
       create_teams
       visit edit_sp_component_path(sp_component)
       select(team.name, from: 'component[team_id]')
-      click_button t('admin.associate_team')
+      click_button t('team.associate_team')
 
       expect(SpComponent.last.team_id).to eq team.id
     end
@@ -25,7 +25,7 @@ RSpec.describe 'Edit SP Component Page', type: :system do
       visit edit_sp_component_path(sp_component)
       select(team.name, from: 'component[team_id]')
       select('Select', from: 'component[team_id]')
-      click_button t('admin.associate_team')
+      click_button t('team.associate_team')
 
       expect(SpComponent.last.team_id).to be_nil
     end


### PR DESCRIPTION
1. Enabled the raise an exception on missing translations
2. Eight tests failed
3. Fixed them :allthethings:

Given we're now using the localized content it makes sense to raise an error when
it's missing. By default, it will not fail and put the key name instead.
Enabling this in the test env to highlight missing content during tests.

