### PR TITLE
Temporarily hard code the integration bucket name 

### DIFF
--- a/config/integration_storage.yml
+++ b/config/integration_storage.yml
@@ -11,7 +11,7 @@ amazon:
   service: S3
   access_key_id: <%= Rails.application.secrets.integration_s3_aws_access_key_id %>
   secret_access_key: <%= Rails.application.secrets.integration_s3_aws_secret_access_key %>
-  region: <%=Rails.application.secrets.integration_aws_region %>
-  bucket: <%=Rails.application.secrets.integration_aws_bucket %>
+  region: <%= Rails.application.secrets.integration_aws_region %>
+  bucket: govukverify-self-service-integration-config-metadata
   upload:
     server_side_encryption: AES256

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -14,6 +14,7 @@ test:
 
 production:
     <<: *default
+    integration_aws_region: <%= ENV["AWS_REGION"] %>
     s3_aws_access_key_id: <%= ENV["AWS_ACCESS_KEY_ID"] %>
     s3_aws_secret_access_key: <%= ENV["AWS_SECRET_ACCESS_KEY"] %>
     aws_bucket: <%= ENV["AWS_BUCKET"] %>


### PR DESCRIPTION
Until the Integration bucket is created do not use the integration storage configuration.