### PR TITLE
4CnGaY9p List teams on the user management page

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,15 @@
 class UsersController < ApplicationController
   layout "main_layout"
 
-  def index; end
+  def index
+    @user = current_user
+    @gds = current_user.permissions.team_management
+    if @gds
+      @teams = Team.all
+    else
+      @team = current_user.team
+    end
+  end
 
   def invite
     @form = InviteUserForm.new({})
@@ -9,7 +17,7 @@ class UsersController < ApplicationController
 
   def new
     @form = InviteUserForm.new(params['invite_user_form'] || {})
-    if @form.valid?
+    if @form.valid? && team_valid?
       invite_user
     else
       flash.now[:errors] = @form.errors.full_messages.join(', ')
@@ -19,32 +27,58 @@ class UsersController < ApplicationController
 
 private
 
-  def invite_user
+  def team_valid?
+    if Team.exists?(params[:team_id]) || params[:team_id] == '0'
+      true
+    else
+      @form.errors.add(t('invite.error.team.missing'))
+      false
+    end
+  end
+
+  def setup_user_in_cognito
     temporary_password = ('a'..'z').to_a.sample(3) + ('A'..'Z').to_a.sample(3) + ('0'..'9').to_a.sample(3) + ('!'..'/').to_a.sample(1)
-    begin
-      invite = SelfService.service(:cognito_client).admin_create_user(
-        temporary_password: temporary_password.join(''),
-        user_attributes: [
-          {
-            name: 'email',
-            value: @form.email
-          },
-          {
-            name: 'given_name',
-            value: @form.given_name
-          },
-          {
-            name: 'family_name',
-            value: @form.family_name
-          },
-          {
-            name: 'custom:roles',
-            value: @form.roles.join(",")
-          }
-        ],
-        username: @form.email,
-        user_pool_id: Rails.application.secrets.cognito_user_pool_id
+    SelfService.service(:cognito_client).admin_create_user(
+      temporary_password: temporary_password.join(''),
+      user_attributes: [
+        {
+          name: 'email',
+          value: @form.email
+        },
+        {
+          name: 'given_name',
+          value: @form.given_name
+        },
+        {
+          name: 'family_name',
+          value: @form.family_name
+        },
+        {
+          name: 'custom:roles',
+          value: @form.roles.join(",")
+        }
+      ],
+      username: @form.email,
+      user_pool_id: user_pool_id
       )
+  end
+
+  def add_user_to_team_in_cognito(new_user, team)
+    SelfService.service(:cognito_client).admin_add_user_to_group(
+      user_pool_id: user_pool_id,
+      username: new_user.username,
+      group_name: team.name
+    )
+  end
+
+  def invite_user
+    begin
+      if params[:team_id] != '0'
+        team = Team.find(params[:team_id])
+      else
+        team = Team.new(id: 0, name: 'gds')
+      end
+      invite = setup_user_in_cognito
     rescue Aws::CognitoIdentityProvider::Errors::AliasExistsException,
            Aws::CognitoIdentityProvider::Errors::UsernameExistsException => e
       flash.now[:errors] = t('users.invite.errors.already_exists')
@@ -52,13 +86,27 @@ private
       flash.now[:errors] = t('users.invite.errors.generic_error')
     end
 
+    begin
+      add_user_to_team_in_cognito(invite.user, team) unless team.nil?
+    rescue Aws::CognitoIdentityProvider::Errors::ServiceError => e
+      flash.now[:errors] = t('users.invite.errors.generic_error')
+    end
+
     if e
       Rails.logger.error e
       render :invite, status: :bad_request
     else
-      UserInvitedEvent.create(data: { user_id: invite.user.username, roles: @form.roles.join(",") })
+      UserInvitedEvent.create(data:
+        { user_id: invite.user.username,
+          roles: @form.roles.join(','),
+          team_id: team.id,
+          team_name: team.name })
       flash.now[:success] = t('users.invite.success')
       redirect_to users_path
     end
+  end
+
+  def user_pool_id
+    Rails.application.secrets.cognito_user_pool_id
   end
 end

--- a/app/models/invite_user_form.rb
+++ b/app/models/invite_user_form.rb
@@ -1,7 +1,7 @@
 class InviteUserForm
   include ActiveModel::Model
 
-  attr_reader :email, :given_name, :family_name, :roles, :team
+  attr_reader :email, :given_name, :family_name, :roles
 
   validates_presence_of :email, :given_name, :family_name, :roles
 

--- a/app/models/user_added_to_team_event.rb
+++ b/app/models/user_added_to_team_event.rb
@@ -1,0 +1,2 @@
+class UserAddedToTeamEvent < Event
+end

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -4,13 +4,17 @@
   <table class="govuk-table">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        <th class="govuk-table__header" scope="col"><%=t('team.name')%></th>
+        <th class="govuk-table__header" scope="col" colspan="2"><%=t('team.name')%></th>
       </tr>
     </thead>
     <tbody class="govuk-table__body">
       <% @teams.reverse.each do |team| %>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell" scope="row"><%= team.name %></td>
+          <td class="govuk-table__cell govuk-table__cell--numeric" scope="row">
+          <%= link_to t('users.invite.button'), invite_to_team_path(team.id), class: 'govuk-button govuk-button--secondary'%>
+
+          </td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/users/index.erb
+++ b/app/views/users/index.erb
@@ -1,3 +1,34 @@
-<h1 class="govuk-heading-xl"><%= t 'users.title' %></h1>
-
-<%= link_to t('users.invite_button'), invite_user_path , class: "govuk-button", data: { module: "govuk-button" }, role:"button", draggable:"false" %>
+<% if @gds %>
+  <h1 class="govuk-heading-xl"><%= t 'users.title_no_team' %></h1>
+  <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
+    <% @teams.reverse.each do |team| %>
+      <div class="govuk-accordion__section ">
+        <div class="govuk-accordion__section-header">
+          <h2 class="govuk-accordion__section-heading">
+            <span class="govuk-accordion__section-button" id="accordion-default-heading-1">
+              <%= team.name %>
+            </span>
+          </h2>
+        </div>
+        <div id="accordion-default-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1">
+          <p class='govuk-body'><%= link_to "#{t('users.invite.button')}", invite_to_team_path(team.id), class: 'govuk-button'%></p>
+        </div>
+      </div>
+    <%end%>
+    <div class="govuk-accordion__section ">
+        <div class="govuk-accordion__section-header">
+          <h2 class="govuk-accordion__section-heading">
+            <span class="govuk-accordion__section-button" id="accordion-default-heading-1">
+              <%= t('common.gds_full') %>
+            </span>
+          </h2>
+        </div>
+        <div id="accordion-default-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1">
+          <p class='govuk-body'><%= link_to "#{t('users.invite.button')}", invite_to_team_path(0), class: 'govuk-button'%></p>
+        </div>
+      </div>
+  </div>
+<% else %>
+  <h1 class="govuk-heading-xl"><%= t 'users.title_for_team' %> <%= team.name %></h1>
+  <%= link_to "#{t('users.invite.button')}", invite_to_team_path(team.id), class: 'govuk-button'%>
+<% end %>

--- a/app/views/users/invite.erb
+++ b/app/views/users/invite.erb
@@ -1,6 +1,6 @@
 <h1 class="govuk-heading-xl"><%= t 'users.invite.title' %></h1>
 
-<%= form_for @form, url: invite_new_user_path, class: 'govuk-form-group' do |f| %>
+<%= form_for @form, url: invite_to_team_post_path, class: 'govuk-form-group' do |f| %>
 
   <div class="govuk-form-group">
     <%= f.label :email, class: "govuk-label" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,6 +33,8 @@ en:
   common:
     error_blank_name: Name can't be blank
     error_name_not_unique: Name has already been taken
+    gds_full: Government Digital Service
+    gds: GDS
   login:
     heading: Log in
     mfa_heading: Log in - One Time Password Request
@@ -47,15 +49,18 @@ en:
     errors:
       generic_error: "There was an error, please try again"
   users:
-    title: Team members
+    title_no_team: Team members
+    title_for_team: Team members for
     invite_button: Invite a new user
     invite:
       title: Invite a new user
       button: Invite user
+      button_to: Invite user to
       success: The user has been invited
       errors:
         already_exists: The user already exists
         generic_error: There was an error creating the user
+        team_missing: Team does not exist
     roles:
       certmgr: Manage certificates
       usermgr: Add, edit and remove team members
@@ -115,7 +120,7 @@ en:
       warning: Warning
       message: "%{message}"
       profile: "Profile"
-      teams: "Teams Admin"
+      teams: "Team Management"
       events: "Events Viewer"
     main_layout:
       team_members: Team Members

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,8 +35,8 @@ Rails.application.routes.draw do
   get '/admin/events/:page', to: 'events#page'
 
   get '/users', to: 'users#index', as: :users
-  get '/users/invite', to: 'users#invite', as: :invite_user
-  post '/users/invite', to: 'users#new', as: :invite_new_user
+  get '/users/team/:team_id/invite', to: 'users#invite', as: :invite_to_team
+  post '/users/team/:team_id/invite', to: 'users#new', as: :invite_to_team_post
 
   get '/mfa-enrolment', to: 'mfa#index', as: :mfa_enrolment
   post '/mfa-enrolment', to: 'mfa#enrol', as: :enrol_to_mfa

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe UsersController, type: :controller do
   include AuthSupport
 
   before(:each) do
-    usermgr_stub_auth
+    gdsuser_stub_auth
   end
 
   describe '#index' do
     it 'renders the page' do
-      get :index
+      get :index, :params => { :team_id => 0 }
       expect(response).to have_http_status(:success)
       expect(subject).to render_template(:index)
     end
@@ -17,7 +17,7 @@ RSpec.describe UsersController, type: :controller do
 
   describe '#invite' do
     it 'renders the invite page' do
-      get :invite
+      get :invite, :params => { :team_id => 0 }
       expect(response).to have_http_status(:success)
       expect(subject).to render_template(:invite)
     end
@@ -28,6 +28,7 @@ RSpec.describe UsersController, type: :controller do
       Rails.application.secrets.cognito_user_pool_id = "dummy"
       SelfService.service(:cognito_client).stub_responses(:admin_create_user, { user: { username:'test@test.test' } })
       post :new, params: { 
+        team_id: 0,
         invite_user_form: 
           { 
             email: 'test@test.test', 
@@ -42,8 +43,8 @@ RSpec.describe UsersController, type: :controller do
       expect(flash.now[:success]).not_to be_nil
     end
 
-    it 'fails to invite user when params missing' do
-      post :new
+    it 'fails to invite user when form params missing' do
+      post :new, :params => { :team_id => 0 }
       expect(response).to have_http_status(:bad_request)
       expect(flash.now[:errors]).not_to be_nil
     end

--- a/spec/models/user_add_to_team_event_spec.rb
+++ b/spec/models/user_add_to_team_event_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe UserAddedToTeamEvent, type: :model do
+  let(:user_id) { SecureRandom.uuid }
+  let(:team_id) { SecureRandom.uuid }
+  let(:team_name) { 'test' }
+  let(:event) { UserAddedToTeamEvent.create(data: { user_id: user_id, team_id: team_id, team_name: team_name }) }
+  let(:event_with_nil_user_id) {
+    UserInfo.current_user = nil
+    UserAddedToTeamEvent.create(user_id: nil)
+  }
+
+  context '#create' do
+    it 'a valid event which contains a user id' do
+      expect(event.data['user_id']).to eq(user_id)
+      expect(event.data['team_id']).to eq(team_id)
+      expect(event.data['team_name']).to eq(team_name)
+    end
+
+    it 'a valid event with no user id' do
+      expect(event_with_nil_user_id.user_id).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
### What
Display the list of teams on the User Management page. Each should have a button/link to the Invite page.

### Why
In preparation for inviting users to teams we need to be able to see the teams and invite new users into them.

### What else we did
Might have also fixed the invite code to invite users to a team.  Handle non-existant gds team as well.