### PR TITLE
bau: to fix pipeline errors on environment

### DIFF
--- a/lib/tasks/acceptance_tests.rake
+++ b/lib/tasks/acceptance_tests.rake
@@ -1,5 +1,4 @@
-require_relative '../../config/initializers/constants/environment'
-unless ENV['RAILS_ENV'] == ENVIRONMENT::PRODUCTION
+unless ENV['RAILS_ENV'] == 'production'
   require 'rspec/core/rake_task'
 
   desc 'Run acceptance tests'


### PR DESCRIPTION
- removing the explicit reference to the s3 environment constant
  should fix this
- we may want to think of a better name for the ENVIRONMENT module
  that houses these constants as it could lead to developer to think
  the constants could be used for RAIL_ENV values.