### PR TITLE
Make Sentry log errors correctly

### DIFF
--- a/config/initializers/logging.rb
+++ b/config/initializers/logging.rb
@@ -1,0 +1,3 @@
+require 'support/raven/logger'
+
+Rails.logger.extend(ActiveSupport::Logger.broadcast(Support::Raven::Logger.new))

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,3 +1,4 @@
 Raven.configure do |config|
   config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
+  config.transport_failure_callback = ->(event) { Rails.logger.error(event.to_s) }
 end

--- a/lib/support/raven/logger.rb
+++ b/lib/support/raven/logger.rb
@@ -1,0 +1,37 @@
+module Support
+  module Raven
+    class Logger < ::Logger
+      def initialize
+        super(nil)
+        @formatter = RavenFormatter.new
+        @logdev = RavenWriter.new
+      end
+
+      def add(severity, _exception = nil, _progname = nil, &block)
+        super if severity >= ::Logger::ERROR
+        true
+      end
+
+      # A Formatter which returns an exception if its there
+      class RavenFormatter < ::Logger::Formatter
+        # This method is invoked when a log event occurs
+        def call(_severity, _timestamp, _progname, msg)
+          case msg
+          when ::Exception
+            msg
+          when String
+            msg
+          else
+            msg.inspect
+          end
+        end
+      end
+
+      class RavenWriter
+        def write(msg = nil)
+          ::Raven.capture_exception(msg) unless msg.nil?
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/support/raven/logger_spec.rb
+++ b/spec/lib/support/raven/logger_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+require 'logger'
+require 'support/raven/logger'
+require 'raven'
+
+describe Support::Raven::Logger do
+  let(:logger) { Support::Raven::Logger.new }
+
+  context "#error" do
+    it 'will send exceptions to sentry' do
+      error = StandardError.new
+      expect(Raven).to receive(:capture_exception).with(error)
+      logger.error(error)
+    end
+
+    it 'will send non-exceptions to sentry after inspection' do
+      msg = double(:message)
+      inspected = double(:inspected)
+      expect(msg).to receive(:inspect).and_return inspected
+      expect(Raven).to receive(:capture_exception).with(inspected)
+      logger.error(msg)
+    end
+
+    it 'will send string to sentry as string' do
+      msg = "foobar"
+      expect(Raven).to receive(:capture_exception).with(msg)
+      logger.error(msg)
+    end
+  end
+
+  context "not #error" do
+    it 'will not send non-error level exceptions to sentry' do
+      raven = double(:raven)
+      stub_const("Raven", raven)
+      error = StandardError.new
+      expect(raven).to_not receive(:capture_exception)
+      logger.warn(error)
+    end
+  end
+end


### PR DESCRIPTION
We need to extend the Rails logger in order for it to send error log events to Sentry. The default for Sentry is to only send exceptions.

https://trello.com/c/lKcAMBvI/528-plug-the-app-to-sentry

Co-authored-by: Jakub Miarka <jakub.miarka@digital.cabinet-office.gov.uk>

![first_try](https://user-images.githubusercontent.com/3466862/63346328-9f5b4380-c34c-11e9-887a-967226377edd.gif)
