### PR TITLE
BAU: Fix caching in production (and dev)

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -26,7 +26,7 @@ Rails.application.configure do
   else
     config.action_controller.perform_caching = false
 
-    config.cache_store = :null_store
+    config.cache_store = :memory_store
   end
 
   # Don't care if the mailer can't send.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,7 +64,7 @@ Rails.application.configure do
   config.log_tags = [ :request_id ]
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :memory_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque


### PR DESCRIPTION
We're now using cache to store the JWK. However, we did not configure it
in production. This enables the `memory_store` in a production deployment.

Additionally, enabling the same for dev, so people don't have to manually create
the `caching-dev.txt` file in their tmp folder.