### PR TITLE
24HFwXaC Assume roles locally (frontend)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,14 @@
 -   repo: local
     hooks:
-    -   id: tests
-        name: tests
-        entry: ./pre-commit.sh
-        language: script
-        types: [ruby]
+    -   id: lint
+        name: govuk linter
+        entry: bundle exec govuk-lint-ruby app lib
+        language: system
+    -   id: bundle-check
+        name: bundle-check
+        entry: bundle check || bundle install
+        language: system
+    -   id: rake
+        name: rake testing
+        entry: bundle exec rake
+        language: system

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,7 @@
 -   repo: local
     hooks:
-    -   id: lint
-        name: govuk linter
-        entry: bundle exec govuk-lint-ruby app lib
-        language: system
-    -   id: bundle-check
-        name: bundle-check
-        entry: bundle check || bundle install
-        language: system
-    -   id: rake
-        name: rake testing
-        entry: bundle exec rake
-        language: system
+    -   id: tests
+        name: tests
+        entry: ./pre-commit.sh
+        language: script
+        types: [ruby]

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -2,7 +2,8 @@ class ProfileController < ApplicationController
   def show
     if Rails.env.development?
       @stub_available = true
-      @using_stub = CognitoStubClient.true?(SelfService.service(:cognito_stub))
+      @using_stub = CognitoStubClient.using_coginito_stub?(SelfService.service(:cognito_stub))
+      @cognito_available = SelfService.service_present?(:real_client)
       @breakerofchains = @using_stub && current_user.given_name == 'Daenerys'
     end
     @user = current_user

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -1,5 +1,36 @@
 class ProfileController < ApplicationController
   def show
+    if Rails.env.development?
+      @stub_available = true
+      @using_stub = CognitoStubClient.true?(SelfService.service(:cognito_stub))
+      @breakerofchains = @using_stub && current_user.given_name == 'Daenerys'
+    end
     @user = current_user
+  end
+
+  def switch_client
+    if params[:client] == 'cognito'
+      CognitoStubClient.switch_to_cognito
+      flash[:notice] = 'Switched to Cognito Auth Client'
+    elsif params[:client] == 'stub'
+      CognitoStubClient.switch_to_stub
+      flash[:notice] = 'Switched to Stub Auth Client'
+    end
+    redirect_to profile_path
+  end
+
+  def update_role
+    role_str = params[:assume_roles][:role_selection].join(',')
+    if params[:assume_roles][:role_selection].include?(ROLE::GDS)
+      CognitoStubClient.update_user(
+        role: role_str, email_domain: 'digital.cabinet-office.gov.uk'
+      )
+    else
+      CognitoStubClient.update_user(role: role_str)
+    end
+    UserSignOutEvent.create(user_id: warden.user.user_id)
+    signed_out = (Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name))
+    flash[:notice] = 'You need to sign in again for role changes to take effect' if signed_out
+    redirect_to root_path
   end
 end

--- a/app/policies/profile_controller_policy.rb
+++ b/app/policies/profile_controller_policy.rb
@@ -2,4 +2,16 @@ class ProfileControllerPolicy < ApplicationPolicy
   def show?
     true
   end
+
+  def switch_client?
+    return false unless Rails.env.development?
+
+    true
+  end
+
+  def update_role?
+    return false unless Rails.env.development?
+
+    true
+  end
 end

--- a/app/views/profile/show.html.erb
+++ b/app/views/profile/show.html.erb
@@ -1,4 +1,4 @@
-<% if !Rails.env.production? %>
+<% if Rails.env.development? %>
   <div class="govuk-phase-banner">
     <p class="govuk-phase-banner__content">
       <strong class="govuk-tag govuk-phase-banner__content__tag">
@@ -72,50 +72,52 @@
     </div>
   </div>
   <% if Rails.env.development? %>
-    <div class="govuk-accordion__section ">
-      <div class="govuk-accordion__section-header">
-        <h2 class="govuk-accordion__section-heading">
-          <span class="govuk-accordion__section-button" id="accordion-default-heading-2">
-            <%= t 'profile.client_switch_h' %>
-          </span>
-          <strong class="govuk-tag">
-            dev
-          </strong>
-        </h2>
-      </div>
-      <div id="accordion-default-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1">
-        <div class="govuk-form-group">
-          <%= form_for:client_switch, url: profile_switch_client_path do |f| %>
-          <fieldset class="govuk-fieldset" aria-describedby="changed-name-hint">
-            <span id="changed-name-hint" class="govuk-hint">
-              <%= t 'profile.client_switch_l' %>
+    <% if @cognito_available %>
+      <div class="govuk-accordion__section ">
+        <div class="govuk-accordion__section-header">
+          <h2 class="govuk-accordion__section-heading">
+            <span class="govuk-accordion__section-button" id="accordion-default-heading-2">
+              <%= t 'profile.client_switch_heading' %>
             </span>
-            <div class="govuk-radios govuk-radios--inline">
-              <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="cognito-radio" name="client" type="radio" value="cognito" <% if !@using_stub %> checked<% end %>>
-                <label class="govuk-label govuk-radios__label" for="cognito-radio">
-                  Cognito Client
-                </label>
+            <strong class="govuk-tag">
+              dev
+            </strong>
+          </h2>
+        </div>
+        <div id="accordion-default-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1">
+          <div class="govuk-form-group">
+            <%= form_for:client_switch, url: profile_switch_client_path do |f| %>
+            <fieldset class="govuk-fieldset" aria-describedby="changed-name-hint">
+              <span id="changed-name-hint" class="govuk-hint">
+                <%= t 'profile.client_switch_legend' %>
+              </span>
+              <div class="govuk-radios govuk-radios--inline">
+                <div class="govuk-radios__item">
+                  <input class="govuk-radios__input" id="cognito-radio" name="client" type="radio" value="cognito" <% if !@using_stub %> checked<% end %>>
+                  <label class="govuk-label govuk-radios__label" for="cognito-radio">
+                    Cognito Client
+                  </label>
+                </div>
+                <div class="govuk-radios__item">
+                  <input class="govuk-radios__input" id="stub-radio" name="client" type="radio" value="stub" <% if @using_stub %> checked<% end %>>
+                  <label class="govuk-label govuk-radios__label" for="stub-radio">
+                    Stub Client
+                  </label>
+                </div>
               </div>
-              <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="stub-radio" name="client" type="radio" value="stub" <% if @using_stub %> checked<% end %>>
-                <label class="govuk-label govuk-radios__label" for="stub-radio">
-                  Stub Client
-                </label>
-              </div>
-            </div>
-          </fieldset>
-          <%= f.submit "Switch Client", class: "govuk-button govuk-!-margin-top-6", data: { module: "govuk-button" } %>
-          <% end %>
+            </fieldset>
+            <%= f.submit "Switch Client", class: "govuk-button govuk-!-margin-top-6", data: { module: "govuk-button" } %>
+            <% end %>
+          </div>
         </div>
       </div>
-    </div>
+    <% end %>
     <% if @using_stub %>
       <div class="govuk-accordion__section ">
         <div class="govuk-accordion__section-header">
           <h2 class="govuk-accordion__section-heading">
             <span class="govuk-accordion__section-button" id="accordion-default-heading-2">
-              <%= t 'profile.assume_roles_h' %>
+              <%= t 'profile.assume_roles_heading' %>
             </span>
             <strong class="govuk-tag">
               dev
@@ -127,7 +129,7 @@
             <div class="govuk-form-group">
               <fieldset class="govuk-fieldset" aria-describedby="assume-roles-hint">
                 <span id="assume-roles-hint" class="govuk-hint">
-                  <%= t 'profile.assume_roles_l' %>
+                  <%= t 'profile.assume_roles_legend' %>
                 </span>
                 <div class="govuk-checkboxes">
                   

--- a/app/views/profile/show.html.erb
+++ b/app/views/profile/show.html.erb
@@ -1,3 +1,18 @@
+<% if !Rails.env.production? %>
+  <div class="govuk-phase-banner">
+    <p class="govuk-phase-banner__content">
+      <strong class="govuk-tag govuk-phase-banner__content__tag">
+        development
+      </strong>
+      <span class="govuk-phase-banner__text">
+        <%= t 'profile.banner' %>
+      </span>
+    </p>
+  </div>
+
+
+  <p>&nbsp;</p>
+<%end%>
 <h1  class="govuk-heading-l"><%= t 'profile.title' %></h1>
 
 <div>
@@ -30,26 +45,110 @@
       </h2>
     </div>
     <div id="accordion-default-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
-      <table class="govuk-table">
-        <thead class="govuk-table__head">
-          <tr class="govuk-table__row">
-            <th scope="col" class="govuk-table__header"><%= t 'profile.permissions' %></th>
-            <th scope="col" class="govuk-table__header"><%= t 'profile.access' %></th>
-          </tr>
-        </thead>
-        <tbody class="govuk-table__body">
-          <% @user.permissions.to_hash.each do |key, value| -%>
-            <tr class="govuk-table__row">
-              <td class="govuk-table__cell"><%= key.titlecase %></th>
-              <td class="govuk-table__cell">
-                <% if value %>
-                  &#9989;
-                <% end %>
-              </td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>  
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
+          <div class="govuk-checkboxes">
+            <% @user.permissions.to_hash.each do |key, value| -%>
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="<% key %>" name="<% key %>" type="checkbox" value="<% key %>"
+                <% if value %>checked<% end %> disabled>
+                <label class="govuk-label govuk-checkboxes__label" for="key">
+                  <%= key.titlecase %>
+                </label>
+              </div>
+            <% end %>
+            <% if @breakerofchains %>
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="breaker_of_chains" name="breaker_of_chains" type="checkbox" value="breaker_of_chains"
+                checked disabled>
+                <label class="govuk-label govuk-checkboxes__label" for="breaker_of_chains">
+                  Breaker of Chains
+                </label>
+              </div>
+            <% end %>
+          </div>
+        </fieldset>
+      </div>
     </div>
   </div>
+  <% if Rails.env.development? %>
+    <div class="govuk-accordion__section ">
+      <div class="govuk-accordion__section-header">
+        <h2 class="govuk-accordion__section-heading">
+          <span class="govuk-accordion__section-button" id="accordion-default-heading-2">
+            <%= t 'profile.client_switch_h' %>
+          </span>
+          <strong class="govuk-tag">
+            dev
+          </strong>
+        </h2>
+      </div>
+      <div id="accordion-default-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1">
+        <div class="govuk-form-group">
+          <%= form_for:client_switch, url: profile_switch_client_path do |f| %>
+          <fieldset class="govuk-fieldset" aria-describedby="changed-name-hint">
+            <span id="changed-name-hint" class="govuk-hint">
+              <%= t 'profile.client_switch_l' %>
+            </span>
+            <div class="govuk-radios govuk-radios--inline">
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="cognito-radio" name="client" type="radio" value="cognito" <% if !@using_stub %> checked<% end %>>
+                <label class="govuk-label govuk-radios__label" for="cognito-radio">
+                  Cognito Client
+                </label>
+              </div>
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="stub-radio" name="client" type="radio" value="stub" <% if @using_stub %> checked<% end %>>
+                <label class="govuk-label govuk-radios__label" for="stub-radio">
+                  Stub Client
+                </label>
+              </div>
+            </div>
+          </fieldset>
+          <%= f.submit "Switch Client", class: "govuk-button govuk-!-margin-top-6", data: { module: "govuk-button" } %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+    <% if @using_stub %>
+      <div class="govuk-accordion__section ">
+        <div class="govuk-accordion__section-header">
+          <h2 class="govuk-accordion__section-heading">
+            <span class="govuk-accordion__section-button" id="accordion-default-heading-2">
+              <%= t 'profile.assume_roles_h' %>
+            </span>
+            <strong class="govuk-tag">
+              dev
+            </strong>
+          </h2>
+        </div>
+        <div id="accordion-default-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1">
+           <%= form_for:assume_roles, url: profile_update_role_path do |f| %>
+            <div class="govuk-form-group">
+              <fieldset class="govuk-fieldset" aria-describedby="assume-roles-hint">
+                <span id="assume-roles-hint" class="govuk-hint">
+                  <%= t 'profile.assume_roles_l' %>
+                </span>
+                <div class="govuk-checkboxes">
+                  
+                  <% ROLE.constants.each do |role| -%>
+                  <% role_string = "ROLE::#{role}".constantize %>
+                  <% is_checked = @user.roles.split(',').include?(role_string) %>
+                    <div class="govuk-checkboxes__item">
+                      <%= f.check_box 'role_selection', { :checked => is_checked,:multiple => true, :class => "govuk-checkboxes__input" }, role_string, nil  %>
+                      
+                      <label class="govuk-label govuk-checkboxes__label" for="assume_roles_role_selection_<%= role_string %>">
+                        <% if role.to_s == 'GDS' %><%= role %><% else %><%= role.to_s.titlecase %><% end %>
+                      </label>
+                    </div>
+                  <% end %>
+                </div>
+              </fieldset>
+              <%= f.submit "Update Roles and Logout", class: "govuk-button govuk-!-margin-top-6", data: { module: "govuk-button" } %>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -89,11 +89,11 @@ en:
     permissions: "Permissions"
     permissions_heading: "Your Permissions"
     access: "Access"
-    client_switch_h: "Switch Authentication Clients"
-    client_switch_l: "In development you can switch between using cognito and the stub authenication clients. If you use the stub client you can assume different roles."
+    client_switch_heading: "Switch Authentication Clients"
+    client_switch_legend: "In development you can switch between using cognito and the stub authentication clients. If you use the stub client you can assume different roles."
     banner: "There are features on this page which are only avialable in the development environment."
-    assume_roles_h: "Switch Roles"
-    assume_roles_l: "Select which role(s) you wish to assume?"
+    assume_roles_heading: "Switch Roles"
+    assume_roles_legend: "Select which role(s) you wish to assume?"
   events:
     title: Events
     type: Type

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -89,6 +89,11 @@ en:
     permissions: "Permissions"
     permissions_heading: "Your Permissions"
     access: "Access"
+    client_switch_h: "Switch Authentication Clients"
+    client_switch_l: "In development you can switch between using cognito and the stub authenication clients. If you use the stub client you can assume different roles."
+    banner: "There are features on this page which are only avialable in the development environment."
+    assume_roles_h: "Switch Roles"
+    assume_roles_l: "Select which role(s) you wish to assume?"
   events:
     title: Events
     type: Type

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.routes.draw do
   resources :teams, path: 'admin/teams', only: %i[index new create]
 
@@ -42,5 +44,6 @@ Rails.application.routes.draw do
   post '/mfa-enrolment', to: 'mfa#enrol', as: :enrol_to_mfa
 
   get 'profile', to: 'profile#show'
-
+  post 'profile/switch-client', to: 'profile#switch_client'
+  post 'profile/update-role', to: 'profile#update_role'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 Rails.application.routes.draw do
   resources :teams, path: 'admin/teams', only: %i[index new create]
 

--- a/lib/auth/cognito_chooser.rb
+++ b/lib/auth/cognito_chooser.rb
@@ -26,6 +26,7 @@ class CognitoChooser
 
   def register_client(client:, is_stub: true)
     SelfService.register_service(name: :cognito_stub, client: is_stub.to_s)
+    SelfService.register_service(name: :real_client, client: client) unless is_stub
     SelfService.register_service(name: :cognito_client, client: client)
   end
 

--- a/lib/auth/cognito_chooser.rb
+++ b/lib/auth/cognito_chooser.rb
@@ -46,6 +46,7 @@ class CognitoChooser
 
   def register_stub_client
     Rails.application.secrets.cognito_client_id = SecureRandom.uuid
+    Rails.application.secrets.cognito_user_pool_id = SecureRandom.uuid
     register_client(
       client: CognitoStubClient.stub_client
     )

--- a/lib/auth/cognito_stub_client.rb
+++ b/lib/auth/cognito_stub_client.rb
@@ -25,6 +25,11 @@ class CognitoStubClient
     SelfService.service(:cognito_client).stub_responses(:get_user, user_hash)
   end
 
+  def self.update_user(role:, email_domain: "test.com")
+    user_hash = stub_user_hash(role: role, email_domain: email_domain)
+    setup_user(user_hash)
+  end
+
   def self.setup_stubs
     SelfService.service(:cognito_client).stub_responses(
       :initiate_auth,
@@ -41,21 +46,47 @@ class CognitoStubClient
     Aws::CognitoIdentityProvider::Client.new(stub_responses: true)
   end
 
+  def self.switch_to_cognito
+    # Exit if we are already a cognito client
+    return "already cognito" if false?(SelfService.service(:cognito_stub))
+    # Exit if there isn't a cognito client available to switch to
+    return "no cognito client" unless SelfService.service_present?(:real_client)
+
+    real_client = SelfService.service(:real_client)
+    SelfService.register_service(name: :cognito_client, client: real_client)
+    SelfService.register_service(name: :cognito_stub, client: 'false')
+    "switched to cognito"
+  end
+
+  def self.switch_to_stub
+    # Exit if we are in production we don't want a stub in production
+    return "in prod" if Rails.env.production?
+    # Exit if we're already a stub client
+    return "already stub" unless false?(SelfService.service(:cognito_stub))
+
+    real_client = SelfService.service(:cognito_client)
+    SelfService.register_service(name: :real_client, client: real_client)
+    SelfService.register_service(name: :cognito_client, client: stub_client)
+    setup_stubs
+    SelfService.register_service(name: :cognito_stub, client: 'true')
+    "switched to stub"
+  end
+
   def self.switch_client
     return false if Rails.env.production?
 
-    if SelfService.service(:cognito_stub) == 'false'
-      real_client = SelfService.service(:cognito_client)
-      SelfService.register_service(name: :real_client, client: real_client)
-      SelfService.register_service(name: :cognito_client, client: stub_client)
-      setup_stubs
-      SelfService.register_service(name: :cognito_stub, client: 'true')
+    if false?(SelfService.service(:cognito_stub))
+      switch_to_stub
     else
-      return false unless SelfService.service_present?(:real_client)
-
-      real_client = SelfService.service(:real_client)
-      SelfService.register_service(name: :cognito_client, client: real_client)
-      SelfService.register_service(name: :cognito_stub, client: 'false')
+      switch_to_cognito
     end
+  end
+
+  def self.true?(obj)
+    obj.to_s.downcase == 'true'
+  end
+
+  def self.false?(obj)
+    obj.to_s.downcase == 'false'
   end
 end

--- a/lib/auth/cognito_stub_client.rb
+++ b/lib/auth/cognito_stub_client.rb
@@ -48,45 +48,39 @@ class CognitoStubClient
 
   def self.switch_to_cognito
     # Exit if we are already a cognito client
-    return "already cognito" if false?(SelfService.service(:cognito_stub))
+    return false unless using_coginito_stub?(SelfService.service(:cognito_stub))
     # Exit if there isn't a cognito client available to switch to
-    return "no cognito client" unless SelfService.service_present?(:real_client)
+    return false unless SelfService.service_present?(:real_client)
 
     real_client = SelfService.service(:real_client)
     SelfService.register_service(name: :cognito_client, client: real_client)
     SelfService.register_service(name: :cognito_stub, client: 'false')
-    "switched to cognito"
   end
 
   def self.switch_to_stub
     # Exit if we are in production we don't want a stub in production
-    return "in prod" if Rails.env.production?
+    return false if Rails.env.production?
     # Exit if we're already a stub client
-    return "already stub" unless false?(SelfService.service(:cognito_stub))
+    return false if using_coginito_stub?(SelfService.service(:cognito_stub))
 
     real_client = SelfService.service(:cognito_client)
     SelfService.register_service(name: :real_client, client: real_client)
     SelfService.register_service(name: :cognito_client, client: stub_client)
     setup_stubs
     SelfService.register_service(name: :cognito_stub, client: 'true')
-    "switched to stub"
   end
 
   def self.switch_client
     return false if Rails.env.production?
 
-    if false?(SelfService.service(:cognito_stub))
+    if !using_coginito_stub?(SelfService.service(:cognito_stub))
       switch_to_stub
     else
       switch_to_cognito
     end
   end
 
-  def self.true?(obj)
+  def self.using_coginito_stub?(obj)
     obj.to_s.downcase == 'true'
-  end
-
-  def self.false?(obj)
-    obj.to_s.downcase == 'false'
   end
 end

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -35,4 +35,14 @@ bundle exec govuk-lint-ruby app lib
 
 bundle check || bundle install
 
-bundle exec rake
+echo -e "[RSPEC] --> init (wait a second)"
+
+FAILS=`bundle exec rake | grep -E '(\d*) failure(s?)' -o | awk '{print $1}'`
+
+if [ $FAILS -ne 0 ]; then
+  echo -e "[RSPEC] --> ✋ Can't commit! You've broken $FAILS tests!!!"
+  exit 1
+else
+  echo -e "[RSPEC] --> 👍 Commit approved."
+  exit 0
+fi

--- a/spec/controllers/profile_controller_spec.rb
+++ b/spec/controllers/profile_controller_spec.rb
@@ -1,20 +1,70 @@
 require 'rails_helper'
 
 RSpec.describe ProfileController, type: :controller do
-  describe "Login Successfully" do
-    it "redirect to login if no user" do
-      get :show
-      expect(response.status).to eq(302)
+  after(:each) do
+    Rails.env = 'test'
+  end
+
+  describe "Profile Controller" do
+    context 'logging in' do
+      it "redirect to login if no user" do
+        get :show
+        expect(response.status).to eq(302)
+      end
+
+      it "get profile if have user" do
+        @request.env["devise.mapping"] = Devise.mappings[:user]
+        user = FactoryBot.create(:user)
+        allow(request.env['warden']).to receive(:authenticate!).and_return(@user)
+        allow(controller).to receive(:current_user).and_return(@user)
+        sign_in user
+        get :show
+        expect(response.status).to eq(200)
+      end
+    end
+    
+    context 'running in test' do
+      it "profile does not populate instance variables when in test" do
+        @request.env["devise.mapping"] = Devise.mappings[:user]
+        @user = FactoryBot.create(:user)
+        allow(request.env['warden']).to receive(:authenticate!).and_return(@user)
+        allow(controller).to receive(:current_user).and_return(@user)
+        sign_in @user
+        get :show
+        expect(@controller.instance_variable_get(:@stub_available)).to eq(nil)
+        expect(@controller.instance_variable_get(:@breakerofchains)).to eq(nil)
+        expect(@controller.instance_variable_get(:@using_stub)).to eq(nil)
+      end
     end
 
-    it "get profile if have user" do
-      @request.env["devise.mapping"] = Devise.mappings[:user]
-      user = FactoryBot.create(:user)
-      allow(request.env['warden']).to receive(:authenticate!).and_return(@user)
-      allow(controller).to receive(:current_user).and_return(@user)
-      sign_in user
-      get :show
-      expect(response.status).to eq(200)
+    context 'running in production' do
+      it "profile populates instance variables when in production" do
+        Rails.env = 'production'
+        @request.env["devise.mapping"] = Devise.mappings[:user]
+        @user = FactoryBot.create(:user)
+        allow(request.env['warden']).to receive(:authenticate!).and_return(@user)
+        allow(controller).to receive(:current_user).and_return(@user)
+        sign_in @user
+        get :show
+        expect(@controller.instance_variable_get(:@stub_available)).to eq(nil)
+        expect(@controller.instance_variable_get(:@breakerofchains)).to eq(nil)
+        expect(@controller.instance_variable_get(:@using_stub)).to eq(nil)
+      end
+    end
+    
+    context 'running in development' do
+      it "profile populates instance variables when in development" do
+        Rails.env = 'development'
+        @request.env["devise.mapping"] = Devise.mappings[:user]
+        @user = FactoryBot.create(:user)
+        allow(request.env['warden']).to receive(:authenticate!).and_return(@user)
+        allow(controller).to receive(:current_user).and_return(@user)
+        sign_in @user
+        get :show
+        expect(@controller.instance_variable_get(:@stub_available)).to eq(true)
+        expect(@controller.instance_variable_get(:@breakerofchains)).to eq(false)
+        expect(@controller.instance_variable_get(:@using_stub)).to eq(true)
+      end
     end
   end
 end


### PR DESCRIPTION
### What
A page (profile) where the dev users can assume different roles as defined in the previous card. We can assume multiple roles (check boxes).

### Why
This will enable us testing different roles.

### Whatelse
This PR also has some small changes to pre-commit to help it run better and some tweaks to the previous backend work.