### PR TITLE
Healthcheck improvements

### DIFF
--- a/app/models/healthcheck/checker.rb
+++ b/app/models/healthcheck/checker.rb
@@ -1,7 +1,7 @@
 module Healthcheck
   STATUSES = [
     OK = :ok,
-    CRITICAL = :critical,
+    UNAVAILABLE = :service_unavailable,
   ].freeze
 
   class Checker
@@ -30,16 +30,16 @@ module Healthcheck
       { status: check.status }
     rescue StandardError => e
       Rails.logger.error("#{check.name} => #{e}")
-      { status: CRITICAL }
+      { status: UNAVAILABLE }
     end
 
     def worst_status
-      critical? ? CRITICAL : OK
+      unavailable? ? UNAVAILABLE : OK
     end
 
-    def critical?
+    def unavailable?
       check_statuses.values.any? do |s|
-        s[:status] == CRITICAL || s[:status].blank?
+        s[:status] == UNAVAILABLE || s[:status].blank?
       end
     end
   end

--- a/app/models/healthcheck/storage_check.rb
+++ b/app/models/healthcheck/storage_check.rb
@@ -6,13 +6,17 @@ module Healthcheck
 
     def status
       Rails.configuration.hub_environments.values.each do |bucket|
-        unless healthcheck_file_exists?(bucket)
-          SelfService.service(:storage_client).put_object(
-            bucket: bucket,
-            key: FILES::HEALTHCHECK,
-            body: '',
-            server_side_encryption: 'AES256'
-          )
+        begin
+          unless healthcheck_file_exists?(bucket)
+            SelfService.service(:storage_client).put_object(
+              bucket: bucket,
+              key: FILES::HEALTHCHECK,
+              body: '',
+              server_side_encryption: 'AES256'
+            )
+          end
+        rescue Aws::S3::Errors::ServiceError
+          raise StandardError.new("Error connecting to #{bucket} bucket")
         end
       end
 

--- a/spec/controllers/healthcheck_controller_spec.rb
+++ b/spec/controllers/healthcheck_controller_spec.rb
@@ -31,10 +31,10 @@ RSpec.describe HealthcheckController, type: :controller do
       get :index
       json_response = JSON.parse(response.body)
 
-      expect(response).to have_http_status(:error)
-      expect(json_response['status']).to eq('critical')
+      expect(response).to have_http_status(:service_unavailable)
+      expect(json_response['status']).to eq('service_unavailable')
       json_response['checks'].each do |_, check_status|
-        expect(check_status['status']).to eq('critical')
+        expect(check_status['status']).to eq('service_unavailable')
       end
     end
   end


### PR DESCRIPTION
### Use service unavailable status instead of error

More appropriate error and will improve our logging output as well.

### Output bucket name in logs for healthcheck

Now that we will be connecting to two buckets in production it would be useful to see the bucket name in the logs should an error occur when checking connectivity.


Rails status codes can be found here: http://www.railsstatuscodes.com/