### PR TITLE
BAU: Fix the linter precommit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,5 +3,5 @@
     -   id: lint
         name: govuk linter
         entry: bundle exec govuk-lint-ruby
-        files: (app|lib)
+        files: (^app|^lib)
         language: system


### PR DESCRIPTION
The regex was too wide capturing the lib folder in the spec folder
which we don't want to lint. This makes sure it only lookes at the root/app and root/lib.