### PR TITLE
BAU: Fix the wrong bucket selection

### DIFF
--- a/app/models/publish_services_metadata_event.rb
+++ b/app/models/publish_services_metadata_event.rb
@@ -31,9 +31,9 @@ private
   end
 
   def hub_environment_bucket
-    Rails.configuration.hub_environments.fetch(environment.to_sym)
+    Rails.configuration.hub_environments.fetch(environment)
   rescue KeyError
     Rails.logger.error("Failed to find bucket for #{environment}")
-    "#{Rails.env}-bucket"
+    "#{environment}-bucket"
   end
 end


### PR DESCRIPTION
We're unable to publish to S3, because we're parsing the list of buckets to
JSON, but querying it by a symbol. This changes it to use the value directly
(rather than symbolizing it first)
Also fix the return value, to return the the component bucket instead of the
Rails.env

Co-Authored-By: Alan Carter <alan.carter@digital.cabinet-office.gov.uk>