### PR TITLE
ywk5OlJS: Fix favicon/assets

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,13 +7,13 @@
 
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
-    <%= favicon_link_tag        asset_path('/assets/govuk-frontend/govuk/assets/images/favicon.ico'), sizes: "16x16 32x32 48x48" %>
+    <%= favicon_link_tag        asset_path('govuk-frontend/govuk/assets/images/favicon.ico'), sizes: "16x16 32x32 48x48" %>
 
-    <link rel="mask-icon" href="<%= asset_path('/assets/govuk-frontend/govuk/assets/images/govuk-mask-icon.svg')%>" color="blue">  
-    <link rel="apple-touch-icon" href="<%= asset_path('/assets/govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-180x180.png')%>" sizes="180x180"> 
-    <link rel="apple-touch-icon" href="<%= asset_path('/assets/govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-167x167.png')%>" sizes="167x167"> 
-    <link rel="apple-touch-icon" href="<%= asset_path('/assets/govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-152x152.png')%>" sizes="152x152"> 
-    <link rel="apple-touch-icon" href="<%= asset_path('/assets/govuk-frontend/govuk/assets/images/govuk-apple-touch-icon.png')%>"> 
+    <link rel="mask-icon" href="<%= asset_path('govuk-frontend/govuk/assets/images/govuk-mask-icon.svg')%>" color="blue">  
+    <link rel="apple-touch-icon" href="<%= asset_path('govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-180x180.png')%>" sizes="180x180"> 
+    <link rel="apple-touch-icon" href="<%= asset_path('govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-167x167.png')%>" sizes="167x167"> 
+    <link rel="apple-touch-icon" href="<%= asset_path('govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-152x152.png')%>" sizes="152x152"> 
+    <link rel="apple-touch-icon" href="<%= asset_path('govuk-frontend/govuk/assets/images/govuk-apple-touch-icon.png')%>"> 
     
 </head>
 
@@ -32,7 +32,7 @@
             <span class="govuk-header__logotype">
               <svg role="presentation" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 132 97" height="32" width="36">
                 <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
-                <image src="<% asset_path('/assets/govuk-frontend/govuk/assets/images/govuk-logotype-crown.png')%>" class="govuk-header__logotype-crown-fallback-image"></image>
+                <image src="<%= asset_path('govuk-frontend/govuk/assets/images/govuk-logotype-crown.png')%>" class="govuk-header__logotype-crown-fallback-image"></image>
               </svg>
               <span class="govuk-header__logotype-text">
                 <%= t 'layout.application.logo_text' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -42,9 +42,7 @@
         </div>
         <div class="govuk-header__content">
 
-          <a href="#">
-            <%= link_to t('layout.application.service_name'), root_path, class: "govuk-header__link govuk-header__link--service-name" %>
-          </a>
+          <%= link_to t('layout.application.service_name'), root_path, class: "govuk-header__link govuk-header__link--service-name" %>
 
           <button type="button" role="button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation" data-module="govuk-button"><%= t 'layout.application.menu' %></button>
           <% if user_signed_in? %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -11,4 +11,4 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
-# Rails.application.config.assets.precompile += %w( admin.js admin.css )
+Rails.application.config.assets.precompile += %w( *.png *.ico *.svg )


### PR DESCRIPTION
Favicon and other image assets are not working once deployed.
This is due to them not being in the asset pipeline. This adds the images and
updates the path. The paths can't start with `/` if we want a relative path.