### PR TITLE
Pcijgfac add new s3 environment field to components

### DIFF
--- a/app/controllers/msa_components_controller.rb
+++ b/app/controllers/msa_components_controller.rb
@@ -43,7 +43,7 @@ class MsaComponentsController < ApplicationController
 private
 
   def component_params
-    params.require(:component).permit(:name, :entity_id, :team_id)
+    params.require(:component).permit(:name, :entity_id, :team_id, :environment)
   end
 
   def find_teams

--- a/app/controllers/sp_components_controller.rb
+++ b/app/controllers/sp_components_controller.rb
@@ -43,7 +43,7 @@ class SpComponentsController < ApplicationController
 private
 
   def component_params
-    params.require(:component).permit(:name, :component_type, :team_id)
+    params.require(:component).permit(:name, :component_type, :team_id, :environment)
   end
 
   def find_teams

--- a/app/models/new_msa_component_event.rb
+++ b/app/models/new_msa_component_event.rb
@@ -1,6 +1,6 @@
 class NewMsaComponentEvent < AggregatedEvent
   belongs_to_aggregate :msa_component
-  data_attributes :name, :entity_id
+  data_attributes :name, :entity_id, :environment
   validate :msa_has_entity_id
   validate :component_is_new, on: :create
   validate :name_is_present
@@ -13,6 +13,7 @@ class NewMsaComponentEvent < AggregatedEvent
     {
       name: name,
       component_type: COMPONENT_TYPE::MSA,
+      environment: environment,
       entity_id: entity_id,
       created_at: created_at
     }

--- a/app/models/new_msa_component_event.rb
+++ b/app/models/new_msa_component_event.rb
@@ -4,6 +4,7 @@ class NewMsaComponentEvent < AggregatedEvent
   validate :msa_has_entity_id
   validate :component_is_new, on: :create
   validate :name_is_present
+  validates_presence_of :environment
 
   def build_msa_component
     MsaComponent.new

--- a/app/models/new_sp_component_event.rb
+++ b/app/models/new_sp_component_event.rb
@@ -4,6 +4,7 @@ class NewSpComponentEvent < AggregatedEvent
 
   validate :name_is_present
   validate :component_is_new, on: :create
+  validates_presence_of :environment
   validates_inclusion_of :component_type,
                          in: [COMPONENT_TYPE::SP, COMPONENT_TYPE::VSP],
                          message: "must be either VSP or SP"

--- a/app/models/new_sp_component_event.rb
+++ b/app/models/new_sp_component_event.rb
@@ -1,6 +1,6 @@
 class NewSpComponentEvent < AggregatedEvent
   belongs_to_aggregate :sp_component
-  data_attributes :name, :component_type
+  data_attributes :name, :component_type, :environment
 
   validate :name_is_present
   validate :component_is_new, on: :create
@@ -16,6 +16,7 @@ class NewSpComponentEvent < AggregatedEvent
   def attributes_to_apply
     {
       name: name,
+      environment: environment,
       component_type: COMPONENT_TYPE::SP,
       vsp: component_type == COMPONENT_TYPE::VSP,
       created_at: created_at

--- a/app/views/msa_components/_all_msa_components.html.erb
+++ b/app/views/msa_components/_all_msa_components.html.erb
@@ -6,6 +6,7 @@
         <th class="govuk-table__header" scope="col"><%= t 'components.name' %></th>
         <th class="govuk-table__header" scope="col"><%= t 'components.entity_id' %></th>
         <th class="govuk-table__header" scope="col"><%= t 'components.team' %></th>
+        <th class="govuk-table__header" scope="col"><%= t 'components.environment' %></th>
         <th class="govuk-table__header" scope="col"></th>
       </tr>
     </thead>
@@ -15,6 +16,7 @@
           <td class="govuk-table__cell" scope="row"><%= component.name %></td>
           <td class="govuk-table__cell"><%= component.entity_id %></td>
           <td class="govuk-table__cell"><%= component.team&.name %></td>
+          <td class="govuk-table__cell"><%= component.environment %></td>
           <td class="govuk-table__cell">
             <%= link_to t('components.view_link'), msa_component_path(component) , class: 'govuk-button'  %>
             <%= link_to t('team.associate_team'), edit_msa_component_path(component), class: 'govuk-button' %>

--- a/app/views/msa_components/new.html.erb
+++ b/app/views/msa_components/new.html.erb
@@ -16,6 +16,9 @@
       <%=error_message_on(f.object.errors, :entity_id) %>
       <%= f.text_field :entity_id, class: "govuk-input#{@component.errors.key?(:entity_id) ? ' govuk-input--error' : ''}" %>
     </div>
+
+    <%= render "shared/component_environments", f: f %>
+
     <div class="govuk-form-group">
         <%=f.submit t('components.create_component', type: COMPONENT_TYPE::MSA_SHORT), class: "govuk-button", data: { module: "govuk-button" } %>
     </div>

--- a/app/views/shared/_component_environments.erb
+++ b/app/views/shared/_component_environments.erb
@@ -1,0 +1,9 @@
+<div class="govuk-form-group <%= 'govuk-form-group--error' if @component.errors.key?(:environment) %>">
+  <h3 class="govuk-heading-m"><%= t 'components.environment' %></h3>
+  <div class="govuk-radios">
+    <div class="govuk-radios__item ">
+      <%= f.radio_button :environment, ENVIRONMENT::STAGING, class: 'govuk-radios__input'  %>
+      <%= f.label :environment, ENVIRONMENT::STAGING.capitalize, class: 'govuk-label govuk-radios__label' %>
+    </div>
+  </div>
+</div>

--- a/app/views/sp_components/_all_sp_components.html.erb
+++ b/app/views/sp_components/_all_sp_components.html.erb
@@ -6,6 +6,7 @@
         <th class="govuk-table__header" scope="col"><%= t 'components.name' %></th>
         <th class="govuk-table__header" scope="col"><%= t 'events.type' %></th>
         <th class="govuk-table__header" scope="col"><%= t 'components.team' %></th>
+        <th class="govuk-table__header" scope="col"><%= t 'components.environment' %></th>
         <th class="govuk-table__header" scope="col"></th>
       </tr>
     </thead>
@@ -17,6 +18,7 @@
             <%= component.view_component_type(component.vsp) %>
           </td>
           <td class="govuk-table__cell" scope="row"><%= component.team&.name %></td>
+          <td class="govuk-table__cell" scope="row"><%= component.environment %></td>
           <td class="govuk-table__cell">
             <%= link_to t('components.view_link'), sp_component_path(component), class: 'govuk-button' %>
             <%= link_to t('team.associate_team'), edit_sp_component_path(component), class: 'govuk-button' %>

--- a/app/views/sp_components/new.html.erb
+++ b/app/views/sp_components/new.html.erb
@@ -25,6 +25,9 @@
         </div>
       </div>
     </div>
+
+    <%= render "shared/component_environments", f: f %>
+
     <div class="govuk-form-group">
         <%=f.submit t('components.create_component', type: COMPONENT_TYPE::SP_SHORT ), class: "govuk-button", data: { module: "govuk-button" } %>
     </div>

--- a/config/initializers/constants/environment.rb
+++ b/config/initializers/constants/environment.rb
@@ -1,0 +1,3 @@
+module ENVIRONMENT
+  STAGING = 'staging'.freeze
+end

--- a/config/initializers/constants/environment.rb
+++ b/config/initializers/constants/environment.rb
@@ -1,3 +1,3 @@
 module ENVIRONMENT
-  STAGING = 'staging'.freeze
+  STAGING = 'staging'
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -157,6 +157,7 @@ en:
     component_name_field: "%{type} Component name"
     component_type_field: "%{type} Component type"
     create_component: Create %{type} component
+    environment: Environment
     upload_component: Upload your %{type} component
     component_entity_id: "%{type} Component Entity ID"
     sign_cert_enabled: Signing Certificates (Enabled)

--- a/db/migrate/20190812105927_add_environment_to_sp_components.rb
+++ b/db/migrate/20190812105927_add_environment_to_sp_components.rb
@@ -1,0 +1,6 @@
+class AddEnvironmentToSpComponents < ActiveRecord::Migration[5.2]
+  def change
+    add_column :sp_components, :environment, :string
+    change_column :sp_components, :environment, :string, null: false
+  end
+end

--- a/db/migrate/20190812110003_add_environment_to_msa_components.rb
+++ b/db/migrate/20190812110003_add_environment_to_msa_components.rb
@@ -1,0 +1,6 @@
+class AddEnvironmentToMsaComponents < ActiveRecord::Migration[5.2]
+  def change
+    add_column :msa_components, :environment, :string
+    change_column :msa_components, :environment, :string, null: false
+  end
+end

--- a/db/migrate/20190813161922_drop_users_table.rb
+++ b/db/migrate/20190813161922_drop_users_table.rb
@@ -1,0 +1,9 @@
+class DropUsersTable < ActiveRecord::Migration[5.2]
+  def up
+    drop_table :users
+  end
+
+  def down
+    fail ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_07_134744) do
+ActiveRecord::Schema.define(version: 2019_08_12_110003) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -63,6 +63,7 @@ ActiveRecord::Schema.define(version: 2019_08_07_134744) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "team_id"
+    t.string "environment", null: false
     t.index ["team_id"], name: "index_msa_components_on_team_id"
   end
 
@@ -84,6 +85,7 @@ ActiveRecord::Schema.define(version: 2019_08_07_134744) do
     t.datetime "updated_at", null: false
     t.boolean "vsp", default: false
     t.integer "team_id"
+    t.string "environment", null: false
     t.index ["team_id"], name: "index_sp_components_on_team_id"
   end
 
@@ -93,6 +95,14 @@ ActiveRecord::Schema.define(version: 2019_08_07_134744) do
     t.datetime "updated_at", null: false
     t.string "team_alias"
     t.index ["name"], name: "index_teams_on_name", unique: true
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_12_110003) do
+ActiveRecord::Schema.define(version: 2019_08_13_161922) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -95,14 +95,6 @@ ActiveRecord::Schema.define(version: 2019_08_12_110003) do
     t.datetime "updated_at", null: false
     t.string "team_alias"
     t.index ["name"], name: "index_teams_on_name", unique: true
-  end
-
-  create_table "users", force: :cascade do |t|
-    t.string "email", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["email"], name: "index_users_on_email", unique: true
   end
 
 end

--- a/spec/factories/components.rb
+++ b/spec/factories/components.rb
@@ -1,10 +1,13 @@
 FactoryBot.define do
   factory :sp_component do
     component_type { COMPONENT_TYPE::SP }
+    name { 'Test Service Provider' }
+    environment { 'staging' }
   end
 
   factory :msa_component do
     component_type { COMPONENT_TYPE::MSA }
-    entity_id { 'https://test-entity-id'}
+    entity_id { 'https://test-entity-id' }
+    environment { 'staging' }
   end
 end

--- a/spec/factories/components.rb
+++ b/spec/factories/components.rb
@@ -2,12 +2,12 @@ FactoryBot.define do
   factory :sp_component do
     component_type { COMPONENT_TYPE::SP }
     name { 'Test Service Provider' }
-    environment { 'staging' }
+    environment { ENVIRONMENT::STAGING }
   end
 
   factory :msa_component do
     component_type { COMPONENT_TYPE::MSA }
     entity_id { 'https://test-entity-id' }
-    environment { 'staging' }
+    environment { ENVIRONMENT::STAGING }
   end
 end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -2,13 +2,13 @@ FactoryBot.define do
   factory :new_sp_component_event do
     name { SecureRandom.alphanumeric }
     component_type { COMPONENT_TYPE::SP }
-    environment { 'staging' }
+    environment { ENVIRONMENT::STAGING }
   end
 
   factory :new_msa_component_event do
     name { SecureRandom.alphanumeric }
     entity_id { 'https://test-entity-id' }
-    environment { 'staging' }
+    environment { ENVIRONMENT::STAGING }
   end
 
   factory :new_team_event do

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -2,11 +2,13 @@ FactoryBot.define do
   factory :new_sp_component_event do
     name { SecureRandom.alphanumeric }
     component_type { COMPONENT_TYPE::SP }
+    environment { 'staging' }
   end
 
   factory :new_msa_component_event do
     name { SecureRandom.alphanumeric }
     entity_id { 'https://test-entity-id' }
+    environment { 'staging' }
   end
 
   factory :new_team_event do

--- a/spec/models/certificate_spec.rb
+++ b/spec/models/certificate_spec.rb
@@ -8,9 +8,7 @@ RSpec.describe Certificate, type: :model do
     pki.generate_signed_cert(expires_in: 2.months).to_pem
   end
 
-  entity_id = 'http://test-entity-id'
-  component_params = { name: 'fake_name', entity_id: entity_id }
-  let(:component) { NewMsaComponentEvent.create(component_params).msa_component }
+  let(:component) { create(:msa_component) }
 
   it 'is valid with valid attributes' do
     expect(Certificate.new(usage: CERTIFICATE_USAGE::SIGNING, value: good_cert_value, component: component)).to be_valid

--- a/spec/models/disable_signing_certificate_event_spec.rb
+++ b/spec/models/disable_signing_certificate_event_spec.rb
@@ -5,8 +5,7 @@ RSpec.describe DisableSigningCertificateEvent, type: :model do
   root = PKI.new
   good_cert_value = root.generate_encoded_cert(expires_in: 2.months)
   expired_cert_value = root.generate_encoded_cert(expires_in: -2.months)
-  component_params = { component_type: COMPONENT_TYPE::SP, name: 'Test Service Provider' }
-  component = NewSpComponentEvent.create(component_params).sp_component
+  let(:component) { create(:sp_component) }
 
   let(:signing_certificate) do
     UploadCertificateEvent.create(

--- a/spec/models/enable_signing_certificate_event_spec.rb
+++ b/spec/models/enable_signing_certificate_event_spec.rb
@@ -6,8 +6,7 @@ RSpec.describe EnableSigningCertificateEvent, type: :model do
   root = PKI.new
   good_cert_value = root.generate_encoded_cert(expires_in: 2.months)
   expired_cert_value = root.generate_encoded_cert(expires_in: -2.months)
-  component_params = { component_type: COMPONENT_TYPE::SP, name: 'Test Service Provider' }
-  component = NewSpComponentEvent.create(component_params).sp_component
+  let(:component) { create(:sp_component) }
 
   let(:signing_certificate) do
     UploadCertificateEvent.create(

--- a/spec/models/new_msa_component_event_spec.rb
+++ b/spec/models/new_msa_component_event_spec.rb
@@ -3,13 +3,13 @@ require 'rails_helper'
 RSpec.describe NewMsaComponentEvent, type: :model do
   entity_id = 'http://test-entity-id'
 
-  include_examples 'has data attributes', NewMsaComponentEvent, %i[name entity_id]
-  include_examples 'is aggregated', NewMsaComponentEvent, name: 'New component', entity_id: entity_id
-  include_examples 'is a creation event', NewMsaComponentEvent, name: 'New component', entity_id: entity_id
+  include_examples 'has data attributes', NewMsaComponentEvent, %i[name entity_id environment]
+  include_examples 'is aggregated', NewMsaComponentEvent, name: 'New component', entity_id: entity_id, environment: 'staging'
+  include_examples 'is a creation event', NewMsaComponentEvent, name: 'New component', entity_id: entity_id, environment: 'staging'
 
   context 'name' do
     it 'must be provided' do
-      event = NewMsaComponentEvent.create(name: '', entity_id: entity_id)
+      event = build(:new_msa_component_event, name: '', entity_id: entity_id, environment: 'staging')
       expect(event).to_not be_valid
       expect(event.errors[:name]).to eql ['can\'t be blank']
     end

--- a/spec/models/new_msa_component_event_spec.rb
+++ b/spec/models/new_msa_component_event_spec.rb
@@ -14,4 +14,12 @@ RSpec.describe NewMsaComponentEvent, type: :model do
       expect(event.errors[:name]).to eql ['can\'t be blank']
     end
   end
+
+  context 'environment' do
+    it 'must be provided' do
+      event = build(:new_msa_component_event, name: 'New component', entity_id: entity_id, environment: '')
+      expect(event).to_not be_valid
+      expect(event.errors[:environment]).to eql ['can\'t be blank']
+    end
+  end
 end

--- a/spec/models/new_msa_component_event_spec.rb
+++ b/spec/models/new_msa_component_event_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe NewMsaComponentEvent, type: :model do
   entity_id = 'http://test-entity-id'
 
   include_examples 'has data attributes', NewMsaComponentEvent, %i[name entity_id environment]
-  include_examples 'is aggregated', NewMsaComponentEvent, name: 'New component', entity_id: entity_id, environment: 'staging'
-  include_examples 'is a creation event', NewMsaComponentEvent, name: 'New component', entity_id: entity_id, environment: 'staging'
+  include_examples 'is aggregated', NewMsaComponentEvent, name: 'New component', entity_id: entity_id, environment: ENVIRONMENT::STAGING
+  include_examples 'is a creation event', NewMsaComponentEvent, name: 'New component', entity_id: entity_id, environment: ENVIRONMENT::STAGING
 
   context 'name' do
     it 'must be provided' do
-      event = build(:new_msa_component_event, name: '', entity_id: entity_id, environment: 'staging')
+      event = build(:new_msa_component_event, name: '', entity_id: entity_id, environment: ENVIRONMENT::STAGING)
       expect(event).to_not be_valid
       expect(event.errors[:name]).to eql ['can\'t be blank']
     end

--- a/spec/models/new_sp_component_event_spec.rb
+++ b/spec/models/new_sp_component_event_spec.rb
@@ -2,13 +2,13 @@ require 'rails_helper'
 
 RSpec.describe NewSpComponentEvent, type: :model do
 
-  include_examples 'has data attributes', NewSpComponentEvent, %i[name component_type]
-  include_examples 'is aggregated', NewSpComponentEvent, name: 'New SP component', component_type: COMPONENT_TYPE::SP
-  include_examples 'is a creation event', NewSpComponentEvent, name: 'New component', component_type: COMPONENT_TYPE::SP
+  include_examples 'has data attributes', NewSpComponentEvent, %i[name component_type], environment: 'staging'
+  include_examples 'is aggregated', NewSpComponentEvent, name: 'New SP component', component_type: COMPONENT_TYPE::SP, environment: 'staging'
+  include_examples 'is a creation event', NewSpComponentEvent, name: 'New component', component_type: COMPONENT_TYPE::SP, environment: 'staging'
 
   context 'name' do
     it 'must be provided' do
-      event = NewSpComponentEvent.create(name: '')
+      event = build(:new_sp_component_event, name: '', environment: 'staging')
       expect(event).to_not be_valid
       expect(event.errors[:name]).to eql ['can\'t be blank']
     end
@@ -16,7 +16,7 @@ RSpec.describe NewSpComponentEvent, type: :model do
 
   context 'component type' do
     it 'must be provided' do
-      event = NewSpComponentEvent.create(component_type: '')
+      event = build(:new_sp_component_event, component_type: '', environment: 'staging')
       expect(event).to_not be_valid
       expect(event.errors[:component_type]).to eql ['must be either VSP or SP']
     end
@@ -28,7 +28,7 @@ RSpec.describe NewSpComponentEvent, type: :model do
       user = User.new
       user.user_id = user_id
       RequestStore.store[:user] = user
-      event = NewSpComponentEvent.create(name: 'New SP component', component_type: COMPONENT_TYPE::SP)
+      event = create(:new_sp_component_event)
 
       expect(event.user_id).to eql user_id
     end

--- a/spec/models/new_sp_component_event_spec.rb
+++ b/spec/models/new_sp_component_event_spec.rb
@@ -14,6 +14,14 @@ RSpec.describe NewSpComponentEvent, type: :model do
     end
   end
 
+  context 'environment' do
+    it 'must be provided' do
+      event = build(:new_sp_component_event, name: 'New component', environment: '')
+      expect(event).to_not be_valid
+      expect(event.errors[:environment]).to eql ['can\'t be blank']
+    end
+  end
+
   context 'component type' do
     it 'must be provided' do
       event = build(:new_sp_component_event, component_type: '', environment: 'staging')

--- a/spec/models/new_sp_component_event_spec.rb
+++ b/spec/models/new_sp_component_event_spec.rb
@@ -2,13 +2,13 @@ require 'rails_helper'
 
 RSpec.describe NewSpComponentEvent, type: :model do
 
-  include_examples 'has data attributes', NewSpComponentEvent, %i[name component_type], environment: 'staging'
-  include_examples 'is aggregated', NewSpComponentEvent, name: 'New SP component', component_type: COMPONENT_TYPE::SP, environment: 'staging'
-  include_examples 'is a creation event', NewSpComponentEvent, name: 'New component', component_type: COMPONENT_TYPE::SP, environment: 'staging'
+  include_examples 'has data attributes', NewSpComponentEvent, %i[name component_type], environment: ENVIRONMENT::STAGING
+  include_examples 'is aggregated', NewSpComponentEvent, name: 'New SP component', component_type: COMPONENT_TYPE::SP, environment: ENVIRONMENT::STAGING
+  include_examples 'is a creation event', NewSpComponentEvent, name: 'New component', component_type: COMPONENT_TYPE::SP, environment: ENVIRONMENT::STAGING
 
   context 'name' do
     it 'must be provided' do
-      event = build(:new_sp_component_event, name: '', environment: 'staging')
+      event = build(:new_sp_component_event, name: '', environment: ENVIRONMENT::STAGING)
       expect(event).to_not be_valid
       expect(event.errors[:name]).to eql ['can\'t be blank']
     end
@@ -24,7 +24,7 @@ RSpec.describe NewSpComponentEvent, type: :model do
 
   context 'component type' do
     it 'must be provided' do
-      event = build(:new_sp_component_event, component_type: '', environment: 'staging')
+      event = build(:new_sp_component_event, component_type: '', environment: ENVIRONMENT::STAGING)
       expect(event).to_not be_valid
       expect(event.errors[:component_type]).to eql ['must be either VSP or SP']
     end

--- a/spec/models/replace_encryption_certificate_event_spec.rb
+++ b/spec/models/replace_encryption_certificate_event_spec.rb
@@ -1,13 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ReplaceEncryptionCertificateEvent, type: :model do
-
-  entity_id = 'http://test-entity-id'
-  let(:component_name) { 'test component' }
-  let(:component) do
-    component_params = { name: component_name, entity_id: entity_id }
-    NewMsaComponentEvent.create(component_params).msa_component
-  end
+  let(:component) { create(:msa_component) }
   let(:root) { PKI.new }
   let(:x509_cert) { root.generate_encoded_cert(expires_in: 9.months) }
   let(:upload_encryption_cert) do

--- a/spec/models/upload_certificate_event_spec.rb
+++ b/spec/models/upload_certificate_event_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
   entity_id = 'http://test-entity-id'
   good_cert_value = root.generate_encoded_cert(expires_in: 2.months)
   component = NewMsaComponentEvent.create(
-    name: 'fake_name', entity_id: entity_id, environment: 'staging'
+    name: 'fake_name', entity_id: entity_id, environment: ENVIRONMENT::STAGING
   ).msa_component
 
   let(:msa_component) { create(:msa_component) }

--- a/spec/models/upload_certificate_event_spec.rb
+++ b/spec/models/upload_certificate_event_spec.rb
@@ -6,8 +6,12 @@ RSpec.describe UploadCertificateEvent, type: :model do
   root = PKI.new
   entity_id = 'http://test-entity-id'
   good_cert_value = root.generate_encoded_cert(expires_in: 2.months)
-  component_params = { name: 'fake_name', entity_id: entity_id }
-  component = NewMsaComponentEvent.create(component_params).msa_component
+  component = NewMsaComponentEvent.create(
+    name: 'fake_name', entity_id: entity_id, environment: 'staging'
+  ).msa_component
+
+  let(:msa_component) { create(:msa_component) }
+
   include_examples 'has data attributes', UploadCertificateEvent, %i[usage value component_id component_type]
   include_examples 'is aggregated', UploadCertificateEvent, usage: CERTIFICATE_USAGE::SIGNING, value: good_cert_value, component_id: component.id, component_type: component.component_type
   include_examples 'is a creation event', UploadCertificateEvent, usage: CERTIFICATE_USAGE::SIGNING, value: good_cert_value, component_id: component.id, component_type: component.component_type
@@ -24,7 +28,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
     let(:root) { PKI.new }
 
     it 'must error with invalid x509 certificate' do
-      event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: 'Not a valid certificate', component: component)
+      event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: 'Not a valid certificate', component: msa_component)
       expect(event).to_not be_valid
       expect(event.errors[:certificate]).to eql ['is not a valid x509 certificate']
     end
@@ -32,7 +36,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
     it 'must allow base64 encoded DER format x509 certificate' do
       cert = root.generate_encoded_cert(expires_in: 2.months)
 
-      event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert, component: component)
+      event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert, component: msa_component)
       expect(event.certificate.value).to eql(cert)
       expect(event).to be_valid
       expect(event.errors[:certificate]).to be_empty
@@ -41,7 +45,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
     it 'must allow PEM format x509 certificate and be stored as base64 encoded DER' do
       cert = root.generate_signed_cert(expires_in: 2.months)
 
-      event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert.to_pem, component: component)
+      event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert.to_pem, component: msa_component)
       expect(event.certificate.value).to eql(Base64.strict_encode64(cert.to_der))
       expect(event).to be_valid
       expect(event.errors[:certificate]).to be_empty
@@ -50,7 +54,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
     it 'must not be expired' do
       cert = root.generate_encoded_cert(expires_in: -1.months)
 
-      event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert, component: component)
+      event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert, component: msa_component)
       expect(event).to_not be_valid
       expect(event.errors[:certificate]).to eql ['has expired']
     end
@@ -58,7 +62,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
     it 'must not expire within 1 month' do
       cert = root.generate_encoded_cert(expires_in: 15.days)
 
-      event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert, component: component)
+      event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert, component: msa_component)
       expect(event).to_not be_valid
       expect(event.errors[:certificate]).to eql ['expires too soon']
     end
@@ -66,7 +70,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
     it 'must expire within 1 year' do
       cert = root.generate_encoded_cert(expires_in: 2.years)
 
-      event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert, component: component)
+      event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert, component: msa_component)
       expect(event).to_not be_valid
       expect(event.errors[:certificate]).to eql ['valid for too long']
     end
@@ -74,7 +78,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
     it 'must be RSA' do
       cert = root.generate_signed_ec_cert(6.months)
 
-      event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert.to_pem, component: component)
+      event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert.to_pem, component: msa_component)
       expect(event).to_not be_valid
       expect(event.errors[:certificate]).to eql ['in not RSA']
     end
@@ -82,7 +86,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
     it 'must be at least 2048 bits' do
       cert = root.generate_signed_rsa_cert_and_key(size: 1024)[0]
 
-      event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert.to_pem, component: component)
+      event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert.to_pem, component: msa_component)
       expect(event).to_not be_valid
       expect(event.errors[:certificate]).to eql ['key size is less than 2048']
     end
@@ -96,19 +100,19 @@ RSpec.describe UploadCertificateEvent, type: :model do
     end
 
     it 'must be signing or encryption' do
-      event = UploadCertificateEvent.create(usage: 'foobar', component: component)
+      event = UploadCertificateEvent.create(usage: 'foobar', component: msa_component)
       expect(event).to_not be_valid
       expect(event.errors[:usage]).to eql ['is not included in the list']
     end
 
     it 'happy when signing' do
-      event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, component: component)
+      event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, component: msa_component)
       expect(event).to_not be_valid
       expect(event.errors[:usage]).to be_empty
     end
 
     it 'happy when encryption' do
-      event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::ENCRYPTION, component: component)
+      event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::ENCRYPTION, component: msa_component)
       expect(event).to_not be_valid
       expect(event.errors[:usage]).to be_empty
     end
@@ -116,9 +120,9 @@ RSpec.describe UploadCertificateEvent, type: :model do
 
   context "#component" do
     it 'refreshes when component changes' do
-      event = UploadCertificateEvent.new(component: component)
-      expect(event.component).to eql component
-      second_component = NewMsaComponentEvent.create(component_params).msa_component
+      event = UploadCertificateEvent.new(component: msa_component)
+      expect(event.component).to eql msa_component
+      second_component = create(:msa_component)
 
       event.component = second_component
       expect(event.component).to_not eql component
@@ -130,17 +134,17 @@ RSpec.describe UploadCertificateEvent, type: :model do
     it 'will set component_id and component_type when called during ::create' do
       event = UploadCertificateEvent.create(
         usage: CERTIFICATE_USAGE::SIGNING,
-        component_id: component.id,
-        component_type: component.component_type
+        component_id: msa_component.id,
+        component_type: msa_component.component_type
       )
-      expect(event.component).to eql component
+      expect(event.component).to eql msa_component
     end
 
     it 'will set component_id when called directly' do
       event = UploadCertificateEvent.new
-      event.component = component
-      expect(event.component).to eql component
-      expect(event.component_id).to eql component.id
+      event.component = msa_component
+      expect(event.component).to eql msa_component
+      expect(event.component_id).to eql msa_component.id
     end
 
     it 'must be invalid when component is new' do
@@ -150,7 +154,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
     end
 
     it 'must be persisted' do
-      event = UploadCertificateEvent.create(component: component)
+      event = UploadCertificateEvent.create(component: msa_component)
       expect(event).to_not be_valid
       expect(event.errors[:component]).to be_empty
     end
@@ -163,7 +167,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
 
   context '#trigger_publish_event' do
     it 'is triggered on creation' do
-      event = UploadCertificateEvent.create!(usage: CERTIFICATE_USAGE::SIGNING, value: good_cert_value, component: component)
+      event = UploadCertificateEvent.create!(usage: CERTIFICATE_USAGE::SIGNING, value: good_cert_value, component: msa_component)
       publish_event = PublishServicesMetadataEvent.last
       expect(event.id).to_not be_nil
       expect(event.id).to eql publish_event.event_id

--- a/spec/system/user_visits_events_page_spec.rb
+++ b/spec/system/user_visits_events_page_spec.rb
@@ -2,9 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'the events page', type: :system do
   include CertificateSupport
-  entity_id = 'http://test-entity-id'
-  component_params = { name: 'fake_name', entity_id: entity_id }
-  let(:component) { NewMsaComponentEvent.create(component_params).msa_component }
+  let(:component) { create(:msa_component) }
   let(:root) { PKI.new }
   before(:each) do
     login_gds_user

--- a/spec/system/visit_msa_component_new_spec.rb
+++ b/spec/system/visit_msa_component_new_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe 'New MSA Component Page', type: :system do
       visit new_msa_component_path
       fill_in 'component_name', with: component_name
       fill_in 'component_entity_id', with: entity
+      choose('component_environment_staging')
       click_button 'Create MSA component'
 
       expect(current_path).to eql root_path
@@ -25,6 +26,7 @@ RSpec.describe 'New MSA Component Page', type: :system do
       visit new_msa_component_path
       fill_in 'component_name', with: component_name
       fill_in 'component_entity_id', with: entity
+      choose('component_environment_staging')
       click_button 'Create MSA component'
 
       expect(page).to have_content 'Entity id is required for MSA component'

--- a/spec/system/visit_sp_component_new_spec.rb
+++ b/spec/system/visit_sp_component_new_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'New SP Component Page', type: :system do
       component_name = 'test component'
       visit new_sp_component_path
       choose 'component_component_type_vspcomponent', allow_label_click: true
+      choose 'component_environment_staging'
       fill_in 'component_name', with: component_name
       click_button 'Create SP component'
 
@@ -22,6 +23,7 @@ RSpec.describe 'New SP Component Page', type: :system do
       component_name = ''
       visit new_sp_component_path
       choose 'component_component_type_vspcomponent', allow_label_click: true
+      choose 'component_environment_staging'
       fill_in 'component_name', with: component_name
       click_button 'Create SP component'
 

--- a/spec/system/visit_upload_page_spec.rb
+++ b/spec/system/visit_upload_page_spec.rb
@@ -6,10 +6,8 @@ RSpec.describe 'UploadPage', type: :system do
   before(:each) do
     login_certificate_manager_user
   end
-
-  entity_id = 'http://test-entity-id'
-  component_params = { name: 'fake_name', entity_id: entity_id }
-  let(:component) { NewMsaComponentEvent.create(component_params).msa_component }
+  
+  let(:component) { create(:msa_component) }
   let(:root) { PKI.new }
   let(:test_certificate) { root.generate_encoded_cert(expires_in: 2.months) }
 


### PR DESCRIPTION
[first task of support multiple environments card](https://trello.com/c/SGmDAu9A/603-support-multiple-environments) which would make it easier to proceed on the rest

The self-service app will be running in production, but will allow changing the certs in both hub production and hub integration environments.
We need to make appropriate changes to support that.

**Components should have a new attribute identifying to which environment the component belongs.**
The environment attribute is a required value on components
The app supports multiple buckets to write to
When a change is made and the publish metadata event is triggered it generates the correct metadata and write it the correct bucket