### PR TITLE
96vC6S4J: Seed cognito with a GDS user

### DIFF
--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -27,7 +27,7 @@ class ProfileController < ApplicationController
       role_str = params[:assume_roles][:role_selection].join(',')
       if params[:assume_roles][:role_selection].include?(ROLE::GDS)
         CognitoStubClient.update_user(
-          role: role_str, email_domain: 'digital.cabinet-office.gov.uk'
+          role: role_str, email_domain: TEAMS::GDS_EMAIL_DOMAIN
         )
       else
         CognitoStubClient.update_user(role: role_str)

--- a/app/models/new_team_event.rb
+++ b/app/models/new_team_event.rb
@@ -27,6 +27,8 @@ class NewTeamEvent < AggregatedEvent
   rescue Aws::CognitoIdentityProvider::Errors::InvalidParameterException => e
     Rails.logger.error("#{I18n.t('team.errors.invalid')} -> #{e.message}")
     errors.add(:team, I18n.t('team.errors.invalid'))
+  rescue Aws::CognitoIdentityProvider::Errors::GroupExistsException
+    Rails.logger.warn("The group #{name} already existed in Cognito...")
   rescue Aws::CognitoIdentityProvider::Errors::ServiceError => e
     Rails.logger.error("#{I18n.t('team.errors.failed')} -> #{e.message}")
     errors.add(:team, I18n.t('team.errors.failed'))

--- a/app/models/user_role_permissions.rb
+++ b/app/models/user_role_permissions.rb
@@ -8,7 +8,7 @@ class UserRolePermissions
     user_manager if roles.include?(ROLE::USER_MANAGER)
     cert_manager if roles.include?(ROLE::CERTIFICATE_MANAGER)
     component_manager if roles.include?(ROLE::COMPONENT_MANAGER)
-    gds_user if roles.include?(ROLE::GDS) && email.ends_with?("@digital.cabinet-office.gov.uk")
+    gds_user if roles.include?(ROLE::GDS) && email.ends_with?(TEAMS::GDS_EMAIL_DOMAIN)
   end
 
   def to_s

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -66,4 +66,10 @@ Rails.application.configure do
   config.cognito_aws_secret_access_key = ENV['COGNITO_AWS_SECRET_ACCESS_KEY']
   config.cognito_client_id = ENV['AWS_COGNITO_CLIENT_ID']
   config.cognito_user_pool_id = ENV['AWS_COGNITO_USER_POOL_ID']
+
+  # To seed Cognito (uncomment, if needed to be run):
+  # config.after_initialize do
+  #   require 'auth/initial_seeder'
+  #   InitialSeeder.new
+  # end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -105,4 +105,16 @@ Rails.application.configure do
 
   config.cognito_client_id = ENV.fetch('AWS_COGNITO_CLIENT_ID')
   config.cognito_user_pool_id = ENV.fetch('AWS_COGNITO_USER_POOL_ID')
+
+  # To seed Cognito
+  # 1. Creates a GDS user if one doesn't exist
+  # 2. Creates a GDS team and/or group if one doesn't exist
+  # 3. Adds any users with GDS role AND GDS email address to the GDS group
+  # NOTE: It's only neccessary to run this once in a new environment or after
+  #       the Cognito instance has been wiped. However, it doesn't do any harm
+  #       if it'll run on every startup
+  config.after_initialize do
+    require 'auth/initial_seeder'
+    InitialSeeder.new unless ENV['DISABLE_COGNITO_SEEDING'].present?
+  end
 end

--- a/config/initializers/constants/teams.rb
+++ b/config/initializers/constants/teams.rb
@@ -1,3 +1,5 @@
 module TEAMS
+  GDS = 'gds'.freeze
+  GDS_EMAIL_DOMAIN = 'digital.cabinet-office.gov.uk'
   GROUP_NAME_REGEX = /[\p{L}\p{M}\p{S}\p{N}\p{P}]+/.freeze
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,7 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+# Set up the GDS group in the app by default. The InitialSeeder class will take
+# care of the rest
+  Team.create(name: TEAMS::GDS, team_alias: TEAMS::GDS)

--- a/lib/auth/cognito_stub_client.rb
+++ b/lib/auth/cognito_stub_client.rb
@@ -18,7 +18,7 @@ class CognitoStubClient
   end
 
   def self.stub_gds_user_hash
-    self.stub_user_hash(role: ROLE::GDS, email_domain: "digital.cabinet-office.gov.uk")
+    self.stub_user_hash(role: ROLE::GDS, email_domain: TEAMS::GDS_EMAIL_DOMAIN)
   end
 
   def self.setup_user(user_hash)

--- a/lib/auth/initial_seeder.rb
+++ b/lib/auth/initial_seeder.rb
@@ -1,0 +1,109 @@
+class InitialSeeder
+  def initialize
+    return if SelfService.service(:cognito_stub)
+
+    Rails.logger.info('Initializing the seed sequence...')
+    create_gds_group unless gds_group_exists?
+    if gds_user_exists?
+      add_gds_users_to_group
+    else
+      create_gds_user
+    end
+  end
+
+  def gds_group_exists?
+    begin
+      SelfService.service(:cognito_client).get_group(
+        group_name: TEAMS::GDS,
+        user_pool_id: Rails.configuration.cognito_user_pool_id
+      )
+    rescue Aws::CognitoIdentityProvider::Errors::ResourceNotFoundException
+      Rails.logger.warn('The GDS group does not exist in Cognito!')
+      return false
+    rescue Aws::CognitoIdentityProvider::Errors::ServiceError => e
+      Rails.logger.warn("Error occurred when checking GDS group: #{e}")
+      return false
+    end
+    Rails.logger.info('The GDS group already exists in Cognito.')
+    if Team.exists?(team_alias: TEAMS::GDS)
+      Rails.logger.info('The GDS group already exists in database.')
+      true
+    else
+      Rails.logger.info('The GDS group does not exist in database.')
+      false
+    end
+  end
+
+  def gds_user_exists?
+    begin
+      users = SelfService.service(:cognito_client).list_users(
+        user_pool_id: Rails.configuration.cognito_user_pool_id,
+        limit: 60
+      )
+      @gds_users = users.users.select { |user|
+        user.attributes.find { |att|
+          att.name == 'custom:roles' && att.value.include?(TEAMS::GDS)
+        }
+      }
+    rescue Aws::CognitoIdentityProvider::Errors::ServiceError => e
+      Rails.logger.error("Error occurred when looking for GDS users: #{e}")
+      return false
+    end
+    Rails.logger.info("Found #{@gds_users.length} existing GDS users.")
+    @gds_users.length
+  end
+
+  def create_gds_user
+    admin_email = ENV['COGNITO_SEEDING_EMAIL'] || 'jakub.miarka+gdsadmin@digital.cabinet-office.gov.uk'
+    SelfService.service(:cognito_client).admin_create_user(
+      temporary_password: ENV['COGNITO_SEEDING_PASSWORD'] || 'abcDEF123%',
+      user_attributes: [
+        {
+          name: 'email',
+          value: admin_email
+        },
+        {
+          name: 'given_name',
+          value: 'Jakub'
+        },
+        {
+          name: 'family_name',
+          value: 'Miarka'
+        },
+        {
+          name: 'custom:roles',
+          value: TEAMS::GDS
+        }
+      ],
+      username: admin_email,
+      user_pool_id: Rails.configuration.cognito_user_pool_id
+    )
+
+    SelfService.service(:cognito_client).admin_add_user_to_group(
+      user_pool_id: Rails.configuration.cognito_user_pool_id,
+      username: admin_email,
+      group_name: TEAMS::GDS
+    )
+  end
+
+  def add_gds_users_to_group(gds_users = @gds_users)
+    gds_users.each { |user|
+      user_email = user.attributes.find { |att| att.name == 'email' }
+      if user_email.value.end_with?(TEAMS::GDS_EMAIL_DOMAIN)
+        Rails.logger.info("Adding user #{user.username} to the GDS group.")
+        SelfService.service(:cognito_client).admin_add_user_to_group(
+          user_pool_id: Rails.configuration.cognito_user_pool_id,
+          username: user.username,
+          group_name: TEAMS::GDS
+        )
+      else
+        Rails.logger.warn("Skipping user #{user.username} from being added GDS group - non-GDS email (#{user_email.value})")
+      end
+    }
+  end
+
+  def create_gds_group
+    event = NewTeamEvent.create(name: TEAMS::GDS)
+    Rails.logger.warn("There was an issue creating the GDS team: #{event.errors.full_messages}") unless event.valid?
+  end
+end

--- a/spec/lib/auth/initial_seeder_spec.rb
+++ b/spec/lib/auth/initial_seeder_spec.rb
@@ -1,0 +1,162 @@
+require 'rails_helper'
+require 'auth/initial_seeder'
+
+RSpec.describe InitialSeeder do
+  include CognitoSupport
+
+  let(:users_without_gds){
+    {:users=>
+          [
+            {:username=>"00000-0000-0000-000",
+             :attributes=>
+             [{:name=> "sub", :value=> "123"},
+              {:name=>"given_name", :value=>"Test"},
+              {:name=>"family_name", :value=>"Test"},
+              {:name=>"email", :value=>"test@test.test"}],
+            :user_create_date=>Time.now,
+            :user_status=>"CONFIRMED"},
+           {:username=>"00000-0000-0000-001",
+            :attributes=>
+             [{:name=>"sub", :value=>"124"},
+              {:name=>"custom:roles", :value=>"usermgr"},
+              {:name=>"given_name", :value=>"Test"},
+              {:name=>"family_name", :value=>"Testerator"},
+              {:name=>"email", :value=>"some@user.com"}],
+            :user_create_date=>Time.now,
+            :user_status=>"CONFIRMED"},
+           {:username=>"00000-0000-0000-002",
+            :attributes=>
+             [{:name=>"sub", :value=>"125"},
+              {:name=>"custom:roles", :value=>"usermgr"},
+              {:name=>"given_name", :value=>"User"},
+              {:name=>"family_name", :value=>"Admin"},
+              {:name=>"email", :value=>"admin@digital.cabinet-office.gov.uk"}],
+            :user_create_date=>Time.now,
+            :enabled=>true,
+            :user_status=>"CONFIRMED"}
+          ]
+      }
+  }
+  let(:users_with_gds){
+    {:users=>
+          [
+            {:username=>"00000-0000-0000-000",
+             :attributes=>
+             [{:name=> "sub", :value=> "123"},
+              {:name=>"email_verified", :value=>"true"},
+              {:name=>"given_name", :value=>"Test"},
+              {:name=>"family_name", :value=>"Test"},
+              {:name=>"email", :value=>"test@test.test"}],
+            :user_create_date=>Time.now,
+            :user_last_modified_date=>Time.now,
+            :enabled=>true,
+            :user_status=>"CONFIRMED"},
+           {:username=>"00000-0000-0000-001",
+            :attributes=>
+             [{:name=>"sub", :value=>"124"},
+              {:name=>"custom:roles", :value=>"usermgr"},
+              {:name=>"given_name", :value=>"Test"},
+              {:name=>"family_name", :value=>"Testerator"},
+              {:name=>"email", :value=>"some@user.com"}],
+            :user_create_date=>Time.now,
+            :user_status=>"CONFIRMED"},
+           {:username=>"00000-0000-0000-002",
+            :attributes=>
+             [{:name=>"sub", :value=>"125"},
+              {:name=>"custom:roles", :value=>"gds"},
+              {:name=>"given_name", :value=>"User"},
+              {:name=>"family_name", :value=>"Admin"},
+              {:name=>"email", :value=>"admin@digital.cabinet-office.gov.uk"}],
+            :user_create_date=>Time.now,
+            :user_status=>"CONFIRMED"}
+          ]
+    }
+  }
+  let(:users_with_gds_but_not_gds_email){
+   
+          [
+            {username:"00000-0000-0000-000",
+             attributes:
+             [{:name=> "sub", :value=> "123"},
+              {:name=>"given_name", :value=>"Test"},
+              {:name=>"family_name", :value=>"Test"},
+              {:name=>"email", :value=>"test@test.test"}],
+            :user_create_date=>Time.now,
+            :user_status=>"CONFIRMED"},
+           {username:"00000-0000-0000-001",
+            attributes:
+             [{:name=>"sub", :value=>"124"},
+              {:name=>"custom:roles", :value=>"usermgr"},
+              {:name=>"given_name", :value=>"Test"},
+              {:name=>"family_name", :value=>"Testerator"},
+              {:name=>"email", :value=>"some@user.com"}],
+            :user_create_date=>Time.now,
+            :user_status=>"CONFIRMED"},
+           {username:"00000-0000-0000-002",
+            attributes:
+             [{:name=>"sub", :value=>"125"},
+              {:name=>"custom:roles", :value=>"gds"},
+              {:name=>"given_name", :value=>"User"},
+              {:name=>"family_name", :value=>"Admin"},
+              {:name=>"email", :value=>"admin@non-gds.com"}],
+            :user_create_date=>Time.now,
+            :user_status=>"CONFIRMED"}
+          ]
+    
+  }
+
+  describe '#gds_group_exists?' do
+    it 'returns true when both Cognito group and the GDS Team exist' do
+      stub_cognito_response(method: :get_group, payload: {})
+      Team.create(name:TEAMS::GDS, team_alias: TEAMS::GDS)
+      expect(subject.gds_group_exists?).to eq(true)
+    end
+    it 'returns false when Cognito group exists but GDS Team does not' do
+      stub_cognito_response(method: :get_group, payload: {})
+      expect(subject.gds_group_exists?).to eq(false)
+    end
+    it 'returns false when Cognito group does not exist' do
+      stub_cognito_response(
+        method: :get_group, 
+        payload: Aws::CognitoIdentityProvider::Errors::ResourceNotFoundException.new(nil, nil))
+      expect(subject.gds_group_exists?).to eq(false)
+    end
+    it 'returns false when Cognito throws an error' do
+      stub_cognito_response(
+        method: :get_group, 
+        payload: Aws::CognitoIdentityProvider::Errors::ServiceError.new(nil, nil))
+      expect(subject.gds_group_exists?).to eq(false)
+    end
+  end
+
+  describe '#gds_user_exists?' do
+    it 'returns number of GDS users found if there are any' do
+      stub_cognito_response(method: :list_users, payload: users_with_gds)
+      expect(subject.gds_user_exists?).to eq(1)
+      expect(subject.gds_user_exists?).to be_truthy
+    end
+    it 'returns false if zero number of GDS users found' do
+      stub_cognito_response(method: :list_users, payload: users_without_gds)
+      expect(subject.gds_user_exists?).to be_truthy
+    end
+    it 'returns false when Cognito throws an error' do
+      stub_cognito_response(
+        method: :list_users, 
+        payload: Aws::CognitoIdentityProvider::Errors::ServiceError.new(nil, nil))
+      expect(subject.gds_user_exists?).to eq(false)
+    end
+  end
+
+  describe '#add_gds_users_to_group' do
+    it 'adds 1 GDS user to the GDS group when 1 user has both GDS role and GDS email' do
+      gds_users = JSON.parse(users_with_gds[:users].to_json, object_class: OpenStruct)
+      expect(SelfService.service(:cognito_client)).to receive(:admin_add_user_to_group).once
+      subject.add_gds_users_to_group(gds_users)
+    end
+    it 'adds none GDS user to the GDS group when 1 user has GDS role but not GDS email' do
+      gds_users = JSON.parse(users_with_gds_but_not_gds_email.to_json, object_class: OpenStruct)
+      expect(SelfService.service(:cognito_client)).to_not receive(:admin_add_user_to_group)
+      subject.add_gds_users_to_group(gds_users)
+    end
+  end
+end

--- a/spec/lib/auth/initial_seeder_spec.rb
+++ b/spec/lib/auth/initial_seeder_spec.rb
@@ -133,11 +133,10 @@ RSpec.describe InitialSeeder do
     it 'returns number of GDS users found if there are any' do
       stub_cognito_response(method: :list_users, payload: users_with_gds)
       expect(subject.gds_user_exists?).to eq(1)
-      expect(subject.gds_user_exists?).to be_truthy
     end
-    it 'returns false if zero number of GDS users found' do
+    it 'returns zero if zero number of GDS users found' do
       stub_cognito_response(method: :list_users, payload: users_without_gds)
-      expect(subject.gds_user_exists?).to be_truthy
+      expect(subject.gds_user_exists?).to eq(0)
     end
     it 'returns false when Cognito throws an error' do
       stub_cognito_response(


### PR DESCRIPTION
Adding logic to seed Cognito and the DB with minimum required user.
It's not possible to login as a GDS user in a new environment or when
cognito is recreated.
This makes sure there's at least one GDS user and the GDS group.
In addition, updated the `db/seeds.rb` to create the GDS group when
the database is set up.

Open to comments or other suggestions.