### PR TITLE
Add logger to storage client

### DIFF
--- a/lib/storage/storage_registrar.rb
+++ b/lib/storage/storage_registrar.rb
@@ -16,7 +16,7 @@ class StorageRegistrar
   def register_production_client
     SelfService.register_service(
       name: :storage_client,
-      client: Aws::S3::Client.new(log_level: :debug)
+      client: Aws::S3::Client.new(logger: Rails.logger, log_level: :debug)
     )
   end
 


### PR DESCRIPTION
Doesn't use Rails' logger by default