### PR TITLE
Add raven sentry for logging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,8 @@ gem 'request_store'
 
 gem 'email_validator'
 
+gem 'sentry-raven'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,8 @@ GEM
     factory_bot_rails (5.0.2)
       factory_bot (~> 5.0.2)
       railties (>= 4.2.0)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
     ffi (1.11.1)
     geckodriver-helper (0.24.0)
       archive-zip (~> 0.7)
@@ -154,6 +156,7 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.11.3)
     msgpack (1.3.0)
+    multipart-post (2.1.1)
     nio4r (2.4.0)
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
@@ -265,6 +268,8 @@ GEM
     selenium-webdriver (3.142.3)
       childprocess (>= 0.5, < 2.0)
       rubyzip (~> 1.2, >= 1.2.2)
+    sentry-raven (2.11.0)
+      faraday (>= 0.7.6, < 1.0)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -332,6 +337,7 @@ DEPENDENCIES
   rspec-rails
   sass-rails (~> 5.0)
   selenium-webdriver
+  sentry-raven
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,5 +40,7 @@ module VerifySelfService
 
     # User will be timed out after 15 minutes of inactivity
     config.session_inactivity = 15.minutes
+
+    config.filter_parameters << :temporary_password << :new_password << :password
   end
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,3 @@
+Raven.configure do |config|
+  config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
+end


### PR DESCRIPTION
### What

Add the Raven gem for sending errors to Sentry. The `SENTRY_DSN` envar was set in [this PR](https://github.com/alphagov/verify-infrastructure/pull/270). Sentry will automatically look for this on startup.

Also added some sensitive parameter filtering to Rails config just in case it. Sentry will not send these parameters should it come across them.

https://trello.com/c/lKcAMBvI/528-plug-the-app-to-sentry