### PR TITLE
Judg1lll: support writing to multiple buckets

### DIFF
--- a/app/models/publish_services_metadata_event.rb
+++ b/app/models/publish_services_metadata_event.rb
@@ -3,7 +3,7 @@ require 'digest/md5'
 
 class PublishServicesMetadataEvent < Event
   attr_reader :metadata
-  data_attributes :event_id, :services_metadata
+  data_attributes :event_id, :services_metadata, :environment
   validates_presence_of :event_id
   before_create :populate_data_attributes
   after_create :upload
@@ -27,7 +27,7 @@ class PublishServicesMetadataEvent < Event
 private
 
   def storage_client
-    #return SelfService.service(:integration_storage_client) if environment == 'integration'
+    return SelfService.service(:integration_storage_client) if environment == ENVIRONMENT::INTEGRATION
 
     SelfService.service(:storage_client)
   end

--- a/app/models/publish_services_metadata_event.rb
+++ b/app/models/publish_services_metadata_event.rb
@@ -17,7 +17,7 @@ class PublishServicesMetadataEvent < Event
     json_data = metadata.to_json
     storage_key = "verify_services_metadata.json"
     check_sum = Digest::MD5.base64digest(json_data)
-    SelfService.service(:storage_client).upload(
+    storage_client.upload(
       storage_key,
       StringIO.new(json_data),
       checksum: check_sum
@@ -25,6 +25,12 @@ class PublishServicesMetadataEvent < Event
   end
 
 private
+
+  def storage_client
+    #return SelfService.service(:integration_storage_client) if environment == 'integration'
+
+    SelfService.service(:storage_client)
+  end
 
   def services_metadata
     Component.to_service_metadata(event_id)

--- a/app/models/trigger_metadata_event_callback.rb
+++ b/app/models/trigger_metadata_event_callback.rb
@@ -1,9 +1,22 @@
 class TriggerMetadataEventCallback
   def after_save(model)
-    PublishServicesMetadataEvent.create(event_id: model.id)
+    PublishServicesMetadataEvent.create(
+      event_id: model.id,
+      environment: environment(model)
+    )
   end
 
   def self.publish
     TriggerMetadataEventCallback.new
+  end
+
+private
+
+  def environment(model)
+    if model.aggregate.respond_to?(:component)
+      model.aggregate.component.environment
+    else
+      model.aggregate.environment
+    end
   end
 end

--- a/config/initializers/constants/environment.rb
+++ b/config/initializers/constants/environment.rb
@@ -1,3 +1,5 @@
 module ENVIRONMENT
-  STAGING = 'staging'
+  STAGING = 'staging'.freeze
+  INTEGRATION = 'integration'.freeze
+  PRODUCTION = 'production'.freeze
 end

--- a/config/initializers/services.rb
+++ b/config/initializers/services.rb
@@ -40,4 +40,14 @@ SelfService.register_service(
   )
 )
 
+if Rails.env.production?
+  SelfService.register_service(
+    name: :integration_storage_client,
+    client: ActiveStorage::Service.configure(
+      Rails.configuration.active_storage.service,
+      configuration('integration_storage.yml')
+    )
+  )
+end
+
 CognitoChooser.new

--- a/config/integration_storage.yml
+++ b/config/integration_storage.yml
@@ -15,22 +15,3 @@ amazon:
   bucket: <%=Rails.application.secrets.integration_aws_bucket %>
   upload:
     server_side_encryption: AES256
-
-# Remember not to checkin your GCS keyfile to a repository
-# google:
-#   service: GCS
-#   project: your_project
-#   credentials: <%= Rails.root.join("path/to/gcs.keyfile") %>
-#   bucket: your_own_bucket
-
-# Use rails credentials:edit to set the Azure Storage secret (as azure_storage:storage_access_key)
-# microsoft:
-#   service: AzureStorage
-#   storage_account_name: your_account_name
-#   storage_access_key: <%= Rails.application.credentials.dig(:azure_storage, :storage_access_key) %>
-#   container: your_container_name
-
-# mirror:
-#   service: Mirror
-#   primary: local
-#   mirrors: [ amazon, google, microsoft ]

--- a/config/integration_storage.yml
+++ b/config/integration_storage.yml
@@ -1,0 +1,36 @@
+test:
+  service: Disk
+  root: <%= Rails.root.join("tmp/storage") %>
+
+local:
+  service: Disk
+  root: <%= Rails.root.join("storage") %>
+
+# Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
+amazon:
+  service: S3
+  access_key_id: <%= Rails.application.secrets.integration_s3_aws_access_key_id %>
+  secret_access_key: <%= Rails.application.secrets.integration_s3_aws_secret_access_key %>
+  region: <%=Rails.application.secrets.integration_aws_region %>
+  bucket: <%=Rails.application.secrets.integration_aws_bucket %>
+  upload:
+    server_side_encryption: AES256
+
+# Remember not to checkin your GCS keyfile to a repository
+# google:
+#   service: GCS
+#   project: your_project
+#   credentials: <%= Rails.root.join("path/to/gcs.keyfile") %>
+#   bucket: your_own_bucket
+
+# Use rails credentials:edit to set the Azure Storage secret (as azure_storage:storage_access_key)
+# microsoft:
+#   service: AzureStorage
+#   storage_account_name: your_account_name
+#   storage_access_key: <%= Rails.application.credentials.dig(:azure_storage, :storage_access_key) %>
+#   container: your_container_name
+
+# mirror:
+#   service: Mirror
+#   primary: local
+#   mirrors: [ amazon, google, microsoft ]

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -17,3 +17,6 @@ production:
     s3_aws_access_key_id: <%= ENV["AWS_ACCESS_KEY_ID"] %>
     s3_aws_secret_access_key: <%= ENV["AWS_SECRET_ACCESS_KEY"] %>
     aws_bucket: <%= ENV["AWS_BUCKET"] %>
+    integration_s3_aws_access_key_id: <%= ENV["INTEGRATION_AWS_ACCESS_KEY_ID"] %>
+    integration_s3_aws_secret_access_key: <%= ENV["INTEGRATION_AWS_SECRET_ACCESS_KEY"] %>
+    integration_aws_bucket: <%= ENV["INTEGRATION_AWS_BUCKET"] %>

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -15,22 +15,3 @@ amazon:
   bucket: <%=Rails.application.secrets.aws_bucket %>
   upload:
     server_side_encryption: AES256
-
-# Remember not to checkin your GCS keyfile to a repository
-# google:
-#   service: GCS
-#   project: your_project
-#   credentials: <%= Rails.root.join("path/to/gcs.keyfile") %>
-#   bucket: your_own_bucket
-
-# Use rails credentials:edit to set the Azure Storage secret (as azure_storage:storage_access_key)
-# microsoft:
-#   service: AzureStorage
-#   storage_account_name: your_account_name
-#   storage_access_key: <%= Rails.application.credentials.dig(:azure_storage, :storage_access_key) %>
-#   container: your_container_name
-
-# mirror:
-#   service: Mirror
-#   primary: local
-#   mirrors: [ amazon, google, microsoft ]

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -97,4 +97,12 @@ ActiveRecord::Schema.define(version: 2019_08_13_161922) do
     t.index ["name"], name: "index_teams_on_name", unique: true
   end
 
+  create_table "users", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+  end
+
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -97,12 +97,4 @@ ActiveRecord::Schema.define(version: 2019_08_13_161922) do
     t.index ["name"], name: "index_teams_on_name", unique: true
   end
 
-  create_table "users", force: :cascade do |t|
-    t.string "email", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["email"], name: "index_users_on_email", unique: true
-  end
-
 end

--- a/lib/tasks/acceptance_tests.rake
+++ b/lib/tasks/acceptance_tests.rake
@@ -1,4 +1,5 @@
-unless ENV['RAILS_ENV'] == 'production'
+require_relative '../../config/initializers/constants/environment'
+unless ENV['RAILS_ENV'] == ENVIRONMENT::PRODUCTION
   require 'rspec/core/rake_task'
 
   desc 'Run acceptance tests'

--- a/spec/models/publish_services_event_metadata_spec.rb
+++ b/spec/models/publish_services_event_metadata_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe PublishServicesMetadataEvent, type: :model do
 
     it 'downloaded content is the same as upload with given key' do
       event.upload
-      key = "verify_services_metadata.json"
+      key = 'verify_services_metadata.json'
       expected_chunks = event.metadata
 
       actual_chunks = []
@@ -35,6 +35,40 @@ RSpec.describe PublishServicesMetadataEvent, type: :model do
       end
 
       expect(expected_chunks.to_json).to eq(actual_chunks.first)
+    end
+  end
+
+  context 'upload' do
+    before do
+      SelfService.register_service(
+        name: :integration_storage_client,
+        client: ActiveStorage::Service.configure(
+          Rails.configuration.active_storage.service,
+          configuration('integration_storage.yml')
+        )
+      )
+    end
+
+    it 'when environment is set to integration on component' do
+      expect(
+        SelfService.service(:integration_storage_client)
+      ).to receive(:upload)
+      expect(
+        SelfService.service(:storage_client)
+      ).not_to receive(:upload)
+
+      PublishServicesMetadataEvent.create(event_id: 0, environment: ENVIRONMENT::INTEGRATION)
+    end
+
+    it 'when environment is set to production on component' do
+      expect(
+        SelfService.service(:storage_client)
+      ).to receive(:upload)
+      expect(
+        SelfService.service(:integration_storage_client)
+      ).not_to receive(:upload)
+
+      PublishServicesMetadataEvent.create(event_id: 0, environment: ENVIRONMENT::PRODUCTION)
     end
   end
 end


### PR DESCRIPTION
Aim: [The app supports multiple buckets to write to](https://trello.com/c/JUdG1LLL/613-self-service-supports-writing-to-multiple-s3-buckets)

Background:

Currently Self Service is already set up to be deployed to a staging environment and to write config to a staging s3 bucket.

We want to extend Self Service to write to different s3 buckets, depending on either the environment of the app or the environment specified within the environment field on the component.

If Self Service is deployed to staging then it will write to a staging s3 bucket.

If Self Service is deployed to production it will write to either an integration or production S3 bucket, depending on which is specified within the environment field of the component in question