### PR TITLE
Remove environment constants

### DIFF
--- a/app/models/new_msa_component_event.rb
+++ b/app/models/new_msa_component_event.rb
@@ -4,7 +4,7 @@ class NewMsaComponentEvent < AggregatedEvent
   validate :msa_has_entity_id
   validate :component_is_new, on: :create
   validate :name_is_present
-  validates_presence_of :environment, in: ENVIRONMENT.constants
+  validates_presence_of :environment, in: Rails.configuration.hub_environments.keys
 
   def build_msa_component
     MsaComponent.new

--- a/app/models/new_sp_component_event.rb
+++ b/app/models/new_sp_component_event.rb
@@ -4,7 +4,7 @@ class NewSpComponentEvent < AggregatedEvent
 
   validate :name_is_present
   validate :component_is_new, on: :create
-  validates_presence_of :environment, in: ENVIRONMENT.constants
+  validates_presence_of :environment, in: Rails.configuration.hub_environments.keys
   validates_inclusion_of :component_type,
                          in: [COMPONENT_TYPE::SP, COMPONENT_TYPE::VSP],
                          message: "must be either VSP or SP"

--- a/config/initializers/constants/environment.rb
+++ b/config/initializers/constants/environment.rb
@@ -1,7 +1,0 @@
-module ENVIRONMENT
-  STAGING = 'staging'.freeze
-  INTEGRATION = 'integration'.freeze
-  PRODUCTION = 'production'.freeze
-  TEST = 'test'.freeze
-  DEVELOPMENT = 'development'.freeze
-end

--- a/spec/factories/components.rb
+++ b/spec/factories/components.rb
@@ -2,12 +2,12 @@ FactoryBot.define do
   factory :sp_component do
     component_type { COMPONENT_TYPE::SP }
     name { 'Test Service Provider' }
-    environment { ENVIRONMENT::STAGING }
+    environment { 'staging' }
   end
 
   factory :msa_component do
     component_type { COMPONENT_TYPE::MSA }
     entity_id { 'https://test-entity-id' }
-    environment { ENVIRONMENT::STAGING }
+    environment { 'staging' }
   end
 end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -2,13 +2,13 @@ FactoryBot.define do
   factory :new_sp_component_event do
     name { SecureRandom.alphanumeric }
     component_type { COMPONENT_TYPE::SP }
-    environment { ENVIRONMENT::STAGING }
+    environment { 'staging' }
   end
 
   factory :new_msa_component_event do
     name { SecureRandom.alphanumeric }
     entity_id { 'https://test-entity-id' }
-    environment { ENVIRONMENT::STAGING }
+    environment { 'staging' }
   end
 
   factory :new_team_event do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,45 +7,26 @@ FactoryBot.define do
     roles { ROLE::USER_MANAGER }
     session_start_time { Time.now.to_s }
     permissions { UserRolePermissions.new(ROLE::USER_MANAGER, nil) }
-  end
 
-  factory :gds_user, class: User do
-    given_name { "John" }
-    family_name  { "Doe" }
-    email { "test.test@digital.cabinet-office.gov.uk" }
-    password { "validpassword" }
-    roles { ROLE::GDS }
-    session_start_time { Time.now.to_s }
-    permissions { UserRolePermissions.new(ROLE::GDS, "test.test@digital.cabinet-office.gov.uk") }
-  end
+    factory :gds_user do
+      email { "test.test@digital.cabinet-office.gov.uk" }
+      roles { ROLE::GDS }
+      permissions { UserRolePermissions.new(ROLE::GDS, "test.test@digital.cabinet-office.gov.uk") }
+    end
 
-  factory :certificate_manager_user, class: User do
-    given_name { "Jane" }
-    family_name  { "Smith" }
-    email { "test@test.test" }
-    password { "validpassword" }
-    roles { ROLE::CERTIFICATE_MANAGER }
-    session_start_time { Time.now.to_s }
-    permissions { UserRolePermissions.new(ROLE::CERTIFICATE_MANAGER, nil) }
-  end
+    factory :certificate_manager_user do
+      roles { ROLE::CERTIFICATE_MANAGER }
+      permissions { UserRolePermissions.new(ROLE::CERTIFICATE_MANAGER, nil) }
+    end
 
-  factory :user_manager_user, class: User do
-    given_name { "Jane" }
-    family_name  { "Smith" }
-    email { "test@test.test" }
-    password { "validpassword" }
-    roles { ROLE::USER_MANAGER }
-    session_start_time { Time.now.to_s }
-    permissions { UserRolePermissions.new(ROLE::USER_MANAGER, nil) }
-  end
+    factory :user_manager_user do
+      roles { ROLE::USER_MANAGER }
+      permissions { UserRolePermissions.new(ROLE::USER_MANAGER, nil) }
+    end
 
-  factory :component_manager_user, class: User do
-    given_name { "Jane" }
-    family_name  { "Smith" }
-    email { "test@test.test" }
-    password { "validpassword" }
-    roles { ROLE::COMPONENT_MANAGER }
-    session_start_time { Time.now.to_s }
-    permissions { UserRolePermissions.new(ROLE::COMPONENT_MANAGER, nil) }
+    factory :component_manager_user do
+      roles { ROLE::COMPONENT_MANAGER }
+      permissions { UserRolePermissions.new(ROLE::COMPONENT_MANAGER, nil) }
+    end
   end
 end

--- a/spec/models/new_msa_component_event_spec.rb
+++ b/spec/models/new_msa_component_event_spec.rb
@@ -1,15 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe NewMsaComponentEvent, type: :model do
-  entity_id = 'http://test-entity-id'
-
-  include_examples 'has data attributes', NewMsaComponentEvent, %i[name entity_id environment]
-  include_examples 'is aggregated', NewMsaComponentEvent, name: 'New component', entity_id: entity_id, environment: ENVIRONMENT::STAGING
-  include_examples 'is a creation event', NewMsaComponentEvent, name: 'New component', entity_id: entity_id, environment: ENVIRONMENT::STAGING
+  include_examples 'components have data attributes', :new_msa_component_event, {
+    name: 'Call me Ishmael',
+    environment: 'staging'
+  }
+  include_examples 'components are aggregated', :new_msa_component_event
+  include_examples 'component creation event', :new_msa_component_event
 
   context 'name' do
     it 'must be provided' do
-      event = build(:new_msa_component_event, name: '', entity_id: entity_id, environment: ENVIRONMENT::STAGING)
+      event = build(:new_msa_component_event, name: '')
       expect(event).to_not be_valid
       expect(event.errors[:name]).to eql ['can\'t be blank']
     end
@@ -17,7 +18,7 @@ RSpec.describe NewMsaComponentEvent, type: :model do
 
   context 'environment' do
     it 'must be provided' do
-      event = build(:new_msa_component_event, name: 'New component', entity_id: entity_id, environment: '')
+      event = build(:new_msa_component_event, environment: '')
       expect(event).to_not be_valid
       expect(event.errors[:environment]).to eql ['can\'t be blank']
     end

--- a/spec/models/new_sp_component_event_spec.rb
+++ b/spec/models/new_sp_component_event_spec.rb
@@ -1,14 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe NewSpComponentEvent, type: :model do
-
-  include_examples 'has data attributes', NewSpComponentEvent, %i[name component_type], environment: ENVIRONMENT::STAGING
-  include_examples 'is aggregated', NewSpComponentEvent, name: 'New SP component', component_type: COMPONENT_TYPE::SP, environment: ENVIRONMENT::STAGING
-  include_examples 'is a creation event', NewSpComponentEvent, name: 'New component', component_type: COMPONENT_TYPE::SP, environment: ENVIRONMENT::STAGING
+  include_examples 'components have data attributes', :new_sp_component_event, {
+    name: 'It was the day my grandmother exploded',
+    component_type: COMPONENT_TYPE::SP,
+    environment: 'staging'
+  }
+  include_examples 'components are aggregated', :new_sp_component_event
+  include_examples 'component creation event', :new_sp_component_event
 
   context 'name' do
     it 'must be provided' do
-      event = build(:new_sp_component_event, name: '', environment: ENVIRONMENT::STAGING)
+      event = build(:new_sp_component_event, name: '')
       expect(event).to_not be_valid
       expect(event.errors[:name]).to eql ['can\'t be blank']
     end
@@ -24,7 +27,7 @@ RSpec.describe NewSpComponentEvent, type: :model do
 
   context 'component type' do
     it 'must be provided' do
-      event = build(:new_sp_component_event, component_type: '', environment: ENVIRONMENT::STAGING)
+      event = build(:new_sp_component_event, component_type: '')
       expect(event).to_not be_valid
       expect(event.errors[:component_type]).to eql ['must be either VSP or SP']
     end

--- a/spec/models/publish_services_event_metadata_spec.rb
+++ b/spec/models/publish_services_event_metadata_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe PublishServicesMetadataEvent, type: :model do
         SelfService.service(:storage_client)
       ).to receive(:put_object).with(hash_including(bucket: "integration-bucket"))
 
-      PublishServicesMetadataEvent.create(event_id: 0, environment: ENVIRONMENT::INTEGRATION)
+      PublishServicesMetadataEvent.create(event_id: 0, environment: 'integration')
     end
 
     it 'when environment is set to production on component' do
@@ -39,7 +39,7 @@ RSpec.describe PublishServicesMetadataEvent, type: :model do
         SelfService.service(:storage_client)
       ).to receive(:put_object).with(hash_including(bucket: "production-bucket"))
 
-      PublishServicesMetadataEvent.create(event_id: 0, environment: ENVIRONMENT::PRODUCTION)
+      PublishServicesMetadataEvent.create(event_id: 0, environment: 'production')
     end
   end
 end

--- a/spec/models/shared_examples/component_event.rb
+++ b/spec/models/shared_examples/component_event.rb
@@ -1,0 +1,58 @@
+RSpec.shared_examples "components have data attributes" do |type, attributes|
+  attributes.each do |k, v|
+    it "#{k} can be added at initialize time" do
+      event = build(type, k => v)
+      expect(event.public_send(k)).to eql v
+      expect(event.data[k.to_s]).to eql v
+    end
+
+    it "#{k} is stored in the data column" do
+      event = create(type, attributes)
+      event.public_send("#{k}=", v)
+      expect(event.public_send(k)).to eql v
+      expect(event.data[k.to_s]).to eql v
+    end
+  end
+end
+
+RSpec.shared_examples "components are aggregated" do |type, attributes = {}|
+  it "has an aggregate" do
+    event = create(type, attributes)
+    expect(event.aggregate).to_not be_nil
+    expect(event.aggregate_id).to eq(event.aggregate.id)
+    expect(event.aggregate).to be_persisted
+    expect(event.public_send(event.aggregate_name)).to eq(event.aggregate)
+  end
+
+  it "updates an attribute" do
+    event = create(type, attributes)
+    aggregate = event.build_aggregate
+    event.save!
+    expect(event.aggregate.attributes).to_not eql aggregate.attributes
+  end
+end
+
+RSpec.shared_examples "component creation event" do |type, attributes = {}|
+  include_examples "components are aggregated", type
+  it "that also creates an aggregate" do
+    event = create(type, attributes)
+    expect(event).to be_valid
+    expect(event).to be_persisted
+    event.reload
+    expect(event.aggregate).to_not be_nil
+    expect(event.aggregate).to be_persisted
+    expect(event.public_send(event.aggregate_name)).to eql event.aggregate
+    expect(event.created_at).to eql event.aggregate.created_at
+  end
+
+  it "cannot be attached to an aggregate that already exists" do
+    first_event = create(type, attributes)
+    expect(first_event).to be_persisted
+    aggregate = first_event.aggregate
+    expect(aggregate).to be_persisted
+
+    expect {
+      create(type, attributes.merge(aggregate: aggregate))
+    }.to raise_error(ActiveRecord::RecordInvalid)
+  end
+end

--- a/spec/models/upload_certificate_event_spec.rb
+++ b/spec/models/upload_certificate_event_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
   entity_id = 'http://test-entity-id'
   good_cert_value = root.generate_encoded_cert(expires_in: 2.months)
   component = NewMsaComponentEvent.create(
-    name: 'fake_name', entity_id: entity_id, environment: ENVIRONMENT::STAGING
+    name: 'fake_name', entity_id: entity_id, environment: 'staging'
   ).msa_component
 
   let(:msa_component) { create(:msa_component) }


### PR DESCRIPTION
This could be a little contentious. 

In response to [this comment](https://github.com/alphagov/verify-self-service/pull/125#discussion_r316805353) this PR removes all the environment constants. The idea behind this is that they should already be defined in the `hub_environments`.

This prompted a little refactor in order to make use of Factory Bot a little more. The upload_certificate_event still needs to be a factory at some point. Perhaps another PR . . . .