### PR TITLE
Set secure cookies

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -54,7 +54,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -168,7 +168,7 @@ Devise.setup do |config|
 
   # Options to be passed to the created cookie. For instance, you can set
   # secure: true in order to force SSL only cookies.
-  # config.rememberable_options = {}
+  config.rememberable_options = { secure: true }
 
   # ==> Configuration for :validatable
   # Range for password length.


### PR DESCRIPTION
- Unmarked cookies will be sent by the web browser as part of a regular HTTP request as well as with the more secure HTTPS request.
- If a logged in user clicks on a link which indicates HTTP as the protocol, rather than HTTPS, then the session cookie will be sent over the network in clear text.
- This config change will prevent ^ from happening.
- Will also force all access to the app over SSL.