### PR TITLE
BAU: Fix the JWK loader caching issues

### DIFF
--- a/lib/auth/cognito_chooser.rb
+++ b/lib/auth/cognito_chooser.rb
@@ -51,6 +51,7 @@ class CognitoChooser
   end
 
   def register_stub_client
+    require 'auth/jwks_loader_stub'
     Rails.configuration.cognito_client_id = SecureRandom.uuid
     Rails.configuration.cognito_user_pool_id = SecureRandom.uuid
     register_client(

--- a/lib/auth/cognito_stub_client.rb
+++ b/lib/auth/cognito_stub_client.rb
@@ -88,8 +88,8 @@ class CognitoStubClient
   end
 
   def self.register_jwks
-    $cognito_jwt_private_key = OpenSSL::PKey::RSA.generate(2048)
-    jwks_loader = JwksLoader.new(false)
+    cognito_jwt_private_key = OpenSSL::PKey::RSA.generate(2048)
+    jwks_loader = JwksLoaderStub.new(cognito_jwt_private_key)
     SelfService.register_service(name: :jwks, client: jwks_loader)
   end
 end

--- a/lib/auth/jwks_loader_stub.rb
+++ b/lib/auth/jwks_loader_stub.rb
@@ -1,0 +1,18 @@
+class JwksLoaderStub < JwksLoader
+  attr_reader :jwk
+  def initialize(cognito_jwk_private_key)
+    @jwk_private_key = cognito_jwk_private_key
+    stub_jwk
+  end
+
+  def call(_options)
+    stub_jwk
+  end
+
+private
+
+  def stub_jwk
+    @jwk = JWT::JWK.new(@jwk_private_key)
+    { keys: [@jwk.export] }
+  end
+end


### PR DESCRIPTION
We're using the cache incorrectly, we never refresh it and so once it expires it fails
to validate JWT as it doesn't have the keys. This PR:
- fixes the fetch/call methods to refresh (not only fetch)
- extract the JWKs loader to its own stub method
- loads the stub JWK loader only if cognito_stub is being loaded
- removes the use of global variable for the keys
- removes the need to use caching for local/stub JWKs as there's no reason