### PR TITLE
Adjust previous migrations

### DIFF
--- a/db/migrate/20190812105927_add_environment_to_sp_components.rb
+++ b/db/migrate/20190812105927_add_environment_to_sp_components.rb
@@ -1,6 +1,6 @@
 class AddEnvironmentToSpComponents < ActiveRecord::Migration[5.2]
   def change
     add_column :sp_components, :environment, :string
-    change_column :sp_components, :environment, :string, null: false
+    change_column :sp_components, :environment, :string, null: false, default: 'development'
   end
 end

--- a/db/migrate/20190812110003_add_environment_to_msa_components.rb
+++ b/db/migrate/20190812110003_add_environment_to_msa_components.rb
@@ -1,6 +1,6 @@
 class AddEnvironmentToMsaComponents < ActiveRecord::Migration[5.2]
   def change
     add_column :msa_components, :environment, :string
-    change_column :msa_components, :environment, :string, null: false
+    change_column :msa_components, :environment, :string, null: false, default: 'development'
   end
 end

--- a/db/migrate/20190813161922_drop_users_table.rb
+++ b/db/migrate/20190813161922_drop_users_table.rb
@@ -1,6 +1,6 @@
 class DropUsersTable < ActiveRecord::Migration[5.2]
   def up
-    drop_table :users
+    drop_table :users, if_exists: true
   end
 
   def down


### PR DESCRIPTION
We need the environment column to have a default value or the migrations
will fail. Changing the previous migration files is awkward but should
not be a problem for local machines that have already run them as they
will be skipped.

The Self Service app has yet to apply these migrations so should run
them as intended.