### PR TITLE
BAU: Fix the pre-commit linter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,5 +2,6 @@
     hooks:
     -   id: lint
         name: govuk linter
-        entry: bundle exec govuk-lint-ruby app lib
+        entry: bundle exec govuk-lint-ruby
+        files: (app|lib)
         language: system


### PR DESCRIPTION
The linter on pre-commit hook ran on all files insted of only the app and lib folders.