### PR TITLE
Fix storage healthcheck

### DIFF
--- a/app/models/healthcheck/storage_check.rb
+++ b/app/models/healthcheck/storage_check.rb
@@ -10,7 +10,8 @@ module Healthcheck
           SelfService.service(:storage_client).put_object(
             bucket: bucket,
             key: FILES::HEALTHCHECK,
-            body: ''
+            body: '',
+            server_side_encryption: 'AES256'
           )
         end
       end

--- a/lib/storage/storage_registrar.rb
+++ b/lib/storage/storage_registrar.rb
@@ -16,7 +16,7 @@ class StorageRegistrar
   def register_production_client
     SelfService.register_service(
       name: :storage_client,
-      client: Aws::S3::Client.new(logger: Rails.logger, log_level: :debug)
+      client: Aws::S3::Client.new(logger: Rails.logger, log_level: :info)
     )
   end
 


### PR DESCRIPTION
We require the encryption header to be set with all requests that put an object in the config metadata bucket.

https://trello.com/c/PMZorhCM/634-add-permission-for-app-in-staging-to-publish-to-integration-bucket

![flip](https://user-images.githubusercontent.com/3466862/63854138-5c285280-c994-11e9-82ee-bc47580fe9dd.gif)
