### PR TITLE
BAU: Add admin interface

### DIFF
--- a/app/assets/stylesheets/_admin.scss
+++ b/app/assets/stylesheets/_admin.scss
@@ -1,0 +1,6 @@
+.govuk-details__text {
+  .wrap-text {
+    overflow-wrap: anywhere;
+    white-space: normal;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,3 +19,4 @@
  @import "components";
  @import "events";
  @import "mfa_enrolment";
+ @import "admin";

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,3 +1,9 @@
 class AdminController < ApplicationController
-  def index; end
+  def index
+    @sp_components = SpComponent.all
+    @msa_components = MsaComponent.all
+    @services = Service.all
+    @certificates = Certificate.all
+    @teams = Team.all
+  end
 end

--- a/app/models/user_role_permissions.rb
+++ b/app/models/user_role_permissions.rb
@@ -1,5 +1,5 @@
 class UserRolePermissions
-  attr_reader :component_management, :team_management, :user_management, :event_management,
+  attr_reader :admin_management, :component_management, :team_management, :user_management, :event_management,
               :certificate_management, :read_components, :update_profile, :change_password
 
   def initialize(roles_str, email)
@@ -19,7 +19,8 @@ class UserRolePermissions
     "component_management = #{component_management}\n" \
     "team_management = #{team_management}\n" \
     "user_management = #{user_management}\n" \
-    "event_management = #{event_management}"
+    "event_management = #{event_management}\n" \
+    "admin_management = #{admin_management}"
   end
 
   def to_hash
@@ -58,5 +59,6 @@ private
     @certificate_management = true
     @user_management = true
     @team_management = true
+    @admin_management = true
   end
 end

--- a/app/policies/admin_controller_policy.rb
+++ b/app/policies/admin_controller_policy.rb
@@ -1,0 +1,5 @@
+class AdminControllerPolicy < ApplicationPolicy
+  def index?
+    user.permissions.admin_management
+  end
+end

--- a/app/views/admin/_certificate.erb
+++ b/app/views/admin/_certificate.erb
@@ -33,7 +33,7 @@
             </summary>
             <div class="govuk-details__text">
               <pre><%= certificate.x509.to_text %></pre>
-              <pre style="overflow-wrap:anywhere;white-space:normal"><%= certificate.value %></pre>
+              <pre class="wrap-text"><%= certificate.value %></pre>
             </div>
           </details>
         </td>

--- a/app/views/admin/_certificate.erb
+++ b/app/views/admin/_certificate.erb
@@ -1,0 +1,63 @@
+<% certificates.reverse.each do |certificate| %>
+  <table class="govuk-table">
+    <caption class="govuk-table__caption" id="certificates/<%= certificate.id %>">Certificate ID: <%= certificate.id %></caption>
+    <tbody class="govuk-table__body">
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Name</th>
+        <td class="govuk-table__cell"><%= certificate.x509.subject.to_s %></td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Enabled</th>
+        <td class="govuk-table__cell"><%= certificate.enabled %></td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Usage</th>
+        <td class="govuk-table__cell"><%= certificate.usage %></td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Valid from</th>
+        <td class="govuk-table__cell"><%= certificate.x509.not_before %></td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Valid until</th>
+        <td class="govuk-table__cell"><%= certificate.x509.not_after %></td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Certificate</th>
+        <td class="govuk-table__cell">
+          <details class="govuk-details" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+              <span class="govuk-details__summary-text">
+                Show certificate
+              </span>
+            </summary>
+            <div class="govuk-details__text">
+              <pre><%= certificate.x509.to_text %></pre>
+              <pre style="overflow-wrap:anywhere;white-space:normal"><%= certificate.value %></pre>
+            </div>
+          </details>
+        </td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Component ID</th>
+        <td class="govuk-table__cell"><%= link_to certificate.component_id, "/admin##{certificate.component_type}/#{certificate.component_id}" %></td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Component type</th>
+        <td class="govuk-table__cell"><%= certificate.component_type %></td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Created</th>
+        <td class="govuk-table__cell"><%= certificate.created_at %></td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Updated</th>
+        <td class="govuk-table__cell"><%= certificate.updated_at %></td>
+      </tr>
+    </tbody>
+  </table>
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+<% end %>
+
+
+

--- a/app/views/admin/_msa_component.html.erb
+++ b/app/views/admin/_msa_component.html.erb
@@ -1,0 +1,44 @@
+<%= link_to "Create new MSA component", new_msa_component_path, class: "govuk-button"  %>
+
+<% components.reverse.each do |component| %>
+  <table class="govuk-table">
+    <caption class="govuk-table__caption" id="MsaComponent/<%= component.id %>">MSA component ID: <%= component.id %></caption>
+    <tbody class="govuk-table__body">
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Name</th>
+        <td class="govuk-table__cell"><%= component.name %></td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Entity ID</th>
+        <td class="govuk-table__cell"><%= component.entity_id %></td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Team ID</th>
+        <td class="govuk-table__cell"><%= link_to(component.team_id, "/admin#teams/#{component.team_id}") if component.team_id %></td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Environment</th>
+        <td class="govuk-table__cell"><%= component.environment %></td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Encryption certificate ID</th>
+        <td class="govuk-table__cell"><%= link_to(component.encryption_certificate_id, "/admin#certificates/#{component.encryption_certificate_id}") if component.encryption_certificate_id %></td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Created</th>
+        <td class="govuk-table__cell"><%= component.created_at %></td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Updated</th>
+        <td class="govuk-table__cell"><%= component.updated_at %></td>
+      </tr>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell govuk-table__cell--numeric" colspan="2"><%= link_to 'Manage', polymorphic_url(component), class: 'govuk-button' %></td>
+      </tr>
+    </tbody>
+  </table>
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+<% end %>
+
+
+

--- a/app/views/admin/_msa_component.html.erb
+++ b/app/views/admin/_msa_component.html.erb
@@ -33,7 +33,7 @@
         <td class="govuk-table__cell"><%= component.updated_at %></td>
       </tr>
       <tr class="govuk-table__row">
-        <td class="govuk-table__cell govuk-table__cell--numeric" colspan="2"><%= link_to 'Manage', polymorphic_url(component), class: 'govuk-button' %></td>
+        <td class="govuk-table__cell govuk-table__cell--numeric" colspan="2"><%= link_to 'Manage', polymorphic_url(component), class: 'govuk-button', data: { module: 'govuk-button' } %></td>
       </tr>
     </tbody>
   </table>

--- a/app/views/admin/_service.erb
+++ b/app/views/admin/_service.erb
@@ -1,0 +1,38 @@
+<% services.reverse.each do |service| %>
+  <table class="govuk-table">
+    <caption class="govuk-table__caption" id="services/<%= service.id %>">Connected Service ID: <%= service.id %></caption>
+    <tbody class="govuk-table__body">
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Name</th>
+        <td class="govuk-table__cell"><%= service.name %></td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Entity ID</th>
+        <td class="govuk-table__cell"><%= service.entity_id %></td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">SP Component ID</th>
+        <td class="govuk-table__cell"><%= link_to service.sp_component_id, "/admin#SpComponent/#{service.sp_component_id}" %> </td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">MSA Component ID???</th>
+        <td class="govuk-table__cell"><%= service.msa_component_id %></td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Created</th>
+        <td class="govuk-table__cell"><%= service.created_at %></td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Updated</th>
+        <td class="govuk-table__cell"><%= service.updated_at %></td>
+      </tr>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell govuk-table__cell--numeric" colspan="2"><%= link_to 'Manage', '', class: 'govuk-button' %></td>
+      </tr>
+    </tbody>
+  </table>
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+<% end %>
+
+
+

--- a/app/views/admin/_service.erb
+++ b/app/views/admin/_service.erb
@@ -27,7 +27,7 @@
         <td class="govuk-table__cell"><%= service.updated_at %></td>
       </tr>
       <tr class="govuk-table__row">
-        <td class="govuk-table__cell govuk-table__cell--numeric" colspan="2"><%= link_to 'Manage', '', class: 'govuk-button' %></td>
+        <td class="govuk-table__cell govuk-table__cell--numeric" colspan="2"><%= link_to 'Manage', '', class: 'govuk-button', data: { module: 'govuk-button' } %></td>
       </tr>
     </tbody>
   </table>

--- a/app/views/admin/_sp_component.html.erb
+++ b/app/views/admin/_sp_component.html.erb
@@ -1,0 +1,44 @@
+<%= link_to "Create new SP component", new_sp_component_path, class: "govuk-button"  %>
+
+<% components.reverse.each do |component| %>
+  <table class="govuk-table">
+    <caption class="govuk-table__caption" id="SpComponent/<%= component.id %>">SP component ID: <%= component.id %></caption>
+    <tbody class="govuk-table__body">
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Name</th>
+        <td class="govuk-table__cell"><%= component.name %></td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">VSP</th>
+        <td class="govuk-table__cell"><%= component.vsp %></td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Team ID</th>
+        <td class="govuk-table__cell"><%= link_to(component.team_id, "/admin#teams/#{component.team_id}") if component.team_id %></td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Environment</th>
+        <td class="govuk-table__cell"><%= component.environment %></td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Encryption certificate ID</th>
+        <td class="govuk-table__cell"><%= link_to(component.encryption_certificate_id, "/admin#certificates/#{component.encryption_certificate_id}") if component.encryption_certificate_id %></td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Created</th>
+        <td class="govuk-table__cell"><%= component.created_at %></td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Updated</th>
+        <td class="govuk-table__cell"><%= component.updated_at %></td>
+      </tr>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell govuk-table__cell--numeric" colspan="2"><%= link_to 'Manage', polymorphic_url(component), class: 'govuk-button' %></td>
+      </tr>
+    </tbody>
+  </table>
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+<% end %>
+
+
+

--- a/app/views/admin/_sp_component.html.erb
+++ b/app/views/admin/_sp_component.html.erb
@@ -33,7 +33,7 @@
         <td class="govuk-table__cell"><%= component.updated_at %></td>
       </tr>
       <tr class="govuk-table__row">
-        <td class="govuk-table__cell govuk-table__cell--numeric" colspan="2"><%= link_to 'Manage', polymorphic_url(component), class: 'govuk-button' %></td>
+        <td class="govuk-table__cell govuk-table__cell--numeric" colspan="2"><%= link_to 'Manage', polymorphic_url(component), class: 'govuk-button', data: { module: 'govuk-button' } %></td>
       </tr>
     </tbody>
   </table>

--- a/app/views/admin/_team.erb
+++ b/app/views/admin/_team.erb
@@ -1,0 +1,32 @@
+<%= link_to t('team.add_team'), new_team_path, class: "govuk-button" %>
+
+<% teams.reverse.each do |team| %>
+  <table class="govuk-table">
+    <caption class="govuk-table__caption" id="teams/<%= team.id %>">Team ID: <%= team.id %></caption>
+    <tbody class="govuk-table__body">
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Name</th>
+        <td class="govuk-table__cell"><%= team.name %></td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Alias</th>
+        <td class="govuk-table__cell"><%= team.team_alias %></td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Created</th>
+        <td class="govuk-table__cell"><%= team.created_at %></td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Updated</th>
+        <td class="govuk-table__cell"><%= team.updated_at %></td>
+      </tr>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell govuk-table__cell--numeric" colspan="2"><%= link_to 'Manage', '', class: 'govuk-button' %></td>
+      </tr>
+    </tbody>
+  </table>
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+<% end %>
+
+
+

--- a/app/views/admin/_team.erb
+++ b/app/views/admin/_team.erb
@@ -21,7 +21,7 @@
         <td class="govuk-table__cell"><%= team.updated_at %></td>
       </tr>
       <tr class="govuk-table__row">
-        <td class="govuk-table__cell govuk-table__cell--numeric" colspan="2"><%= link_to 'Manage', '', class: 'govuk-button' %></td>
+        <td class="govuk-table__cell govuk-table__cell--numeric" colspan="2"><%= link_to 'Manage', '', class: 'govuk-button', data: { module: 'govuk-button' } %></td>
       </tr>
     </tbody>
   </table>

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -1,0 +1,68 @@
+<h1 class="govuk-heading-xl">Admin</h1>
+
+<div class="govuk-tabs" data-module="govuk-tabs">
+  <h2 class="govuk-tabs__title">
+    Admin
+  </h2>
+  <ul class="govuk-tabs__list">
+    <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+      <a class="govuk-tabs__tab" href="#SpComponent">
+        SP Components
+      </a>
+    </li>
+    <li class="govuk-tabs__list-item">
+      <a class="govuk-tabs__tab" href="#MsaComponent">
+        MSA Components
+      </a>
+    </li>
+    <li class="govuk-tabs__list-item">
+      <a class="govuk-tabs__tab" href="#services">
+        Services
+      </a>
+    </li>
+    <li class="govuk-tabs__list-item">
+      <a class="govuk-tabs__tab" href="#teams">
+        Teams
+      </a>
+    </li>
+    <li class="govuk-tabs__list-item">
+      <a class="govuk-tabs__tab" href="#certificates">
+        Certificates
+      </a>
+    </li>
+    <li class="govuk-tabs__list-item">
+      <a class="govuk-tabs__tab" href="#events">
+        Events
+      </a>
+    </li>
+  </ul>
+  <section class="govuk-tabs__panel" id="SpComponent">
+    <h2 class="govuk-heading-l">SP components</h2>
+    <%= render "admin/sp_component", components: @sp_components %>
+  </section>
+
+  <section class="govuk-tabs__panel govuk-tabs__panel--hidden" id="MsaComponent">
+    <h2 class="govuk-heading-l">MSA components</h2>
+    <%= render "admin/msa_component", components: @msa_components %>
+  </section>
+
+  <section class="govuk-tabs__panel govuk-tabs__panel--hidden" id="services">
+    <h2 class="govuk-heading-l">Services</h2>
+    <%= render "admin/service", services: @services %>
+  </section>
+
+  <section class="govuk-tabs__panel govuk-tabs__panel--hidden" id="teams">
+    <h2 class="govuk-heading-l">Teams</h2>
+     <%= render "admin/team", teams: @teams %>
+  </section>
+
+  <section class="govuk-tabs__panel govuk-tabs__panel--hidden" id="certificates">
+    <h2 class="govuk-heading-l">Certificates</h2>
+    <%= render "admin/certificate", certificates: @certificates %>
+  </section>
+
+  <section class="govuk-tabs__panel govuk-tabs__panel--hidden" id="events">
+    <h2 class="govuk-heading-l">Events</h2>
+    <%= link_to t('layout.application.events'), admin_events_path %>
+  </section>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,14 +43,9 @@
           <% if user_signed_in? %>
             <nav>
               <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
-                <% if policy(EventsController).index? %>
+                <% if policy(AdminController).index? %>
                   <li class="govuk-header__navigation-item">
-                    <%= link_to t('layout.application.events'), admin_events_path, class: "govuk-header__link" %>
-                  </li>
-                <% end %>
-                <% if policy(TeamsController).index? %>
-                  <li class="govuk-header__navigation-item">
-                    <%= link_to t('layout.application.teams') , teams_path, class: "govuk-header__link" %>
+                    <%= link_to t('layout.application.admin') , admin_path, class: "govuk-header__link" %>
                   </li>
                 <% end %>
                 <li class="govuk-header__navigation-item">

--- a/app/views/sp_components/edit.html.erb
+++ b/app/views/sp_components/edit.html.erb
@@ -6,13 +6,13 @@
 
 <%= form_for  @sp_component , url: sp_component_path, as: :component do |f| %>
   <div class="govuk-form-group <%= 'govuk-form-group--error' if  @sp_component.errors.key?(:name) %>">
-    <%=error_message_on(f.object.errors, :name) %>
+    <%= error_message_on(f.object.errors, :name) %>
     <%= f.select(:team_id, @teams.map{|t|[t.name, t.id]},
     {include_blank: 'Select'},
     {class: 'govuk-select'})  
     %>
   </div>
   <div class="govuk-form-group">
-    <%=f.submit t('team.associate_team'), class: "govuk-button" %>
+    <%= f.submit t('team.associate_team'), class: "govuk-button" %>
  </div>
 <%end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -111,7 +111,7 @@ en:
   layout:
     application:
       title: Verify Self-Service
-      admin_link: Admin
+      admin: Admin
       skip_link: Skip to main content
       sign_out_link: Sign out
       logo_text: GOV.UK

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
 
   get '/healthcheck', to: 'healthcheck#index'
 
-  get '/admin', to: 'components#index'
+  get '/admin', to: 'admin#index'
 
   resources :sp_components, path: 'admin/sp-components' do
     resources :services

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -1,4 +1,26 @@
 require 'rails_helper'
 
 RSpec.describe AdminController, type: :controller do
+  include AuthSupport
+
+    it 'should render when GDS user' do
+      gdsuser_stub_auth
+      get :index
+      expect(response).to have_http_status(:success)
+      expect(subject).to render_template(:index)
+    end
+
+    it 'should not render when user is certificate manager' do
+      certmgr_stub_auth
+      get :index
+      expect(flash[:warn]).to eq 'You are not authorised to perform this action'      
+      expect(subject).to_not render_template(:index)
+    end
+
+    it 'should not render when user is user manager' do
+      usermgr_stub_auth
+      get :index
+      expect(flash[:warn]).to eq 'You are not authorised to perform this action'      
+      expect(subject).to_not render_template(:index)
+    end
 end


### PR DESCRIPTION
Initial work to help us display what's in the app from a GDS user point of view.
This lists all the components, services, certificates and teams present.

I did not do the localisation, given this is a pure admin view...

(reviewing commit by commit might be easier)

<img width="1004" alt="Screen Shot 2019-08-23 at 17 41 46" src="https://user-images.githubusercontent.com/30629434/63608614-5960e280-c5cd-11e9-9ec5-590868c152d0.png">
