### PR TITLE
Refactored stub client and allow client switching

### DIFF
--- a/config/initializers/services.rb
+++ b/config/initializers/services.rb
@@ -1,5 +1,7 @@
-module SelfService
+require 'auth/cognito_chooser'
+require 'auth/cognito_stub_client'
 
+module SelfService
   def self.register_service(name:, client:)
     @services ||= {}
 
@@ -10,52 +12,14 @@ module SelfService
     @services[name] || raise(ServiceNotRegisteredException.new(name))
   end
 
-  class ServiceNotRegisteredException < RuntimeError; end
-end
-
-def aws_access_key
-  Rails.application.secrets.cognito_aws_access_key_id
-end
-
-def aws_secret_key
-  Rails.application.secrets.cognito_aws_secret_access_key
-end
-
-def stub_client
-  Rails.application.secrets.cognito_client_id = SecureRandom.uuid
-  client = Aws::CognitoIdentityProvider::Client.new(stub_responses: true)
-  client.stub_responses(:initiate_auth, { challenge_name: nil, authentication_result: { access_token: "valid-token" }})
-  client.stub_responses(:respond_to_auth_challenge, { challenge_name: nil, authentication_result: {access_token: "valid-token" }})
-  client.stub_responses(:get_user, { username: '00000000-0000-0000-0000-000000000000', user_attributes:
-    [
-      { name: 'sub', value: '00000000-0000-0000-0000-000000000000' },
-      { name: 'custom:roles', value: 'gds' },
-      { name: 'email_verified', value: 'true' },
-      { name: 'phone_number_verified', value: 'true' },
-      { name: 'phone_number', value: '+447000000000' },
-      { name: 'given_name', value: 'Test' },
-      { name: 'family_name', value: 'User' },
-      { name: 'email', value: 'test@test.test' }
-    ],
-  preferred_mfa_setting: 'SOFTWARE_TOKEN_MFA',
-  user_mfa_setting_list: ['SOFTWARE_TOKEN_MFA'] })
-  client
-end
-
-def cognito_client
-  return Aws::CognitoIdentityProvider::Client.new if Rails.env == "production"
-
-  if aws_access_key.present? && aws_secret_key.present? && Rails.env != "test"
-    Aws::CognitoIdentityProvider::Client.new(
-      region: Rails.application.secrets.aws_region,
-      access_key_id: aws_access_key,
-      secret_access_key: aws_secret_key
-    )
-  elsif %w(test development).include? Rails.env
-    stub_client
-  else
-    raise StandandError("Unable to configure AWS Cognito Client.  Exiting.")
+  def self.service_present?(name)
+    self.service(name)
+    true
+  rescue SelfService::ServiceNotRegisteredException
+    false
   end
+
+  class ServiceNotRegisteredException < RuntimeError; end
 end
 
 def configuration(yaml_file_name)
@@ -68,12 +32,6 @@ rescue Errno::ENOENT
   {}
 end
 
-
-SelfService.register_service(
-  name: :cognito_client,
-  client: cognito_client
-)
-
 SelfService.register_service(
   name: :storage_client,
   client: ActiveStorage::Service.configure(
@@ -81,3 +39,5 @@ SelfService.register_service(
     configuration('storage.yml')
   )
 )
+
+CognitoChooser.new

--- a/lib/auth/cognito_chooser.rb
+++ b/lib/auth/cognito_chooser.rb
@@ -1,0 +1,53 @@
+class CognitoChooser
+  def initialize
+    Rails.logger.info "Loading cognito..."
+    if Rails.env.production?
+      Rails.logger.info "choosing production client"
+      register_production_client
+    elsif aws_access_key.present? && aws_secret_key.present? && Rails.env != 'test'
+      Rails.logger.info "choosing dev client"
+      register_dev_client
+    elsif %w(test development).include? Rails.env
+      Rails.logger.info "choosing stub client"
+      register_stub_client
+      CognitoStubClient.setup_stubs
+    else
+      raise StandandError('Unable to configure AWS Cognito Client.  Exiting.')
+    end
+  end
+
+  def aws_access_key
+    Rails.application.secrets.cognito_aws_access_key_id
+  end
+
+  def aws_secret_key
+    Rails.application.secrets.cognito_aws_secret_access_key
+  end
+
+  def register_client(client:, is_stub: true)
+    SelfService.register_service(name: :cognito_stub, client: is_stub.to_s)
+    SelfService.register_service(name: :cognito_client, client: client)
+  end
+
+  def register_production_client
+    register_client(
+      client: Aws::CognitoIdentityProvider::Client.new,
+      is_stub: false
+    )
+  end
+
+  def register_dev_client
+    register_client(client: Aws::CognitoIdentityProvider::Client.new(
+      region: Rails.application.secrets.aws_region,
+      access_key_id: aws_access_key,
+      secret_access_key: aws_secret_key
+    ), is_stub: false)
+  end
+
+  def register_stub_client
+    Rails.application.secrets.cognito_client_id = SecureRandom.uuid
+    register_client(
+      client: CognitoStubClient.stub_client
+    )
+  end
+end

--- a/lib/auth/cognito_stub_client.rb
+++ b/lib/auth/cognito_stub_client.rb
@@ -1,0 +1,61 @@
+class CognitoStubClient
+  # TODO Turn stub_user_hash into a JWT token which
+  # can be returned by the stub client
+  def self.stub_user_hash(role:, email_domain: "test.com")
+    { username: '00000000-0000-0000-0000-000000000000', user_attributes:
+      [
+        { name: 'sub', value: '00000000-0000-0000-0000-000000000000' },
+        { name: 'custom:roles', value: role },
+        { name: 'email_verified', value: 'true' },
+        { name: 'phone_number_verified', value: 'true' },
+        { name: 'phone_number', value: '+447000000000' },
+        { name: 'given_name', value: 'Daenerys' },
+        { name: 'family_name', value: 'Targaryen' },
+        { name: 'email', value: "daenerys.targaryen@#{email_domain}" }
+      ],
+    preferred_mfa_setting: 'SOFTWARE_TOKEN_MFA',
+    user_mfa_setting_list: %w[SOFTWARE_TOKEN_MFA] }
+  end
+
+  def self.stub_gds_user_hash
+    self.stub_user_hash(role: ROLE::GDS, email_domain: "digital.cabinet-office.gov.uk")
+  end
+
+  def self.setup_user(user_hash)
+    SelfService.service(:cognito_client).stub_responses(:get_user, user_hash)
+  end
+
+  def self.setup_stubs
+    SelfService.service(:cognito_client).stub_responses(
+      :initiate_auth,
+      challenge_name: nil, authentication_result: { access_token: "valid-token" }
+    )
+    SelfService.service(:cognito_client).stub_responses(
+      :respond_to_auth_challenge,
+      challenge_name: nil, authentication_result: { access_token: "valid-token" }
+    )
+    setup_user(stub_gds_user_hash)
+  end
+
+  def self.stub_client
+    Aws::CognitoIdentityProvider::Client.new(stub_responses: true)
+  end
+
+  def self.switch_client
+    return false if Rails.env.production?
+
+    if SelfService.service(:cognito_stub) == 'false'
+      real_client = SelfService.service(:cognito_client)
+      SelfService.register_service(name: :real_client, client: real_client)
+      SelfService.register_service(name: :cognito_client, client: stub_client)
+      setup_stubs
+      SelfService.register_service(name: :cognito_stub, client: 'true')
+    else
+      return false unless SelfService.service_present?(:real_client)
+
+      real_client = SelfService.service(:real_client)
+      SelfService.register_service(name: :cognito_client, client: real_client)
+      SelfService.register_service(name: :cognito_stub, client: 'false')
+    end
+  end
+end


### PR DESCRIPTION
This PR refactors the stub cognito client stuff in to its own module and allows for switching between the stub client and real client.  Next part will be to wire something up in the front end which allows the switch and then to assume roles.  This will be done on the profiles controller.