### PR TITLE
Add healthcheck name to logger output

### DIFF
--- a/app/models/healthcheck/checker.rb
+++ b/app/models/healthcheck/checker.rb
@@ -29,7 +29,7 @@ module Healthcheck
     def build_check_status(check)
       { status: check.status }
     rescue StandardError => e
-      Rails.logger.error(e.to_s)
+      Rails.logger.error("#{check.name} => #{e}")
       { status: CRITICAL }
     end
 


### PR DESCRIPTION
It would be a little more helpful if the specific healthcheck name was also logged when something is critical.