### PR TITLE
Rename constant

### DIFF
--- a/app/models/publish_services_metadata_event.rb
+++ b/app/models/publish_services_metadata_event.rb
@@ -27,7 +27,7 @@ class PublishServicesMetadataEvent < Event
 private
 
   def storage_client
-    return SelfService.service(:integration_storage_client) if environment == ENVIRONMENT::INTEGRATION
+    return SelfService.service(:integration_storage_client) if environment == S3::ENVIRONMENT::INTEGRATION
 
     SelfService.service(:storage_client)
   end

--- a/app/views/shared/_component_environments.erb
+++ b/app/views/shared/_component_environments.erb
@@ -2,8 +2,8 @@
   <h3 class="govuk-heading-m"><%= t 'components.environment' %></h3>
   <div class="govuk-radios">
     <div class="govuk-radios__item ">
-      <%= f.radio_button :environment, ENVIRONMENT::STAGING, class: 'govuk-radios__input'  %>
-      <%= f.label :environment, ENVIRONMENT::STAGING.capitalize, class: 'govuk-label govuk-radios__label' %>
+      <%= f.radio_button :environment, S3::ENVIRONMENT::STAGING, class: 'govuk-radios__input'  %>
+      <%= f.label :environment, S3::ENVIRONMENT::STAGING.capitalize, class: 'govuk-label govuk-radios__label' %>
     </div>
   </div>
 </div>

--- a/config/initializers/constants/environment.rb
+++ b/config/initializers/constants/environment.rb
@@ -1,5 +1,0 @@
-module ENVIRONMENT
-  STAGING = 'staging'.freeze
-  INTEGRATION = 'integration'.freeze
-  PRODUCTION = 'production'.freeze
-end

--- a/config/initializers/constants/s3_environment.rb
+++ b/config/initializers/constants/s3_environment.rb
@@ -1,0 +1,7 @@
+module S3
+  module ENVIRONMENT
+    STAGING = 'staging'.freeze
+    INTEGRATION = 'integration'.freeze
+    PRODUCTION = 'production'.freeze
+  end
+end

--- a/lib/tasks/acceptance_tests.rake
+++ b/lib/tasks/acceptance_tests.rake
@@ -1,5 +1,4 @@
-require_relative '../../config/initializers/constants/environment'
-unless ENV['RAILS_ENV'] == ENVIRONMENT::PRODUCTION
+unless ENV['RAILS_ENV'] == 'production'
   require 'rspec/core/rake_task'
 
   desc 'Run acceptance tests'

--- a/spec/factories/components.rb
+++ b/spec/factories/components.rb
@@ -2,12 +2,12 @@ FactoryBot.define do
   factory :sp_component do
     component_type { COMPONENT_TYPE::SP }
     name { 'Test Service Provider' }
-    environment { ENVIRONMENT::STAGING }
+    environment { S3::ENVIRONMENT::STAGING }
   end
 
   factory :msa_component do
     component_type { COMPONENT_TYPE::MSA }
     entity_id { 'https://test-entity-id' }
-    environment { ENVIRONMENT::STAGING }
+    environment { S3::ENVIRONMENT::STAGING }
   end
 end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -2,13 +2,13 @@ FactoryBot.define do
   factory :new_sp_component_event do
     name { SecureRandom.alphanumeric }
     component_type { COMPONENT_TYPE::SP }
-    environment { ENVIRONMENT::STAGING }
+    environment { S3::ENVIRONMENT::STAGING }
   end
 
   factory :new_msa_component_event do
     name { SecureRandom.alphanumeric }
     entity_id { 'https://test-entity-id' }
-    environment { ENVIRONMENT::STAGING }
+    environment { S3::ENVIRONMENT::STAGING }
   end
 
   factory :new_team_event do

--- a/spec/models/new_msa_component_event_spec.rb
+++ b/spec/models/new_msa_component_event_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe NewMsaComponentEvent, type: :model do
   entity_id = 'http://test-entity-id'
 
   include_examples 'has data attributes', NewMsaComponentEvent, %i[name entity_id environment]
-  include_examples 'is aggregated', NewMsaComponentEvent, name: 'New component', entity_id: entity_id, environment: ENVIRONMENT::STAGING
-  include_examples 'is a creation event', NewMsaComponentEvent, name: 'New component', entity_id: entity_id, environment: ENVIRONMENT::STAGING
+  include_examples 'is aggregated', NewMsaComponentEvent, name: 'New component', entity_id: entity_id, environment: S3::ENVIRONMENT::STAGING
+  include_examples 'is a creation event', NewMsaComponentEvent, name: 'New component', entity_id: entity_id, environment: S3::ENVIRONMENT::STAGING
 
   context 'name' do
     it 'must be provided' do
-      event = build(:new_msa_component_event, name: '', entity_id: entity_id, environment: ENVIRONMENT::STAGING)
+      event = build(:new_msa_component_event, name: '', entity_id: entity_id, environment: S3::ENVIRONMENT::STAGING)
       expect(event).to_not be_valid
       expect(event.errors[:name]).to eql ['can\'t be blank']
     end

--- a/spec/models/new_sp_component_event_spec.rb
+++ b/spec/models/new_sp_component_event_spec.rb
@@ -2,13 +2,13 @@ require 'rails_helper'
 
 RSpec.describe NewSpComponentEvent, type: :model do
 
-  include_examples 'has data attributes', NewSpComponentEvent, %i[name component_type], environment: ENVIRONMENT::STAGING
-  include_examples 'is aggregated', NewSpComponentEvent, name: 'New SP component', component_type: COMPONENT_TYPE::SP, environment: ENVIRONMENT::STAGING
-  include_examples 'is a creation event', NewSpComponentEvent, name: 'New component', component_type: COMPONENT_TYPE::SP, environment: ENVIRONMENT::STAGING
+  include_examples 'has data attributes', NewSpComponentEvent, %i[name component_type], environment: S3::ENVIRONMENT::STAGING
+  include_examples 'is aggregated', NewSpComponentEvent, name: 'New SP component', component_type: COMPONENT_TYPE::SP, environment: S3::ENVIRONMENT::STAGING
+  include_examples 'is a creation event', NewSpComponentEvent, name: 'New component', component_type: COMPONENT_TYPE::SP, environment: S3::ENVIRONMENT::STAGING
 
   context 'name' do
     it 'must be provided' do
-      event = build(:new_sp_component_event, name: '', environment: ENVIRONMENT::STAGING)
+      event = build(:new_sp_component_event, name: '', environment: S3::ENVIRONMENT::STAGING)
       expect(event).to_not be_valid
       expect(event.errors[:name]).to eql ['can\'t be blank']
     end
@@ -24,7 +24,7 @@ RSpec.describe NewSpComponentEvent, type: :model do
 
   context 'component type' do
     it 'must be provided' do
-      event = build(:new_sp_component_event, component_type: '', environment: ENVIRONMENT::STAGING)
+      event = build(:new_sp_component_event, component_type: '', environment: S3::ENVIRONMENT::STAGING)
       expect(event).to_not be_valid
       expect(event.errors[:component_type]).to eql ['must be either VSP or SP']
     end

--- a/spec/models/publish_services_event_metadata_spec.rb
+++ b/spec/models/publish_services_event_metadata_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe PublishServicesMetadataEvent, type: :model do
         SelfService.service(:storage_client)
       ).not_to receive(:upload)
 
-      PublishServicesMetadataEvent.create(event_id: 0, environment: ENVIRONMENT::INTEGRATION)
+      PublishServicesMetadataEvent.create(event_id: 0, environment: S3::ENVIRONMENT::INTEGRATION)
     end
 
     it 'when environment is set to production on component' do
@@ -68,7 +68,7 @@ RSpec.describe PublishServicesMetadataEvent, type: :model do
         SelfService.service(:integration_storage_client)
       ).not_to receive(:upload)
 
-      PublishServicesMetadataEvent.create(event_id: 0, environment: ENVIRONMENT::PRODUCTION)
+      PublishServicesMetadataEvent.create(event_id: 0, environment: S3::ENVIRONMENT::PRODUCTION)
     end
   end
 end

--- a/spec/models/upload_certificate_event_spec.rb
+++ b/spec/models/upload_certificate_event_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
   entity_id = 'http://test-entity-id'
   good_cert_value = root.generate_encoded_cert(expires_in: 2.months)
   component = NewMsaComponentEvent.create(
-    name: 'fake_name', entity_id: entity_id, environment: ENVIRONMENT::STAGING
+    name: 'fake_name', entity_id: entity_id, environment: S3::ENVIRONMENT::STAGING
   ).msa_component
 
   let(:msa_component) { create(:msa_component) }


### PR DESCRIPTION
- to mitigate 'already initialized constant' name clash once deployed