### PR TITLE
Tvw7aqnq: switch to guids from ids

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
 language: ruby
 addons:
   firefox: latest
+services:
+  - postgresql
+before_script:
+  - psql -c 'create database vss_test;' -U postgres
+test:
+  adapter: postgresql
+  database: vss_test

--- a/Gemfile
+++ b/Gemfile
@@ -57,8 +57,6 @@ group :development, :test do
   gem 'capybara'
   gem 'selenium-webdriver'
   gem 'geckodriver-helper'
-  # still use sqlite3 in development and testing.
-  gem 'sqlite3'
   gem 'pry'
   gem 'govuk-lint'
   gem 'factory_bot_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,7 +282,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.1)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
@@ -342,7 +341,6 @@ DEPENDENCIES
   sentry-raven
   spring
   spring-watcher-listen (~> 2.0.0)
-  sqlite3
   turbolinks (~> 5)
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,7 +28,10 @@ module VerifySelfService
     # the framework and any gems in your application.
     # Don't generate system test files.
     config.generators.system_tests = nil
-
+    # explicitly override ActiveRecord primary_key type from id to use uuid
+    config.generators do |g|
+      g.orm :active_record, primary_key_type: :uuid
+    end
     # by default rails wraps invalid inputs with <div class="field_with_errors">
     # we have our own way of styling errors, so we don't need this behaviour:
     config.action_view.field_error_proc = Proc.new { |html_tag| html_tag }

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,30 +1,35 @@
-# SQLite version 3.x
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
-#
+# Install postgres
+# brew install postgresql
+
+# How to postgres databases:
+# Start postgres:
+# pg_ctl -D /usr/local/var/postgres -l /usr/local/var/postgres/server.log start
+
+# list all postgres databases
+# psql postgres -h localhost -l
+
+# Stop postgres:
+# pg_ctl -D /usr/local/var/postgres stop -s -m fast
+
 default: &default
+  adapter: postgresql
+  encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
-  encoding: unicode
 
 development:
   <<: *default
-  adapter: sqlite3
-  database: db/vss_development.sqlite3
+  database: vss_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  adapter: sqlite3
-  database: db/vss_test.sqlite3
+  database: vss_test
 
 production:
   <<: *default
-  adapter: postgresql
   username: <%= ENV['DATABASE_USERNAME'] %>
   password: <%= ENV['DATABASE_PASSWORD'] %>
   database: <%= ENV['DATABASE_NAME'] %>

--- a/config/initializers/constants/teams.rb
+++ b/config/initializers/constants/teams.rb
@@ -1,5 +1,5 @@
 module TEAMS
   GDS = 'gds'.freeze
-  GDS_EMAIL_DOMAIN = 'digital.cabinet-office.gov.uk'
+  GDS_EMAIL_DOMAIN = 'digital.cabinet-office.gov.uk'.freeze
   GROUP_NAME_REGEX = /[\p{L}\p{M}\p{S}\p{N}\p{P}]+/.freeze
 end

--- a/db/migrate/20190831095851_enable_pg_uuid_extension.rb
+++ b/db/migrate/20190831095851_enable_pg_uuid_extension.rb
@@ -1,0 +1,5 @@
+class EnablePgUuidExtension < ActiveRecord::Migration[5.2]
+  def change
+    enable_extension 'pgcrypto'
+  end
+end

--- a/db/migrate/20190831100053_drop_all_selfservice_table.rb
+++ b/db/migrate/20190831100053_drop_all_selfservice_table.rb
@@ -1,0 +1,14 @@
+class DropAllSelfserviceTable < ActiveRecord::Migration[5.2]
+  def up
+    drop_table "certificates" , if_exists: true
+    drop_table "events" , if_exists: true
+    drop_table "msa_components" , if_exists: true
+    drop_table "services" , if_exists: true
+    drop_table "sp_components" , if_exists: true
+    drop_table "teams" , if_exists: true
+  end
+
+  def down
+    fail ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20190831100615_recreate_selfservice_table_from_schema_uuid.rb
+++ b/db/migrate/20190831100615_recreate_selfservice_table_from_schema_uuid.rb
@@ -1,0 +1,67 @@
+class RecreateSelfserviceTableFromSchemaUuid < ActiveRecord::Migration[5.2]
+  def change
+    create_table "certificates", id: :uuid do |t|
+      t.string "value"
+      t.string "usage"
+      t.datetime "created_at", null: false
+      t.datetime "updated_at", null: false
+      t.uuid "component_id"
+      t.boolean "enabled", default: true
+      t.string "component_type"
+      t.index ["component_id"], name: "index_certificates_on_component_id"
+    end
+
+    create_table "events", id: :uuid do |t|
+      t.string "type", null: false
+      t.json "data"
+      t.string "aggregate_type"
+      t.uuid "aggregate_id"
+      t.datetime "created_at", null: false
+      t.datetime "updated_at", null: false
+      t.string "user_id"
+      t.index ["aggregate_type", "aggregate_id"], name: "index_events_on_aggregate_type_and_aggregate_id"
+    end
+
+    create_table "teams", id: :uuid do |t|
+      t.string "name"
+      t.datetime "created_at", null: false
+      t.datetime "updated_at", null: false
+      t.string "team_alias"
+      t.index ["name"], name: "index_teams_on_name", unique: true
+    end
+
+    create_table "msa_components", id: :uuid do |t|
+      t.string "name"
+      t.string "component_type"
+      t.uuid "encryption_certificate_id", null: true
+      t.string "entity_id"
+      t.datetime "created_at", null: false
+      t.datetime "updated_at", null: false
+      t.uuid "team_id"
+      t.string "environment", null: false
+      t.index ["team_id"], name: "index_msa_components_on_team_id"
+    end
+
+    create_table "sp_components", id: :uuid do |t|
+      t.string "name"
+      t.string "component_type"
+      t.uuid "encryption_certificate_id", null: true
+      t.datetime "created_at", null: false
+      t.datetime "updated_at", null: false
+      t.boolean "vsp", default: false
+      t.uuid "team_id"
+      t.string "environment", null: false
+      t.index ["team_id"], name: "index_sp_components_on_team_id"
+    end
+
+    create_table "services", id: :uuid do |t|
+      t.string "entity_id", null: false
+      t.string "name"
+      t.uuid "sp_component_id"
+      t.uuid "msa_component_id"
+      t.datetime "created_at", null: false
+      t.datetime "updated_at", null: false
+      t.index ["entity_id"], name: "index_services_on_entity_id", unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,65 +10,69 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_22_141252) do
+ActiveRecord::Schema.define(version: 2019_08_31_100615) do
 
-  create_table "certificates", force: :cascade do |t|
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "pgcrypto"
+  enable_extension "plpgsql"
+
+  create_table "certificates", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "value"
     t.string "usage"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "component_id"
+    t.uuid "component_id"
     t.boolean "enabled", default: true
     t.string "component_type"
     t.index ["component_id"], name: "index_certificates_on_component_id"
   end
 
-  create_table "events", force: :cascade do |t|
+  create_table "events", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "type", null: false
     t.json "data"
     t.string "aggregate_type"
-    t.integer "aggregate_id"
+    t.uuid "aggregate_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "user_id"
     t.index ["aggregate_type", "aggregate_id"], name: "index_events_on_aggregate_type_and_aggregate_id"
   end
 
-  create_table "msa_components", force: :cascade do |t|
+  create_table "msa_components", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name"
     t.string "component_type"
-    t.integer "encryption_certificate_id"
+    t.uuid "encryption_certificate_id"
     t.string "entity_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "team_id"
-    t.string "environment"
+    t.uuid "team_id"
+    t.string "environment", null: false
     t.index ["team_id"], name: "index_msa_components_on_team_id"
   end
 
-  create_table "services", force: :cascade do |t|
+  create_table "services", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "entity_id", null: false
     t.string "name"
-    t.integer "sp_component_id"
-    t.integer "msa_component_id"
+    t.uuid "sp_component_id"
+    t.uuid "msa_component_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["entity_id"], name: "index_services_on_entity_id", unique: true
   end
 
-  create_table "sp_components", force: :cascade do |t|
+  create_table "sp_components", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name"
     t.string "component_type"
-    t.integer "encryption_certificate_id"
+    t.uuid "encryption_certificate_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "vsp", default: false
-    t.integer "team_id"
-    t.string "environment"
+    t.uuid "team_id"
+    t.string "environment", null: false
     t.index ["team_id"], name: "index_sp_components_on_team_id"
   end
 
-  create_table "teams", force: :cascade do |t|
+  create_table "teams", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -42,7 +42,7 @@ ActiveRecord::Schema.define(version: 2019_08_22_141252) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "team_id"
-    t.string "environment", null: false
+    t.string "environment"
     t.index ["team_id"], name: "index_msa_components_on_team_id"
   end
 
@@ -64,7 +64,7 @@ ActiveRecord::Schema.define(version: 2019_08_22_141252) do
     t.datetime "updated_at", null: false
     t.boolean "vsp", default: false
     t.integer "team_id"
-    t.string "environment", null: false
+    t.string "environment"
     t.index ["team_id"], name: "index_sp_components_on_team_id"
   end
 

--- a/spec/controllers/msa_components_controller_spec.rb
+++ b/spec/controllers/msa_components_controller_spec.rb
@@ -3,6 +3,8 @@
 RSpec.describe MsaComponentsController, type: :controller do
   include AuthSupport
 
+  let(:msa_component) { create(:msa_component) }
+
   describe "GET #index" do
     it "returns http success" do
       compmgr_stub_auth
@@ -29,7 +31,7 @@ RSpec.describe MsaComponentsController, type: :controller do
   describe "GET #edit" do
     it "returns http success" do
       certmgr_stub_auth
-      get :edit, params: { id: 1 }
+      get :edit, params: { id: msa_component.id }
       expect(response).to have_http_status(:success)
     end
   end

--- a/spec/controllers/sp_components_controller_spec.rb
+++ b/spec/controllers/sp_components_controller_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe SpComponentsController, type: :controller do
   include AuthSupport
 
+  let(:sp_component) { create(:sp_component) }
+
   describe "GET #index" do
     it "returns http success" do
       compmgr_stub_auth
@@ -29,7 +31,7 @@ RSpec.describe SpComponentsController, type: :controller do
   describe "GET #edit" do
     it "returns http success" do
       certmgr_stub_auth
-      get :edit, params: { id: 1 }
+      get :edit, params: { id: sp_component.id }
       expect(response).to have_http_status(:success)
     end
   end

--- a/spec/controllers/user_journey_controller_spec.rb
+++ b/spec/controllers/user_journey_controller_spec.rb
@@ -3,22 +3,31 @@ require 'rails_helper'
 RSpec.describe UserJourneyController, type: :controller do
   include AuthSupport
   include CertificateSupport
+  let(:msa_component) { create(:msa_component) }
+  let(:msa_encryption_cert) { create(:msa_encryption_certificate) }
 
-  describe "GET #index" do
-    it "returns http success" do
-      certmgr_stub_auth
-      get :index
-      expect(response).to have_http_status(:success)
-    end
+  before do
+    ReplaceEncryptionCertificateEvent.create(
+      component: msa_encryption_cert.component, encryption_certificate_id: msa_encryption_cert.id
+    )
+  end
 
-    it "should redirect to sign-page" do
+  context 'GET #index' do
+
+    it 'should redirect to sign-page when not logged in' do
       get :index
       expect(response).to have_http_status(:redirect)
       expect(subject).to redirect_to(new_user_session_path)
       expect(subject).not_to redirect_to(root_path)
     end
-  
-    it "should render when logged in" do
+
+    it 'returns http success' do
+      certmgr_stub_auth
+      get :index
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'should render when logged in' do
       certmgr_stub_auth
       get :index
       expect(response).to have_http_status(:success)
@@ -26,77 +35,98 @@ RSpec.describe UserJourneyController, type: :controller do
       expect(subject).to render_template(:index)
     end
 
-    it "should show the user their team components" do
+    it 'should show the user their team components' do
       certmgr_stub_auth
-      sp_component = FactoryBot.create(:sp_component, team_id: 1)
+      sp_component = FactoryBot.create(:sp_component, team_id: @user.team)
       get :index
       expect(response).to have_http_status(:success)
       expect(@controller.instance_variable_get(:@sp_components).length).to eq(1)
       expect(@controller.instance_variable_get(:@sp_components)[0].team_id).to eq(sp_component.team_id)
     end
 
-    it "should not show user components with different id" do
+    it 'should not show user components with different id' do
       certmgr_stub_auth
-      sp_component = FactoryBot.create(:sp_component, team_id: 99)
+      FactoryBot.create(:sp_component, team_id: SecureRandom.uuid)
       get :index
       expect(response).to have_http_status(:success)
       expect(@controller.instance_variable_get(:@sp_components).length).to eq(0)
       expect(@controller.instance_variable_get(:@sp_components)[0]).to eq(nil)
     end
 
-    it "should only show the user their team components with the same id" do
+    it 'should only show the user their team components with the same id' do
       certmgr_stub_auth
-      sp_component = FactoryBot.create(:sp_component, team_id: 1)
-      other_team_sp_component = FactoryBot.create(:sp_component, team_id: 99)
+      sp_component = FactoryBot.create(:sp_component, team_id: @user.team)
+      FactoryBot.create(:sp_component, team_id: SecureRandom.uuid)
       get :index
       expect(response).to have_http_status(:success)
       expect(@controller.instance_variable_get(:@sp_components).length).to eq(1)
       expect(@controller.instance_variable_get(:@sp_components)[0].team_id).to eq(sp_component.team_id)
     end
-
-
   end
 
-  describe '#view_certificate' do
+  context '#view_certificate ' do
     it 'renders the view certificate page' do
       certmgr_stub_auth
-      get :view_certificate, params: { component_type: 'MsaComponent', component_id: 1, certificate_id: 1 }
+      get :view_certificate,
+          params: {
+            component_type: msa_component.component_type,
+            component_id: msa_component.id,
+            certificate_id: msa_encryption_cert.id
+          }
       expect(response).to have_http_status(:success)
       expect(subject).to render_template(:view_certificate)
     end
 
-    it "returns http redirect for unauthorised user" do
+    it 'returns http redirect for unauthorised user' do
       usermgr_stub_auth
-      get :view_certificate, params: { component_type: 'MsaComponent', component_id: 1, certificate_id: 1 }
-      expect(flash[:warn]).to match("You are not authorised to perform this action")
+      get :view_certificate,params: {
+        component_type: msa_component.component_type,
+        component_id: msa_component.id,
+        certificate_id: msa_encryption_cert.id
+      }
+      expect(flash[:warn]).to match('You are not authorised to perform this action')
       expect(response).to have_http_status(:forbidden)
     end
   end
 
-  describe '#before_you_start' do
+  context '#before_you_start' do
     it 'renders the before you start page' do
       certmgr_stub_auth
-      get :before_you_start, params: { component_type: 'MsaComponent', component_id: 1, certificate_id: 1 }
+      get :before_you_start,
+          params: {
+            component_type: msa_component.component_type,
+            component_id: msa_component.id,
+            certificate_id: msa_encryption_cert.id
+          }
       expect(response).to have_http_status(:success)
       expect(subject).to render_template(:before_you_start)
     end
   end
 
-  describe '#upload_certificate' do
+  context '#upload_certificate ' do
     it 'renders upload certificate page' do
       certmgr_stub_auth
-      get(:upload_certificate, params: { component_type: 'MsaComponent', component_id: 1, certificate_id: 1 })
+      get :upload_certificate,
+          params: {
+            component_type: msa_component.component_type,
+            component_id: msa_component.id,
+            certificate_id: msa_encryption_cert.id
+          }
       expect(response).to have_http_status(:success)
       expect(subject).to render_template(:upload_certificate)
     end
   end
 
-  describe '#check_your_certificate' do
-    it 'renders check your certificate page' do
+  context '#check_your_certificate' do
+    it 'renders upload certificate page' do
       certmgr_stub_auth
-      certificate = create(:msa_encryption_certificate)
-      msa_component = certificate.component
-      post(:submit, params: { component_type: 'MsaComponent', component_id: 1, certificate_id: 1, certificate: { value: certificate.value } })
+      post :submit,
+           params: {
+             component_type: msa_component.component_type,
+             component_id: msa_component.id,
+             certificate_id: msa_encryption_cert.id,
+             certificate: { value: msa_encryption_cert.value }
+           }
       expect(response).to have_http_status(:success)
       expect(subject).to render_template(:check_your_certificate)
     end
@@ -107,7 +137,13 @@ RSpec.describe UserJourneyController, type: :controller do
       certmgr_stub_auth
       certificate = create(:msa_encryption_certificate)
       msa_component = certificate.component
-      post(:confirm, params: { component_type: 'MsaComponent', component_id: 1, certificate_id: 1, certificate: { new_certificate: certificate.value } })
+      post(:confirm,
+           params: {
+             component_type: msa_component.component_type,
+             component_id: msa_component.id,
+             certificate_id: msa_encryption_cert.id,
+             certificate: { new_certificate: certificate.value } }
+          )
       expect(response).to have_http_status(:success)
       expect(subject).to render_template(:confirmation)
     end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -7,26 +7,26 @@ RSpec.describe UsersController, type: :controller do
     before(:each) do
       gdsuser_stub_auth
     end
-  
+
     describe '#index' do
       it 'renders the page' do
-        get :index, :params => { :team_id => 0 }
+        get :index, :params => { :team_id => @user.team }
         expect(response).to have_http_status(:success)
         expect(subject).to render_template(:index)
       end
     end
-  
+
     describe '#invite' do
       it 'renders the invite page' do
-        get :invite, :params => { :team_id => 0 }
+        get :invite, :params => { :team_id => @user.team }
         expect(response).to have_http_status(:success)
         expect(subject).to render_template(:invite)
       end
     end
-  
+
     describe '#new' do
       it 'invites the user when all valid' do
-        Rails.configuration.cognito_user_pool_id = "dummy"
+        Rails.configuration.cognito_user_pool_id = 'dummy'
         stub_cognito_response(method: :admin_create_user, payload: { user: { username:'test@test.test' } })
         team = FactoryBot.create(:team)
         post :new, params: {
@@ -44,7 +44,7 @@ RSpec.describe UsersController, type: :controller do
         expect(flash.now[:errors]).to be_nil
         expect(flash.now[:success]).not_to be_nil
       end
-  
+
       it 'fails to invite user when form params missing' do
         post :new, :params => { :team_id => 0 }
         expect(response).to have_http_status(:bad_request)
@@ -57,26 +57,26 @@ RSpec.describe UsersController, type: :controller do
     before(:each) do
       usermgr_stub_auth
     end
-  
+
     describe '#index' do
       it 'renders the page when team is matching' do
-        team = FactoryBot.create(:team)
-        get :index, :params => { :team_id => team.id }
+        team = FactoryBot.create(:team, id: @user.team)
+        get :index, :params => { :team_id => team.id}
         expect(response).to have_http_status(:success)
         expect(subject).to render_template(:index)
       end
     end
-  
+
     describe '#invite' do
       it 'renders the invite page when team is matching' do
-        team = FactoryBot.create(:team)
+        team = FactoryBot.create(:team, id: @user.team)
         get :invite, :params => { :team_id => team.id }
         expect(response).to have_http_status(:success)
         expect(subject).to render_template(:invite)
       end
 
       it 'does not render the invite page when team is not matching' do
-        foreign_team = FactoryBot.create(:team, id: 99)
+        foreign_team = FactoryBot.create(:team, id: SecureRandom.uuid)
         get :invite, :params => { :team_id => foreign_team.id }
         expect(response).to_not have_http_status(:success)
         expect(subject).to_not render_template(:invite)
@@ -84,12 +84,13 @@ RSpec.describe UsersController, type: :controller do
         expect(flash[:warn]).to eq("You are not authorised to perform this action")
       end
     end
-  
+
     describe '#new' do
       it 'invites the user when all valid' do
         Rails.configuration.cognito_user_pool_id = "dummy"
         stub_cognito_response(method: :admin_create_user, payload: { user: { username:'test@test.test' } })
-        team = FactoryBot.create(:team)
+        team = FactoryBot.create(:team, id: @user.team)
+
         post :new, params: {
           team_id: team.id,
           invite_user_form:
@@ -105,9 +106,9 @@ RSpec.describe UsersController, type: :controller do
         expect(flash.now[:errors]).to be_nil
         expect(flash.now[:success]).not_to be_nil
       end
-  
+
       it 'fails to invite user when inviting to a foreign team' do
-        foreign_team = FactoryBot.create(:team, id: 99)
+        foreign_team = FactoryBot.create(:team, id: SecureRandom.uuid)
         post :new, params: {
           team_id: foreign_team.id,
           invite_user_form:

--- a/spec/factories/certificate.rb
+++ b/spec/factories/certificate.rb
@@ -2,12 +2,12 @@ FactoryBot.define do
   factory :msa_encryption_certificate, class: Certificate do
     usage { CERTIFICATE_USAGE::ENCRYPTION }
     value { PKI.new.generate_encoded_cert(expires_in: 9.months) }
-    component { create(:msa_component, encryption_certificate_id: 1) }
+    component { create(:msa_component) }
   end
   factory :sp_encryption_certificate, class: Certificate do
     usage { CERTIFICATE_USAGE::ENCRYPTION }
     value { PKI.new.generate_encoded_cert(expires_in: 9.months) }
-    component { create(:sp_component, encryption_certificate_id: 1) }
+    component { create(:sp_component) }
   end
   factory :msa_signing_certificate, class: Certificate do
     usage { CERTIFICATE_USAGE::SIGNING }

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :team do
-    id { 1 }
     name { 'Test Team' }
     team_alias { 'testteam' }
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,29 +1,27 @@
 FactoryBot.define do
   factory :user do
-    given_name { "John" }
-    family_name  { "Doe" }
-    email { "test@test.test" }
-    password { "validpassword" }
+    given_name { 'John' }
+    family_name  { 'Doe' }
+    email { 'test@test.test' }
+    password { 'validpassword' }
     roles { ROLE::USER_MANAGER }
     cognito_groups { ['test'] }
-    team { 1 }
+    team { SecureRandom.uuid }
     session_start_time { Time.now.to_s }
 
     factory :gds_user do
-      email { "test.test@digital.cabinet-office.gov.uk" }
+      email { 'test.test@digital.cabinet-office.gov.uk' }
       roles { ROLE::GDS }
-      permissions { UserRolePermissions.new(ROLE::GDS, "test.test@digital.cabinet-office.gov.uk") }
+      permissions { UserRolePermissions.new(ROLE::GDS, 'test.test@digital.cabinet-office.gov.uk') }
     end
 
     factory :certificate_manager_user do
       roles { ROLE::CERTIFICATE_MANAGER }
-      team { 1 }
       permissions { UserRolePermissions.new(ROLE::CERTIFICATE_MANAGER) }
     end
 
     factory :user_manager_user do
       roles { ROLE::USER_MANAGER }
-      team { 1 }
       permissions { UserRolePermissions.new(ROLE::USER_MANAGER) }
     end
 

--- a/spec/models/change_component_event_spec.rb
+++ b/spec/models/change_component_event_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe ChangeComponentEvent, type: :model do
   let(:msa_component) { create(:new_msa_component_event).msa_component }
   let(:sp_component) { create(:new_sp_component_event).sp_component }
-  let(:team_id) { 1 }
+  let(:team) { create(:team) }
   let(:msa_change_event) do
     ChangeComponentEvent.create(component: msa_component)
   end
@@ -20,12 +20,12 @@ RSpec.describe ChangeComponentEvent, type: :model do
 
     it 'has team id assigned to event metadata' do
       expect(msa_component.team_id).to be_nil
-      msa_component.team_id = team_id
+      msa_component.team_id = team.id
 
-      expect(msa_change_event.team_id).to eq team_id
+      expect(msa_change_event.team_id).to eq team.id
     end
   end
- 
+
   context 'on SP' do
     it 'must be valid' do
       expect(sp_change_event).to be_valid
@@ -35,10 +35,9 @@ RSpec.describe ChangeComponentEvent, type: :model do
 
     it 'has team id assigned to event metadata' do
       expect(sp_component.team_id).to be_nil
-      sp_component.team_id = team_id
+      sp_component.team_id = team.id
 
-      expect(sp_change_event.team_id).to eq team_id
+      expect(sp_change_event.team_id).to eq team.id
     end
   end
-
 end

--- a/spec/models/component_spec.rb
+++ b/spec/models/component_spec.rb
@@ -15,35 +15,35 @@ RSpec.describe Component, type: :model do
       UploadCertificateEvent.create(
         usage: CERTIFICATE_USAGE::SIGNING,
         value: root.generate_encoded_cert(expires_in: 2.months),
-        component: msa_component,
+        component: msa_component
       )
     end
     let!(:upload_signing_certificate_event_2) do
       UploadCertificateEvent.create(
         usage: CERTIFICATE_USAGE::SIGNING,
         value: root.generate_encoded_cert(expires_in: 2.months),
-        component: msa_component,
+        component: msa_component
       )
     end
     let!(:upload_signing_certificate_event_3) do
       UploadCertificateEvent.create(
         usage: CERTIFICATE_USAGE::SIGNING,
         value: root.generate_encoded_cert(expires_in: 2.months),
-        component: sp_component,
+        component: sp_component
       )
     end
     let!(:upload_signing_certificate_event_4) do
       UploadCertificateEvent.create(
         usage: CERTIFICATE_USAGE::SIGNING,
         value: root.generate_encoded_cert(expires_in: 2.months),
-        component: sp_component,
+        component: sp_component
       )
     end
     let!(:upload_encryption_event_1) do
       event = UploadCertificateEvent.create(
         usage: CERTIFICATE_USAGE::ENCRYPTION,
         value: root.generate_encoded_cert(expires_in: 2.months),
-        component: msa_component,
+        component: msa_component
       )
       ReplaceEncryptionCertificateEvent.create(
         component: msa_component,
@@ -55,7 +55,7 @@ RSpec.describe Component, type: :model do
       event = UploadCertificateEvent.create(
         usage: CERTIFICATE_USAGE::ENCRYPTION,
         value: root.generate_encoded_cert(expires_in: 2.months),
-        component: sp_component,
+        component: sp_component
       )
       ReplaceEncryptionCertificateEvent.create(
         component: sp_component,
@@ -63,15 +63,15 @@ RSpec.describe Component, type: :model do
       )
       event
     end
-    let(:msa_service) { create(:service, entity_id: 'https://old-and-boring') }
-    let(:sp_service) { create(:service, entity_id: 'https://new-hotness') }
+    let!(:msa_service) { create(:service, entity_id: 'https://old-and-boring') }
+    let!(:sp_service) { create(:service, entity_id: 'https://new-hotness') }
 
-    it "publishes all the components and services metadata correctly" do
+    it 'publishes all the components and services metadata correctly' do
       msa_component.services << msa_service
       sp_component.services << sp_service
-      event_id = Event.last.id
-      actual_config = Component.to_service_metadata(event_id, published_at)
+      event_id = Event.order(created_at: :desc).first.id
 
+      actual_config = Component.to_service_metadata(event_id, published_at)
       expect(expected_config(event_id)).to eq(actual_config)
     end
 

--- a/spec/models/disable_signing_certificate_event_spec.rb
+++ b/spec/models/disable_signing_certificate_event_spec.rb
@@ -25,10 +25,9 @@ RSpec.describe DisableSigningCertificateEvent, type: :model do
     ).certificate
   end
 
-  def disable_signing_certificate_event
+  let(:disable_signing_certificate_event) do
     DisableSigningCertificateEvent.create(certificate: signing_certificate)
   end
-
 
   it 'disables a signing certificate' do
     cert = disable_signing_certificate_event.certificate
@@ -61,9 +60,12 @@ RSpec.describe DisableSigningCertificateEvent, type: :model do
   context '#trigger_publish_event' do
     it 'when signing certificate is disabled' do
       event = disable_signing_certificate_event
-      publish_event = PublishServicesMetadataEvent.last
-      expect(event.id).to_not be_nil
-      expect(event.id).to eql publish_event.event_id
+
+      resulting_event = PublishServicesMetadataEvent.all.select do |evt|
+        evt.event_id == event.id
+      end.first
+
+      expect(resulting_event).to be_present
     end
   end
 end

--- a/spec/models/enable_signing_certificate_event_spec.rb
+++ b/spec/models/enable_signing_certificate_event_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe EnableSigningCertificateEvent, type: :model do
     ).certificate
   end
 
-  def enable_signing_certificate_event
+  let(:enable_signing_certificate_event) do
     EnableSigningCertificateEvent.create(certificate: signing_certificate)
   end
 
@@ -73,9 +73,12 @@ RSpec.describe EnableSigningCertificateEvent, type: :model do
   context '#trigger_publish_event' do
     it 'when signing certificate is enabled' do
       event = enable_signing_certificate_event
-      publish_event = PublishServicesMetadataEvent.last
-      expect(event.id).to_not be_nil
-      expect(event.id).to eql publish_event.event_id
+
+      resulting_event = PublishServicesMetadataEvent.all.select do |evt|
+        evt.event_id == event.id
+      end.first
+
+      expect(resulting_event).to be_present
     end
   end
 end

--- a/spec/models/replace_encryption_certificate_event_spec.rb
+++ b/spec/models/replace_encryption_certificate_event_spec.rb
@@ -5,7 +5,10 @@ RSpec.describe ReplaceEncryptionCertificateEvent, type: :model do
   let(:root) { PKI.new }
   let(:x509_cert) { root.generate_encoded_cert(expires_in: 9.months) }
   let(:upload_encryption_cert) do
-    UploadCertificateEvent.create( usage: CERTIFICATE_USAGE::ENCRYPTION, value: x509_cert, component: component).certificate
+    UploadCertificateEvent.create(
+      usage: CERTIFICATE_USAGE::ENCRYPTION,
+      value: x509_cert, component: component
+    ).certificate
   end
 
   def certificate_created_with(params = {})
@@ -102,12 +105,18 @@ RSpec.describe ReplaceEncryptionCertificateEvent, type: :model do
 
   context '#trigger_publish_event' do
     it 'when encryption certificate is replaced' do
+      resulting_event = Event.find_by(
+        type: 'PublishServicesMetadataEvent'
+      )
+      expect(resulting_event).not_to be_present
       event = ReplaceEncryptionCertificateEvent.create(
         component: component, encryption_certificate_id: upload_encryption_cert.id
       )
-      publish_event = PublishServicesMetadataEvent.last
+      resulting_event = Event.find_by(
+        type: 'PublishServicesMetadataEvent'
+      )
       expect(event.id).to_not be_nil
-      expect(event.id).to eq publish_event.event_id
+      expect(resulting_event).to be_present
     end
   end
 end

--- a/spec/models/replace_encryption_certificate_event_spec.rb
+++ b/spec/models/replace_encryption_certificate_event_spec.rb
@@ -105,17 +105,13 @@ RSpec.describe ReplaceEncryptionCertificateEvent, type: :model do
 
   context '#trigger_publish_event' do
     it 'when encryption certificate is replaced' do
-      resulting_event = Event.find_by(
-        type: 'PublishServicesMetadataEvent'
-      )
-      expect(resulting_event).not_to be_present
       event = ReplaceEncryptionCertificateEvent.create(
         component: component, encryption_certificate_id: upload_encryption_cert.id
       )
-      resulting_event = Event.find_by(
-        type: 'PublishServicesMetadataEvent'
-      )
-      expect(event.id).to_not be_nil
+      resulting_event = PublishServicesMetadataEvent.all.select do |evt|
+        evt.event_id == event.id
+      end.first
+
       expect(resulting_event).to be_present
     end
   end

--- a/spec/models/upload_certificate_event_spec.rb
+++ b/spec/models/upload_certificate_event_spec.rb
@@ -167,10 +167,18 @@ RSpec.describe UploadCertificateEvent, type: :model do
 
   context '#trigger_publish_event' do
     it 'is triggered on creation' do
-      event = UploadCertificateEvent.create!(usage: CERTIFICATE_USAGE::SIGNING, value: good_cert_value, component: msa_component)
-      publish_event = PublishServicesMetadataEvent.last
+      event = UploadCertificateEvent.create!(
+        usage: CERTIFICATE_USAGE::SIGNING, value: good_cert_value,
+        component: msa_component
+      )
+
+      resulting_event = Event.find_by_aggregate_id(
+        event.aggregate_id
+      )
+
       expect(event.id).to_not be_nil
-      expect(event.id).to eql publish_event.event_id
+      expect(resulting_event.usage).to eq CERTIFICATE_USAGE::SIGNING
+      expect(resulting_event.value).to eq event.certificate.value
     end
   end
 end

--- a/spec/models/upload_certificate_event_spec.rb
+++ b/spec/models/upload_certificate_event_spec.rb
@@ -171,14 +171,11 @@ RSpec.describe UploadCertificateEvent, type: :model do
         usage: CERTIFICATE_USAGE::SIGNING, value: good_cert_value,
         component: msa_component
       )
+      resulting_event = PublishServicesMetadataEvent.all.select do |evt|
+        evt.event_id == event.id
+      end.first
 
-      resulting_event = Event.find_by_aggregate_id(
-        event.aggregate_id
-      )
-
-      expect(event.id).to_not be_nil
-      expect(resulting_event.usage).to eq CERTIFICATE_USAGE::SIGNING
-      expect(resulting_event.value).to eq event.certificate.value
+      expect(resulting_event).to be_present
     end
   end
 end

--- a/spec/policies/group_policy_spec.rb
+++ b/spec/policies/group_policy_spec.rb
@@ -5,15 +5,16 @@ describe GroupPolicy do
 
   permissions :new?, :create?, :invite? do
     it "denies when the user's team differs from the object's one" do
-      expect(subject).not_to permit(FactoryBot.create(:user_manager_user), FactoryBot.create(:team, id: 99))
+      expect(subject).not_to permit(FactoryBot.create(:user_manager_user), FactoryBot.create(:team, id: SecureRandom.uuid))
     end
 
     it "grants access when the user's team matches the object's one" do
-      expect(subject).to permit(FactoryBot.create(:user_manager_user),  FactoryBot.create(:team))
+      user_manager_user = FactoryBot.create(:user_manager_user)
+      expect(subject).to permit(user_manager_user, FactoryBot.create(:team, id: user_manager_user.team))
     end
 
     it 'grants access when the GDS user' do
-      expect(subject).to permit(FactoryBot.create(:gds_user), FactoryBot.create(:team, id: 99))
+      expect(subject).to permit(FactoryBot.create(:gds_user), FactoryBot.create(:team, id: SecureRandom.uuid))
     end
   end
 end

--- a/spec/support/helpers/session_helpers.rb
+++ b/spec/support/helpers/session_helpers.rb
@@ -3,7 +3,7 @@ require 'support/cognito_support'
 module System
   module SessionHelpers
     include CognitoSupport
-  
+
     def sign_in(email, password)
       visit new_user_session_path
       fill_in 'Email', with: email
@@ -29,16 +29,6 @@ module System
     def login_component_manager_user
       user = FactoryBot.create(:component_manager_user)
       login_as(user, scope: :user)
-    end
-
-    def login_gds_user
-      user = FactoryBot.create(:gds_user)
-      login_as(user, :scope => :user)
-    end
-
-    def login_component_manager_user
-      user = FactoryBot.create(:component_manager_user)
-      login_as(user, :scope => :user)
     end
 
     def login_certificate_manager_user

--- a/spec/system/visit_msa_component_edit_spec.rb
+++ b/spec/system/visit_msa_component_edit_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe 'Edit MSA Component Page', type: :system do
   before(:each) do
     login_gds_user
   end
-
-  let(:msa_component) { create(:msa_component) }
+  let(:original_team_id) { SecureRandom.uuid }
+  let(:msa_component) { create(:new_msa_component_event).msa_component }
   let(:team) { create(:new_team_event).team }
   let(:create_teams) { team }
 
@@ -15,8 +15,9 @@ RSpec.describe 'Edit MSA Component Page', type: :system do
       visit edit_msa_component_path(msa_component)
       select(team.name, from: 'component[team_id]')
       click_button t('team.associate_team')
-
-      expect(MsaComponent.last.team_id).to eq team.id
+      result = MsaComponent.find_by_id(msa_component.id)
+      expect(current_path).to eq msa_components_path
+      expect(result.team_id).to eq team.id
     end
   end
 
@@ -27,8 +28,9 @@ RSpec.describe 'Edit MSA Component Page', type: :system do
       select(team.name, from: 'component[team_id]')
       select('Select', from: 'component[team_id]')
       click_button t('team.associate_team')
-
-      expect(MsaComponent.last.team_id).to be_nil
+      result = MsaComponent.find_by_id(msa_component.id)
+      expect(current_path).to eq msa_components_path
+      expect(result.team_id).to be_nil
     end
   end
 end

--- a/spec/system/visit_sp_component_edit_spec.rb
+++ b/spec/system/visit_sp_component_edit_spec.rb
@@ -14,8 +14,9 @@ RSpec.describe 'Edit SP Component Page', type: :system do
       visit edit_sp_component_path(sp_component)
       select(team.name, from: 'component[team_id]')
       click_button t('team.associate_team')
-
-      expect(SpComponent.last.team_id).to eq team.id
+      result = SpComponent.find_by_id(sp_component.id)
+      expect(current_path).to eq sp_components_path
+      expect(result.team_id).to eq team.id
     end
   end
 
@@ -26,8 +27,9 @@ RSpec.describe 'Edit SP Component Page', type: :system do
       select(team.name, from: 'component[team_id]')
       select('Select', from: 'component[team_id]')
       click_button t('team.associate_team')
-
-      expect(SpComponent.last.team_id).to be_nil
+      result = SpComponent.find_by_id(sp_component.id)
+      expect(current_path).to eq sp_components_path
+      expect(result.team_id).to be_nil
     end
   end
 end

--- a/spec/system/visit_user_journey_before_you_start_page_spec.rb
+++ b/spec/system/visit_user_journey_before_you_start_page_spec.rb
@@ -3,13 +3,23 @@ require 'rails_helper'
 RSpec.describe 'Before you start page', type: :system do
   include CertificateSupport
 
+  let(:msa_encryption_certificate) { create(:msa_encryption_certificate) }
+  let(:sp_encryption_certificate) { create(:sp_encryption_certificate) }
+
   before(:each) do
     login_certificate_manager_user
+    ReplaceEncryptionCertificateEvent.create(
+      component: sp_encryption_certificate.component,
+      encryption_certificate_id: sp_encryption_certificate.id
+    )
+    ReplaceEncryptionCertificateEvent.create(
+      component: msa_encryption_certificate.component,
+      encryption_certificate_id: msa_encryption_certificate.id
+    )
   end
 
   it 'shows before you start page for msa encryption and successfully goes to next page' do
-    certificate = create(:msa_encryption_certificate)
-    msa_component = certificate.component
+    msa_component = msa_encryption_certificate.component
     visit before_you_start_path(msa_component.component_type, msa_component.id, msa_component.encryption_certificate_id)
     expect(page).to have_content 'Matching Service Adapter (MSA) encryption certificate'
     click_link 'I have updated my MSA configuration'
@@ -17,8 +27,7 @@ RSpec.describe 'Before you start page', type: :system do
   end
 
   it 'shows before you start page for sp encryption and successfully goes to next page' do
-    certificate = create(:sp_encryption_certificate)
-    sp_component = certificate.component
+    sp_component = sp_encryption_certificate.component
     visit before_you_start_path(sp_component.component_type, sp_component.id, sp_component.encryption_certificate_id)
     expect(page).to have_content 'Verify Service Provider (VSP) encryption certificate'
     click_link 'I have updated my VSP configuration'
@@ -28,19 +37,18 @@ RSpec.describe 'Before you start page', type: :system do
   it 'shows before you start page for msa signing and successfully goes to next page' do
     certificate = create(:msa_signing_certificate)
     msa_component = certificate.component
-    visit before_you_start_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
+    visit before_you_start_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates.first)
     expect(page).to have_content 'Matching Service Adapter (MSA) signing certificate'
     click_link 'Continue'
-    expect(current_path).to eql upload_certificate_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
+    expect(current_path).to eql upload_certificate_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates.first)
   end
 
   it 'shows before you start page for sp signing and successfully goes to next page' do
     certificate = create(:sp_signing_certificate)
-    msa_component = certificate.component
-    visit before_you_start_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
+    sp_component = certificate.component
+    visit before_you_start_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates.first)
     expect(page).to have_content 'Verify Service Provider (VSP) signing certificate'
     click_link 'Continue'
-    expect(current_path).to eql upload_certificate_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
+    expect(current_path).to eql upload_certificate_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates.first)
   end
-
 end

--- a/spec/system/visit_user_journey_before_you_start_page_spec.rb
+++ b/spec/system/visit_user_journey_before_you_start_page_spec.rb
@@ -37,18 +37,18 @@ RSpec.describe 'Before you start page', type: :system do
   it 'shows before you start page for msa signing and successfully goes to next page' do
     certificate = create(:msa_signing_certificate)
     msa_component = certificate.component
-    visit before_you_start_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates.first)
+    visit before_you_start_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
     expect(page).to have_content 'Matching Service Adapter (MSA) signing certificate'
     click_link 'Continue'
-    expect(current_path).to eql upload_certificate_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates.first)
+    expect(current_path).to eql upload_certificate_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
   end
 
   it 'shows before you start page for sp signing and successfully goes to next page' do
     certificate = create(:sp_signing_certificate)
     sp_component = certificate.component
-    visit before_you_start_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates.first)
+    visit before_you_start_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])
     expect(page).to have_content 'Verify Service Provider (VSP) signing certificate'
     click_link 'Continue'
-    expect(current_path).to eql upload_certificate_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates.first)
+    expect(current_path).to eql upload_certificate_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])
   end
 end

--- a/spec/system/visit_user_journey_check_your_certificate_page_spec.rb
+++ b/spec/system/visit_user_journey_check_your_certificate_page_spec.rb
@@ -3,60 +3,43 @@ require 'rails_helper'
 RSpec.describe 'Check your certificate page', type: :system do
   include CertificateSupport
 
+  let(:msa_encryption_certificate) { create(:msa_encryption_certificate) }
+  let(:sp_encryption_certificate) { create(:sp_encryption_certificate) }
+
   before(:each) do
     login_certificate_manager_user
+    ReplaceEncryptionCertificateEvent.create(
+      component: sp_encryption_certificate.component,
+      encryption_certificate_id: sp_encryption_certificate.id
+    )
+    ReplaceEncryptionCertificateEvent.create(
+      component: msa_encryption_certificate.component,
+      encryption_certificate_id: msa_encryption_certificate.id
+    )
   end
+  context 'shows check your certificate page for' do
+    it 'msa encryption and successfully goes to next page' do
+      msa_component = msa_encryption_certificate.component
+      visit upload_certificate_path(msa_component.component_type, msa_component.id, msa_component.encryption_certificate_id)
+      fill_in 'certificate_value', with: msa_encryption_certificate.value
+      click_button 'Continue'
+      expect(current_path).to eql check_your_certificate_path(msa_component.component_type, msa_component.id, msa_component.encryption_certificate_id)
+      expect(page).to have_content 'MSA'
+      expect(page).to have_content 'Encryption'
+      click_button 'Use this certificate'
+      expect(current_path).to eql confirmation_path(msa_component.component_type, msa_component.id, msa_component.encryption_certificate_id)
+    end
 
-  it 'shows check your certificate page for msa encryption and successfully goes to next page' do
-    certificate = create(:msa_encryption_certificate)
-    msa_component = certificate.component
-    visit upload_certificate_path(msa_component.component_type, msa_component.id, msa_component.encryption_certificate_id)
-    fill_in 'certificate_value', with: certificate.value
-    click_button 'Continue'
-    expect(current_path).to eql check_your_certificate_path(msa_component.component_type, msa_component.id, msa_component.encryption_certificate_id)
-    expect(page).to have_content 'MSA'
-    expect(page).to have_content 'Encryption'
-    click_button 'Use this certificate'
-    expect(current_path).to eql confirmation_path(msa_component.component_type, msa_component.id, msa_component.encryption_certificate_id)
+    it 'sp encryption and successfully goes to next page' do
+      sp_component = sp_encryption_certificate.component
+      visit upload_certificate_path(sp_component.component_type, sp_component.id, sp_component.encryption_certificate_id)
+      fill_in 'certificate_value', with: sp_encryption_certificate.value
+      click_button 'Continue'
+      expect(current_path).to eql check_your_certificate_path(sp_component.component_type, sp_component.id, sp_component.encryption_certificate_id)
+      expect(page).to have_content 'VSP'
+      expect(page).to have_content 'Encryption'
+      click_button 'Use this certificate'
+      expect(current_path).to eql confirmation_path(sp_component.component_type, sp_component.id, sp_component.encryption_certificate_id)
+    end
   end
-
-  it 'shows check your certificate page for sp encryption and successfully goes to next page' do
-    certificate = create(:sp_encryption_certificate)
-    sp_component = certificate.component
-    visit upload_certificate_path(sp_component.component_type, sp_component.id, sp_component.encryption_certificate_id)
-    fill_in 'certificate_value', with: certificate.value
-    click_button 'Continue'
-    expect(current_path).to eql check_your_certificate_path(sp_component.component_type, sp_component.id, sp_component.encryption_certificate_id)
-    expect(page).to have_content 'VSP'
-    expect(page).to have_content 'Encryption'
-    click_button 'Use this certificate'
-    expect(current_path).to eql confirmation_path(sp_component.component_type, sp_component.id, sp_component.encryption_certificate_id)
-  end
-
-  it 'shows check your certificate page for msa signing and successfully goes to next page' do
-    certificate = create(:msa_signing_certificate)
-    msa_component = certificate.component
-    visit upload_certificate_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
-    fill_in 'certificate_value', with: certificate.value
-    click_button 'Continue'
-    expect(current_path).to eql check_your_certificate_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
-    expect(page).to have_content 'MSA'
-    expect(page).to have_content 'Signing'
-    click_button 'Use this certificate'
-    expect(current_path).to eql confirmation_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
-  end
-
-  it 'shows check your certificate page for sp signing and successfully goes to next page' do
-    certificate = create(:sp_signing_certificate)
-    sp_component = certificate.component
-    visit upload_certificate_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])
-    fill_in 'certificate_value', with: certificate.value
-    click_button 'Continue'
-    expect(current_path).to eql check_your_certificate_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])
-    expect(page).to have_content 'VSP'
-    expect(page).to have_content 'Signing'
-    click_button 'Use this certificate'
-    expect(current_path).to eql confirmation_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])
-  end
-
 end

--- a/spec/system/visit_user_journey_confirmation_page_spec.rb
+++ b/spec/system/visit_user_journey_confirmation_page_spec.rb
@@ -3,47 +3,60 @@ require 'rails_helper'
 RSpec.describe 'Confirmation page', type: :system do
   include CertificateSupport
 
+  let(:msa_encryption_certificate) { create(:msa_encryption_certificate) }
+  let(:sp_encryption_certificate) { create(:sp_encryption_certificate) }
+
   before(:each) do
     login_certificate_manager_user
+    ReplaceEncryptionCertificateEvent.create(
+      component: sp_encryption_certificate.component,
+      encryption_certificate_id: sp_encryption_certificate.id
+    )
+    ReplaceEncryptionCertificateEvent.create(
+      component: msa_encryption_certificate.component,
+      encryption_certificate_id: msa_encryption_certificate.id
+    )
   end
 
-  it 'shows confirmation page for msa encryption and successfully goes to next page' do
-    certificate = create(:msa_encryption_certificate)
-    msa_component = certificate.component
-    visit confirmation_path(msa_component.component_type, msa_component.id, msa_component.encryption_certificate_id)
-    expect(page).to have_content 'MSA'
-    expect(page).to have_content 'delete the old encryption key and certificate from your MSA configuration'
-    click_link 'Rotate more certificates'
-    expect(current_path).to eql root_path
+  context 'shows confirmation page for msa' do
+    it 'encryption and successfully goes to next page' do
+      msa_component = msa_encryption_certificate.component
+      visit confirmation_path(msa_component.component_type, msa_component.id, msa_component.encryption_certificate_id)
+      expect(page).to have_content 'MSA'
+      expect(page).to have_content 'delete the old encryption key and certificate from your MSA configuration'
+      click_link 'Rotate more certificates'
+      expect(current_path).to eql root_path
+    end
+
+    it 'signing and successfully goes to next page' do
+      certificate = create(:msa_signing_certificate)
+      msa_component = certificate.component
+      visit confirmation_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
+      expect(page).to have_content 'MSA'
+      expect(page).to have_content 'delete the old signing key and certificate from your MSA configuration'
+      click_link 'Rotate more certificates'
+      expect(current_path).to eql root_path
+    end
   end
 
-  it 'shows confirmation page for sp encryption and successfully goes to next page' do
-    certificate = create(:sp_encryption_certificate)
-    sp_component = certificate.component
-    visit confirmation_path(sp_component.component_type, sp_component.id, sp_component.encryption_certificate_id)
-    expect(page).to have_content 'VSP'
-    expect(page).to have_content 'delete the old encryption key and certificate from your VSP configuration'
-    click_link 'Rotate more certificates'
-    expect(current_path).to eql root_path
-  end
+  context 'shows confirmation page for sp' do
+    it 'encryption and successfully goes to next page' do
+      sp_component = sp_encryption_certificate.component
+      visit confirmation_path(sp_component.component_type, sp_component.id, sp_component.encryption_certificate_id)
+      expect(page).to have_content 'VSP'
+      expect(page).to have_content 'delete the old encryption key and certificate from your VSP configuration'
+      click_link 'Rotate more certificates'
+      expect(current_path).to eql root_path
+    end
 
-  it 'shows confirmation page for msa signing and successfully goes to next page' do
-    certificate = create(:msa_signing_certificate)
-    msa_component = certificate.component
-    visit confirmation_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
-    expect(page).to have_content 'MSA'
-    expect(page).to have_content 'delete the old signing key and certificate from your MSA configuration'
-    click_link 'Rotate more certificates'
-    expect(current_path).to eql root_path
-  end
-
-  it 'shows confirmation page for sp signing and successfully goes to next page' do
-    certificate = create(:sp_signing_certificate)
-    sp_component = certificate.component
-    visit confirmation_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])
-    expect(page).to have_content 'VSP'
-    expect(page).to have_content 'delete the old signing key and certificate from your VSP configuration'
-    click_link 'Rotate more certificates'
-    expect(current_path).to eql root_path
+    it 'signing and successfully goes to next page' do
+      certificate = create(:sp_signing_certificate)
+      sp_component = certificate.component
+      visit confirmation_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])
+      expect(page).to have_content 'VSP'
+      expect(page).to have_content 'delete the old signing key and certificate from your VSP configuration'
+      click_link 'Rotate more certificates'
+      expect(current_path).to eql root_path
+    end
   end
 end

--- a/spec/system/visit_user_journey_upload_certificate_page_spec.rb
+++ b/spec/system/visit_user_journey_upload_certificate_page_spec.rb
@@ -3,51 +3,63 @@ require 'rails_helper'
 RSpec.describe 'Upload certificate page', type: :system do
   include CertificateSupport
 
+  let(:msa_encryption_certificate) { create(:msa_encryption_certificate) }
+  let(:sp_encryption_certificate) { create(:sp_encryption_certificate) }
+
   before(:each) do
     login_certificate_manager_user
-  end
 
-  it 'shows upload page for msa encryption and successfully goes to next page' do
-    certificate = create(:msa_encryption_certificate)
-    msa_component = certificate.component
-    visit upload_certificate_path(msa_component.component_type, msa_component.id, msa_component.encryption_certificate_id)
-    expect(page).to have_content 'MSA'
-    expect(page).to have_content 'Upload your new encryption certificate'
-    fill_in 'certificate_value', with: certificate.value
-    click_button 'Continue'
-    expect(current_path).to eql check_your_certificate_path(msa_component.component_type, msa_component.id, msa_component.encryption_certificate_id)
+    ReplaceEncryptionCertificateEvent.create(
+      component: sp_encryption_certificate.component,
+      encryption_certificate_id: sp_encryption_certificate.id
+    )
+    ReplaceEncryptionCertificateEvent.create(
+      component: msa_encryption_certificate.component,
+      encryption_certificate_id: msa_encryption_certificate.id
+    )
   end
+  context 'shows upload page for msa' do
+    it 'encryption and successfully goes to next page' do
+      msa_component = msa_encryption_certificate.component
+      visit upload_certificate_path(msa_component.component_type, msa_component.id, msa_component.encryption_certificate_id)
+      expect(page).to have_content 'MSA'
+      expect(page).to have_content 'Upload your new encryption certificate'
+      fill_in 'certificate_value', with: msa_encryption_certificate.value
+      click_button 'Continue'
+      expect(current_path).to eql check_your_certificate_path(msa_component.component_type, msa_component.id, msa_component.encryption_certificate_id)
+    end
 
-  it 'shows upload page for sp encryption and successfully goes to next page' do
-    certificate = create(:sp_encryption_certificate)
-    sp_component = certificate.component
-    visit upload_certificate_path(sp_component.component_type, sp_component.id, sp_component.encryption_certificate_id)
-    expect(page).to have_content 'VSP'
-    expect(page).to have_content 'Upload your new encryption certificate'
-    fill_in 'certificate_value', with: certificate.value
-    click_button 'Continue'
-    expect(current_path).to eql check_your_certificate_path(sp_component.component_type, sp_component.id, sp_component.encryption_certificate_id)
+    it 'signing and successfully goes to next page' do
+      certificate = create(:msa_signing_certificate)
+      msa_component = certificate.component
+      visit upload_certificate_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
+      expect(page).to have_content 'MSA'
+      expect(page).to have_content 'Upload your new signing certificate'
+      fill_in 'certificate_value', with: certificate.value
+      click_button 'Continue'
+      expect(current_path).to eql check_your_certificate_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
+    end
   end
+  context 'shows upload page for sp' do
+    it 'encryption and successfully goes to next page' do
+      sp_component = sp_encryption_certificate.component
+      visit upload_certificate_path(sp_component.component_type, sp_component.id, sp_component.encryption_certificate_id)
+      expect(page).to have_content 'VSP'
+      expect(page).to have_content 'Upload your new encryption certificate'
+      fill_in 'certificate_value', with: sp_encryption_certificate.value
+      click_button 'Continue'
+      expect(current_path).to eql check_your_certificate_path(sp_component.component_type, sp_component.id, sp_component.encryption_certificate_id)
+    end
 
-  it 'shows upload page for msa signing and successfully goes to next page' do
-    certificate = create(:msa_signing_certificate)
-    msa_component = certificate.component
-    visit upload_certificate_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
-    expect(page).to have_content 'MSA'
-    expect(page).to have_content 'Upload your new signing certificate'
-    fill_in 'certificate_value', with: certificate.value
-    click_button 'Continue'
-    expect(current_path).to eql check_your_certificate_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
-  end
-
-  it 'shows upload page for sp signing and successfully goes to next page' do
-    certificate = create(:sp_signing_certificate)
-    sp_component = certificate.component
-    visit upload_certificate_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])
-    expect(page).to have_content 'VSP'
-    expect(page).to have_content 'Upload your new signing certificate'
-    fill_in 'certificate_value', with: certificate.value
-    click_button 'Continue'
-    expect(current_path).to eql check_your_certificate_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])
+    it 'signing and successfully goes to next page' do
+      certificate = create(:sp_signing_certificate)
+      sp_component = certificate.component
+      visit upload_certificate_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])
+      expect(page).to have_content 'VSP'
+      expect(page).to have_content 'Upload your new signing certificate'
+      fill_in 'certificate_value', with: certificate.value
+      click_button 'Continue'
+      expect(current_path).to eql check_your_certificate_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])
+    end
   end
 end

--- a/spec/system/visit_user_journey_view_certificate_page_spec.rb
+++ b/spec/system/visit_user_journey_view_certificate_page_spec.rb
@@ -2,44 +2,54 @@ require 'rails_helper'
 
 RSpec.describe 'View certificate page', type: :system do
   include CertificateSupport
+  let(:msa_encryption_certificate) { create(:msa_encryption_certificate) }
+  let(:sp_encryption_certificate) { create(:sp_encryption_certificate) }
 
   before(:each) do
     login_certificate_manager_user
+    ReplaceEncryptionCertificateEvent.create(
+      component: sp_encryption_certificate.component,
+      encryption_certificate_id: sp_encryption_certificate.id
+    )
+    ReplaceEncryptionCertificateEvent.create(
+      component: msa_encryption_certificate.component,
+      encryption_certificate_id: msa_encryption_certificate.id
+    )
+  end
+  context 'shows existing msa' do
+    it 'encryption certificate information and navigates to next page' do
+      msa_component = msa_encryption_certificate.component
+      visit view_certificate_path(msa_component.component_type, msa_component.id, msa_component.encryption_certificate_id)
+      expect(page).to have_content 'Matching Service Adapter: encryption certificate'
+      click_link 'Replace certificate'
+      expect(current_path).to eql before_you_start_path(msa_component.component_type, msa_component.id, msa_component.encryption_certificate_id)
+    end
+
+    it 'signing certificate information and navigates to next page' do
+      certificate = create(:msa_signing_certificate)
+      msa_component = certificate.component
+      visit view_certificate_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
+      expect(page).to have_content 'Matching Service Adapter: signing certificate'
+      click_link 'Add new certificate'
+      expect(current_path).to eql before_you_start_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
+    end
   end
 
-  it 'shows existing msa encryption certificate information and successfully goes to next page' do
-    certificate = create(:msa_encryption_certificate)
-    msa_component = certificate.component
-    visit view_certificate_path(msa_component.component_type, msa_component.id, msa_component.encryption_certificate_id)
-    expect(page).to have_content 'Matching Service Adapter: encryption certificate'
-    click_link 'Replace certificate'
-    expect(current_path).to eql before_you_start_path(msa_component.component_type, msa_component.id, msa_component.encryption_certificate_id)
-  end
-
-  it 'shows existing vsp encryption certificate information and successfully goes to next page' do
-    certificate = create(:sp_encryption_certificate)
-    sp_component = certificate.component
-    visit view_certificate_path(sp_component.component_type, sp_component.id, sp_component.encryption_certificate_id)
-    expect(page).to have_content 'Verify Service Provider: encryption certificate'
-    click_link 'Replace certificate'
-    expect(current_path).to eql before_you_start_path(sp_component.component_type, sp_component.id, sp_component.encryption_certificate_id)
-  end
-
-  it 'shows existing msa signing certificate information and successfully goes to next page' do
-    certificate = create(:msa_signing_certificate)
-    msa_component = certificate.component
-    visit view_certificate_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
-    expect(page).to have_content 'Matching Service Adapter: signing certificate'
-    click_link 'Add new certificate'
-    expect(current_path).to eql before_you_start_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
-  end
-
-  it 'shows existing vsp signing certificate information and successfully goes to next page' do
-    certificate = create(:sp_signing_certificate)
-    sp_component = certificate.component
-    visit view_certificate_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])
-    expect(page).to have_content 'Verify Service Provider: signing certificate'
-    click_link 'Add new certificate'
-    expect(current_path).to eql before_you_start_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])
+  context 'shows existing vsp' do
+    it 'encryption certificate information and navigates to next page' do
+      sp_component = sp_encryption_certificate.component
+      visit view_certificate_path(sp_component.component_type, sp_component.id, sp_component.encryption_certificate_id)
+      expect(page).to have_content 'Verify Service Provider: encryption certificate'
+      click_link 'Replace certificate'
+      expect(current_path).to eql before_you_start_path(sp_component.component_type, sp_component.id, sp_component.encryption_certificate_id)
+    end
+    it 'signing certificate information and navigates to next page' do
+      certificate = create(:sp_signing_certificate)
+      sp_component = certificate.component
+      visit view_certificate_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])
+      expect(page).to have_content 'Verify Service Provider: signing certificate'
+      click_link 'Add new certificate'
+      expect(current_path).to eql before_you_start_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])
+    end
   end
 end


### PR DESCRIPTION
### What
**This part of the  [Pen test remediation card](https://trello.com/c/TvW7aqNq/623-switch-to-guids-from-ids). It aims to replace sequential ids with guids**

-Travis would need to be configured to support postgres.
-Concourse pipeline would need to be adjusted as well.
**Why**
UUIDs or GUIDS are globally unique even across models compared to sequential ids where different models can have the same id. Using GUIDS helps to avoid collisions which can happen with sequential id
From a security perspective using GUIDS makes it substantially more difficult for a malicious entity to guess model id's in the URL
**How**
The approach used was to examine all the tests where ids have been exposed in there raw form and 


1. Refactor where possible with id's generated from model objects i.e.

``` id = 1``` replaced with  ``` id = msa_component.id```

Implement a series of migrations
2. Implement PostgreSQL UUID support into the application using a migration
3. Drop all existing self service tables
4. Create a new migration file from existing **schema.rb** changing id to uuid's in the schema.rb
file.
5. Change database.yml file development and test to use postgresSQL adapters.
SQLite has poor support for GUIDS and potential [workarounds](https://github.com/jashmenn/activeuuid) are currently inadequate.
