### PR TITLE
Mdakxfzx allow only two signing certificate

### DIFF
--- a/app/assets/stylesheets/_components.scss
+++ b/app/assets/stylesheets/_components.scss
@@ -3,7 +3,7 @@
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
 .app-certificate-tag-expiring .govuk-tag {
-  background-color: #CB4B0B;
+  background-color: $warning-colour;
 }
 .app-certificate-tag .govuk-tag {
   float: right;

--- a/app/assets/stylesheets/_user_journey.scss
+++ b/app/assets/stylesheets/_user_journey.scss
@@ -36,3 +36,9 @@
 dt {
   display: block;
 }
+.govuk-error-summary--grey {
+  border-color: $govuk-border-colour;
+}
+.govuk-error-summary--orange {
+  border-color: #CB4B0B;
+}

--- a/app/assets/stylesheets/_user_journey.scss
+++ b/app/assets/stylesheets/_user_journey.scss
@@ -40,5 +40,5 @@ dt {
   border-color: $govuk-border-colour;
 }
 .govuk-error-summary--orange {
-  border-color: #CB4B0B;
+  border-color: $warning-colour;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,6 +16,8 @@
  $govuk-fonts-path: "govuk-frontend/govuk/assets/fonts/";
  @import "govuk-frontend/govuk/all";
 
+ $warning-colour: #CB4B0B;
+
  @import "components";
  @import "events";
  @import "mfa_enrolment";

--- a/app/helpers/user_journey_helper.rb
+++ b/app/helpers/user_journey_helper.rb
@@ -3,15 +3,15 @@ module UserJourneyHelper
     certificate.component_type == COMPONENT_TYPE::MSA ? COMPONENT_TYPE::MSA_SHORT : COMPONENT_TYPE::VSP_SHORT
   end
 
-  def primary_signing_certificate(certificate)
+  def primary_signing_certificate?(certificate)
     certificate == certificate.component.signing_certificates.reverse.first
   end
 
-  def secondary_signing_certificate(certificate)
+  def secondary_signing_certificate?(certificate)
     certificate == certificate.component.signing_certificates.reverse.second
   end
 
   def position(certificate)
-    certificate == certificate.component.signing_certificates.reverse.first ? 'primary' : 'secondary'
+    primary_signing_certificate?(certificate) ? 'primary' : 'secondary'
   end
 end

--- a/app/helpers/user_journey_helper.rb
+++ b/app/helpers/user_journey_helper.rb
@@ -2,4 +2,16 @@ module UserJourneyHelper
   def display_component(certificate)
     certificate.component_type == COMPONENT_TYPE::MSA ? COMPONENT_TYPE::MSA_SHORT : COMPONENT_TYPE::VSP_SHORT
   end
+
+  def primary_signing_certificate(certificate)
+    certificate == certificate.component.signing_certificates.reverse.first
+  end
+
+  def secondary_signing_certificate(certificate)
+    certificate == certificate.component.signing_certificates.reverse.second
+  end
+
+  def position(certificate)
+    certificate == certificate.component.signing_certificates.reverse.first ? 'primary' : 'secondary'
+  end
 end

--- a/app/views/shared/_user_component_certificates.html.erb
+++ b/app/views/shared/_user_component_certificates.html.erb
@@ -29,7 +29,7 @@
           <tr class="govuk-table__row">
             <td class="govuk-table__cell">
               <% if component.signing_certificates.length == 2 %>
-                <%= link_to t('user_journey.two_signing_certificate', type: signing == component.signing_certificates.reverse.first ? t('user_journey.primary') : t('user_journey.secondary')) , view_certificate_path(signing.component_type, component.id, signing.id) %>
+                <%= link_to t('user_journey.two_signing_certificate', type: t("user_journey.#{position(signing)}")) , view_certificate_path(signing.component_type, component.id, signing.id) %>
               <% else %>
                 <%= link_to t('user_journey.signing_certificate'), view_certificate_path(signing.component_type, component.id, signing.id) %>
               <% end %>

--- a/app/views/shared/_user_component_certificates.html.erb
+++ b/app/views/shared/_user_component_certificates.html.erb
@@ -25,9 +25,15 @@
             </td>
           </tr>
         <% end%>
-        <% component.signing_certificates.each do |signing| %>
+        <% component.signing_certificates.reverse.each do |signing| %>
           <tr class="govuk-table__row">
-            <td class="govuk-table__cell"><%= link_to t('user_journey.signing_certificate') , view_certificate_path(signing.component_type, component.id, signing.id) %></td> 
+            <td class="govuk-table__cell">
+              <% if component.signing_certificates.length == 2 %>
+                <%= link_to t('user_journey.two_signing_certificate', type: signing == component.signing_certificates.reverse.first ? t('user_journey.primary') : t('user_journey.secondary')) , view_certificate_path(signing.component_type, component.id, signing.id) %>
+              <% else %>
+                <%= link_to t('user_journey.signing_certificate'), view_certificate_path(signing.component_type, component.id, signing.id) %>
+              <% end %>
+            </td> 
             <td class="govuk-table__cell">
               <div class="app-certificate-tag app-certificate-tag-expiring">
                 <strong class="govuk-tag"><%= format_date_time(signing.updated_at) %></strong> <!-- TODO: implement the logic for expiry -->

--- a/app/views/user_journey/confirmation.html.erb
+++ b/app/views/user_journey/confirmation.html.erb
@@ -1,6 +1,6 @@
 <%= render 'shared/certificate_details', certificate: @certificate %>
 
-<h1 class="govuk-heading-l"><%= t 'user_journey.confirmation.title' %></h1>
+<h1 class="govuk-heading-l"><%= t 'user_journey.adding_certificate_to_config' %></h1>
 <p><%= t('user_journey.confirmation.what_to_expect', type: @certificate.usage ) %></p>
 <h2 class="govuk-heading-m"><%= t 'user_journey.confirmation.next_steps' %></h2>
 <ul class="govuk-list govuk-list--number">
@@ -19,7 +19,7 @@
     <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
     <strong class="govuk-warning-text__text">
       <span class="govuk-warning-text__assistive"><%= t 'layout.application.warning' %></span>
-      <%= t('user_journey.confirmation.configuration_warning', component: display_component(@certificate), date: "TODO") %>
+      <%= t('user_journey.confirmation.configuration_warning', component: display_component(@certificate), date: date_to_readable_long_format(@certificate.x509.not_after)) %>
     </strong>
   </div>
 <% end %>

--- a/app/views/user_journey/view_certificate.html.erb
+++ b/app/views/user_journey/view_certificate.html.erb
@@ -1,11 +1,11 @@
 <% if @certificate.signing? && @certificate.component.signing_certificates.length == 2 %>
-  <div class="govuk-error-summary <%= primary_signing_certificate(@certificate) ? "govuk-error-summary--grey" : "govuk-error-summary--orange" %>" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
-    <h2 class="govuk-error-summary__title" id="error-summary-title"><%= primary_signing_certificate(@certificate) ? t('user_journey.adding_certificate_to_config') : t('user_journey.wait_for_an_email') %></h2>
+  <div class="govuk-error-summary <%= primary_signing_certificate?(@certificate) ? "govuk-error-summary--grey" : "govuk-error-summary--orange" %>" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
+    <h2 class="govuk-error-summary__title" id="error-summary-title"><%= primary_signing_certificate?(@certificate) ? t('user_journey.adding_certificate_to_config') : t('user_journey.wait_for_an_email') %></h2>
     <div class="govuk-error-summary__body">
-      <% if primary_signing_certificate(@certificate) %>
+      <% if primary_signing_certificate?(@certificate) %>
         <p><%= t 'user_journey.we_will_email_you' %></p>
         <p><%= t('user_journey.add_new_signing_key_warning', component: display_component(@certificate), date: date_to_readable_long_format(@certificate.x509.not_after)) %></p>
-      <% elsif secondary_signing_certificate(@certificate) %>
+      <% elsif secondary_signing_certificate?(@certificate) %>
         <p><%= t 'user_journey.how_long_it_takes' %></p>
         <p><%= t('user_journey.delete_old_signing_key_and_cert', component: display_component(@certificate)) %></p>
       <% end %>

--- a/app/views/user_journey/view_certificate.html.erb
+++ b/app/views/user_journey/view_certificate.html.erb
@@ -1,8 +1,51 @@
+<% if @certificate.component.signing_certificates.length == 2 %>
+  <% if @certificate == @certificate.component.signing_certificates.reverse.first %>
+    <div class="govuk-error-summary govuk-error-summary--grey" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
+      <h2 class="govuk-error-summary__title" id="error-summary-title">
+        GOV.UK Verify is adding your certificate to its configuration
+      </h2>
+      <div class="govuk-error-summary__body">
+        <p>
+          This usually takes around 10 minutes. We'll email you when this is done.
+        </p>
+        <p>
+          After receiving this email you must add the new signing key to your MSA config by 2 August 2019, or your service’s connection to GOV.UK Verify will break.
+        </p>
+        <p>
+          Find out more about <a href="https://prototype-docs.cloudapps.digital/rotating-your-keys-and-certificates/msa-signing/#rotate-your-msa-signing-key-and-certificate">rotating your MSA signing key and certificate</a> in the documentation.
+        </p>
+      </div>
+    </div>
+  <% end %>
+  <% if @certificate == @certificate.component.signing_certificates.reverse.second %>
+    <div class="govuk-error-summary govuk-error-summary--orange" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
+      <h2 class="govuk-error-summary__title" id="error-summary-title">
+        Wait for an email from GOV.UK Verify confirming your new signing certificate is in use
+      </h2>
+      <div class="govuk-error-summary__body">
+        <p>
+          This usually takes around 10 minutes from the time you uploaded the new signing certificate.
+        </p>
+        <p>
+          Then you can delete the old signing key and certificate from your MSA configuration.
+        </p>
+        <p>
+          Find out more about <a href="https://prototype-docs.cloudapps.digital/rotating-your-keys-and-certificates/msa-signing/#rotate-your-msa-signing-key-and-certificate">rotating your MSA signing key and certificate</a> in the documentation.
+        </p>
+      </div>
+    </div>
+  <% end %>
+<% end %>
+
 <h1 class="govuk-heading-l">
   <%= @certificate.component.component_type == COMPONENT_TYPE::MSA ? t('user_journey.certificate.msa_heading') : t('user_journey.certificate.vsp_heading') %>
   <%= t('user_journey.certificate.certificate', type: @certificate.usage ) %>
+  <% if !@certificate.encryption? %>
+    <%= @certificate == @certificate.component.signing_certificates.reverse.first ? t('user_journey.primary') : t('user_journey.secondary') %>
+  <% end %>
 </h1>
 
 <%= render 'shared/user_certificate_view', certificate: @certificate, full_details: true %>
-
-<%= link_to @certificate.encryption? ? t('user_journey.certificate.replace') : t('user_journey.certificate.add_new'), before_you_start_path, class: "govuk-button", data: { module: "govuk-button" }, role:"button" %>
+<% if @certificate.encryption? || @certificate.component.signing_certificates.length < 2 %>
+  <%= link_to @certificate.encryption? ? t('user_journey.certificate.replace') : t('user_journey.certificate.add_new'), before_you_start_path, class: "govuk-button", data: { module: "govuk-button" }, role:"button" %>
+<% end %>

--- a/app/views/user_journey/view_certificate.html.erb
+++ b/app/views/user_journey/view_certificate.html.erb
@@ -1,51 +1,33 @@
-<% if @certificate.component.signing_certificates.length == 2 %>
-  <% if @certificate == @certificate.component.signing_certificates.reverse.first %>
-    <div class="govuk-error-summary govuk-error-summary--grey" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
-      <h2 class="govuk-error-summary__title" id="error-summary-title">
-        GOV.UK Verify is adding your certificate to its configuration
-      </h2>
-      <div class="govuk-error-summary__body">
-        <p>
-          This usually takes around 10 minutes. We'll email you when this is done.
-        </p>
-        <p>
-          After receiving this email you must add the new signing key to your MSA config by 2 August 2019, or your service’s connection to GOV.UK Verify will break.
-        </p>
-        <p>
-          Find out more about <a href="https://prototype-docs.cloudapps.digital/rotating-your-keys-and-certificates/msa-signing/#rotate-your-msa-signing-key-and-certificate">rotating your MSA signing key and certificate</a> in the documentation.
-        </p>
-      </div>
+<% if @certificate.signing? && @certificate.component.signing_certificates.length == 2 %>
+  <div class="govuk-error-summary <%= primary_signing_certificate(@certificate) ? "govuk-error-summary--grey" : "govuk-error-summary--orange" %>" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
+    <h2 class="govuk-error-summary__title" id="error-summary-title"><%= primary_signing_certificate(@certificate) ? t('user_journey.adding_certificate_to_config') : t('user_journey.wait_for_an_email') %></h2>
+    <div class="govuk-error-summary__body">
+      <% if primary_signing_certificate(@certificate) %>
+        <p><%= t 'user_journey.we_will_email_you' %></p>
+        <p><%= t('user_journey.add_new_signing_key_warning', component: display_component(@certificate), date: date_to_readable_long_format(@certificate.x509.not_after)) %></p>
+      <% elsif secondary_signing_certificate(@certificate) %>
+        <p><%= t 'user_journey.how_long_it_takes' %></p>
+        <p><%= t('user_journey.delete_old_signing_key_and_cert', component: display_component(@certificate)) %></p>
+      <% end %>
+      <p><%= render 'shared/component_certificate_doc_links', certificate: @certificate %></p>
     </div>
-  <% end %>
-  <% if @certificate == @certificate.component.signing_certificates.reverse.second %>
-    <div class="govuk-error-summary govuk-error-summary--orange" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
-      <h2 class="govuk-error-summary__title" id="error-summary-title">
-        Wait for an email from GOV.UK Verify confirming your new signing certificate is in use
-      </h2>
-      <div class="govuk-error-summary__body">
-        <p>
-          This usually takes around 10 minutes from the time you uploaded the new signing certificate.
-        </p>
-        <p>
-          Then you can delete the old signing key and certificate from your MSA configuration.
-        </p>
-        <p>
-          Find out more about <a href="https://prototype-docs.cloudapps.digital/rotating-your-keys-and-certificates/msa-signing/#rotate-your-msa-signing-key-and-certificate">rotating your MSA signing key and certificate</a> in the documentation.
-        </p>
-      </div>
-    </div>
-  <% end %>
+  </div>
 <% end %>
 
 <h1 class="govuk-heading-l">
   <%= @certificate.component.component_type == COMPONENT_TYPE::MSA ? t('user_journey.certificate.msa_heading') : t('user_journey.certificate.vsp_heading') %>
   <%= t('user_journey.certificate.certificate', type: @certificate.usage ) %>
-  <% if !@certificate.encryption? %>
-    <%= @certificate == @certificate.component.signing_certificates.reverse.first ? t('user_journey.primary') : t('user_journey.secondary') %>
+  <% if @certificate.signing? && @certificate.component.signing_certificates.length == 2 %>
+    <%= t "user_journey.#{position(@certificate)}" %>
   <% end %>
 </h1>
 
 <%= render 'shared/user_certificate_view', certificate: @certificate, full_details: true %>
-<% if @certificate.encryption? || @certificate.component.signing_certificates.length < 2 %>
-  <%= link_to @certificate.encryption? ? t('user_journey.certificate.replace') : t('user_journey.certificate.add_new'), before_you_start_path, class: "govuk-button", data: { module: "govuk-button" }, role:"button" %>
+
+<% if @certificate.signing? %>
+  <% if @certificate.component.signing_certificates.length < 2 %>
+    <%= link_to t('user_journey.certificate.add_new'), before_you_start_path, class: "govuk-button", data: { module: "govuk-button" }, role:"button" %> 
+  <% end %>
+<% elsif @certificate.encryption? %>
+  <%= link_to t('user_journey.certificate.replace'), before_you_start_path, class: "govuk-button", data: { module: "govuk-button" }, role:"button" %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -192,6 +192,9 @@ en:
     in_use: IN USE
     encryption_certificate: Encryption certificate
     signing_certificate: Signing certificate
+    two_signing_certificate: Signing certificate %{type}
+    primary: (primary)
+    secondary: (secondary)
     urls:
       msa_encryption: https://prototype-docs.cloudapps.digital/rotating-your-keys-and-certificates/msa-encryption/#rotate-your-msa-encryption-key-and-certificate
       msa_signing: https://prototype-docs.cloudapps.digital/rotating-your-keys-and-certificates/msa-signing/#rotate-your-msa-signing-key-and-certificate

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -195,6 +195,12 @@ en:
     two_signing_certificate: Signing certificate %{type}
     primary: (primary)
     secondary: (secondary)
+    adding_certificate_to_config: GOV.UK Verify is adding your certificate to its configuration
+    we_will_email_you: This usually takes around 10 minutes. We'll email you when this is done.
+    add_new_signing_key_warning: After receiving this email you must add the new signing key to your %{component} config by %{date}, or your service’s connection to GOV.UK Verify will break.
+    wait_for_an_email: Wait for an email from GOV.UK Verify confirming your new signing certificate is in use
+    how_long_it_takes: This usually takes around 10 minutes from the time you uploaded the new signing certificate.
+    delete_old_signing_key_and_cert: Then you can delete the old signing key and certificate from your %{component} configuration.
     urls:
       msa_encryption: https://prototype-docs.cloudapps.digital/rotating-your-keys-and-certificates/msa-encryption/#rotate-your-msa-encryption-key-and-certificate
       msa_signing: https://prototype-docs.cloudapps.digital/rotating-your-keys-and-certificates/msa-signing/#rotate-your-msa-signing-key-and-certificate
@@ -238,7 +244,6 @@ en:
       upload_certificate_file_body: Upload file
       paste_certificate: Paste certificate text into a text box
     confirmation:
-      title: GOV.UK Verify is adding your certificate to its configuration
       what_to_expect: This usually takes around 10 minutes. We'll email you when your new %{type} certificate is in use.
       next_steps: Next steps
       rotate_other_certificates: You can rotate other certificates straight away - you do not need to wait for the email.

--- a/spec/factories/components.rb
+++ b/spec/factories/components.rb
@@ -3,13 +3,11 @@ FactoryBot.define do
     component_type { COMPONENT_TYPE::SP }
     name { 'Test Service Provider' }
     environment { 'staging' }
-    team_id { 1 }
   end
 
   factory :msa_component do
     component_type { COMPONENT_TYPE::MSA }
     entity_id { 'https://test-entity-id' }
     environment { 'staging' }
-    team_id { 1 }
   end
 end

--- a/spec/factories/components.rb
+++ b/spec/factories/components.rb
@@ -3,11 +3,13 @@ FactoryBot.define do
     component_type { COMPONENT_TYPE::SP }
     name { 'Test Service Provider' }
     environment { 'staging' }
+    team_id { 1 }
   end
 
   factory :msa_component do
     component_type { COMPONENT_TYPE::MSA }
     entity_id { 'https://test-entity-id' }
     environment { 'staging' }
+    team_id { 1 }
   end
 end

--- a/spec/support/helpers/session_helpers.rb
+++ b/spec/support/helpers/session_helpers.rb
@@ -19,21 +19,25 @@ module System
     def login_user
       user = FactoryBot.create(:user_manager_user)
       login_as(user, scope: :user)
+      user
     end
 
     def login_gds_user
       user = FactoryBot.create(:gds_user)
       login_as(user, scope: :user)
+      user
     end
 
     def login_component_manager_user
       user = FactoryBot.create(:component_manager_user)
       login_as(user, scope: :user)
+      user
     end
 
     def login_certificate_manager_user
       user = FactoryBot.create(:certificate_manager_user)
       login_as(user, scope: :user)
+      user
     end
 
     def setup_simple_auth_stub

--- a/spec/system/visit_index_page_spec.rb
+++ b/spec/system/visit_index_page_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe 'IndexPage', type: :system do
     login_gds_user
   end
 
-  let(:second_certificate) { PKI.new.generate_encoded_cert(expires_in: 9.months) }
-
   it 'shows greeting without JS' do
     visit '/'
     expect(page).to have_content 'Manage certificates'
@@ -19,12 +17,7 @@ RSpec.describe 'IndexPage', type: :system do
 
   it 'shows whether certificate is primary or secondary when there are two signing certificates' do
     first_certificate = create(:msa_signing_certificate)
-    defaults = {
-      usage: CERTIFICATE_USAGE::SIGNING,
-      value: second_certificate,
-      component: first_certificate.component
-    }
-    Certificate.create(defaults)
+    create(:msa_signing_certificate, component: first_certificate.component)
     visit root_path
     expect(page).to have_content 'Signing certificate (primary)'
     expect(page).to have_content 'Signing certificate (secondary)'

--- a/spec/system/visit_index_page_spec.rb
+++ b/spec/system/visit_index_page_spec.rb
@@ -4,6 +4,9 @@ RSpec.describe 'IndexPage', type: :system do
   before(:each) do
     login_gds_user
   end
+
+  let(:second_certificate) { PKI.new.generate_encoded_cert(expires_in: 9.months) }
+
   it 'shows greeting without JS' do
     visit '/'
     expect(page).to have_content 'Manage certificates'
@@ -13,4 +16,18 @@ RSpec.describe 'IndexPage', type: :system do
     visit '/'
     expect(page).to have_content 'Manage certificates'
   end
+
+  it 'shows whether certificate is primary or secondary when there are two signing certificates' do
+    first_certificate = create(:msa_signing_certificate)
+    defaults = {
+      usage: CERTIFICATE_USAGE::SIGNING,
+      value: second_certificate,
+      component: first_certificate.component
+    }
+    Certificate.create(defaults)
+    visit root_path
+    expect(page).to have_content 'Signing certificate (primary)'
+    expect(page).to have_content 'Signing certificate (secondary)'
+  end
+
 end

--- a/spec/system/visit_index_page_spec.rb
+++ b/spec/system/visit_index_page_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'IndexPage', type: :system do
     expect(page).to have_content 'Manage certificates'
   end
 
-  it 'shows whether certificate is primary or secondary when there are two signing certificates' do
+  it 'shows whether signing certificate is primary or secondary when there are two signing certificates' do
     first_certificate = create(:msa_signing_certificate)
     create(:msa_signing_certificate, component: first_certificate.component)
     visit root_path
@@ -23,4 +23,16 @@ RSpec.describe 'IndexPage', type: :system do
     expect(page).to have_content 'Signing certificate (secondary)'
   end
 
+  it 'shows when a second signing certificate is added the new certificate becomes primary and the older one becomes secondary' do
+    first_certificate = create(:msa_signing_certificate)
+    visit root_path
+    expect(page).to_not have_content 'Signing certificate (primary)'
+    expect(page).to_not have_content 'Signing certificate (secondary)'
+    second_certificate = create(:msa_signing_certificate, component: first_certificate.component)
+    visit root_path
+    primary_certificate_link = find_link('Signing certificate (primary)')['href']
+    secondary_certificate_link = find_link('Signing certificate (secondary)')['href']
+    expect(primary_certificate_link).to have_content second_certificate.id
+    expect(secondary_certificate_link).to have_content first_certificate.id
+  end
 end

--- a/spec/system/visit_user_journey_view_certificate_page_spec.rb
+++ b/spec/system/visit_user_journey_view_certificate_page_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe 'View certificate page', type: :system do
       click_link 'Replace certificate'
       expect(current_path).to eql before_you_start_path(sp_component.component_type, sp_component.id, sp_component.encryption_certificate_id)
     end
+    
     it 'signing certificate information and navigates to next page' do
       certificate = create(:sp_signing_certificate)
       sp_component = certificate.component
@@ -51,5 +52,33 @@ RSpec.describe 'View certificate page', type: :system do
       click_link 'Add new certificate'
       expect(current_path).to eql before_you_start_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])
     end
+  end
+
+  it 'shows specific information when certificate is primary' do
+    first_certificate = create(:msa_signing_certificate)
+    defaults = {
+      usage: CERTIFICATE_USAGE::SIGNING,
+      value: second_certificate,
+      component: first_certificate.component
+    }
+    second_cert = Certificate.create(defaults)
+    visit root_path
+    click_link 'Signing certificate (primary)'
+    expect(page).to have_content 'GOV.UK Verify is adding your certificate to its configuration'
+    expect(page).to_not have_button('Add new certificate')
+  end
+
+  it 'shows specific information when certificate is secondary' do
+    first_certificate = create(:msa_signing_certificate)
+    defaults = {
+      usage: CERTIFICATE_USAGE::SIGNING,
+      value: second_certificate,
+      component: first_certificate.component
+    }
+    second_cert = Certificate.create(defaults)
+    visit root_path
+    click_link 'Signing certificate (secondary)'
+    expect(page).to have_content 'Wait for an email from GOV.UK Verify confirming your new signing certificate is in use'
+    expect(page).to_not have_button('Add new certificate')
   end
 end

--- a/spec/system/visit_user_journey_view_certificate_page_spec.rb
+++ b/spec/system/visit_user_journey_view_certificate_page_spec.rb
@@ -3,10 +3,10 @@ require 'rails_helper'
 RSpec.describe 'View certificate page', type: :system do
   include CertificateSupport
   let(:msa_encryption_certificate) { create(:msa_encryption_certificate) }
-  let(:sp_encryption_certificate) { create(:sp_encryption_certificate) }
+  let(:sp_encryption_certificate) { create(:sp_encryption_certificate) }  
 
   before(:each) do
-    login_certificate_manager_user
+    @user = login_certificate_manager_user
     ReplaceEncryptionCertificateEvent.create(
       component: sp_encryption_certificate.component,
       encryption_certificate_id: sp_encryption_certificate.id
@@ -26,8 +26,8 @@ RSpec.describe 'View certificate page', type: :system do
     end
 
     it 'signing certificate information and navigates to next page' do
-      certificate = create(:msa_signing_certificate)
-      msa_component = certificate.component
+      msa_signing_certificate = create(:msa_signing_certificate)
+      msa_component = msa_signing_certificate.component
       visit view_certificate_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
       expect(page).to have_content 'Matching Service Adapter: signing certificate'
       click_link 'Add new certificate'
@@ -43,10 +43,10 @@ RSpec.describe 'View certificate page', type: :system do
       click_link 'Replace certificate'
       expect(current_path).to eql before_you_start_path(sp_component.component_type, sp_component.id, sp_component.encryption_certificate_id)
     end
-    
+
     it 'signing certificate information and navigates to next page' do
-      certificate = create(:sp_signing_certificate)
-      sp_component = certificate.component
+      sp_signing_certificate = create(:sp_signing_certificate)
+      sp_component = sp_signing_certificate.component
       visit view_certificate_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])
       expect(page).to have_content 'Verify Service Provider: signing certificate'
       click_link 'Add new certificate'
@@ -54,31 +54,23 @@ RSpec.describe 'View certificate page', type: :system do
     end
   end
 
-  it 'shows specific information when certificate is primary' do
-    first_certificate = create(:msa_signing_certificate)
-    defaults = {
-      usage: CERTIFICATE_USAGE::SIGNING,
-      value: second_certificate,
-      component: first_certificate.component
-    }
-    second_cert = Certificate.create(defaults)
-    visit root_path
-    click_link 'Signing certificate (primary)'
-    expect(page).to have_content 'GOV.UK Verify is adding your certificate to its configuration'
-    expect(page).to_not have_button('Add new certificate')
-  end
+  context 'show signing' do
+    it 'specific information when certificate is primary' do
+      first_certificate = create(:msa_signing_certificate, component: create(:msa_component, team_id: @user.team))
+      create(:msa_signing_certificate, component: first_certificate.component)
+      visit root_path
+      click_link 'Signing certificate (primary)'
+      expect(page).to have_content 'GOV.UK Verify is adding your certificate to its configuration'
+      expect(page).to_not have_button('Add new certificate')
+    end
 
-  it 'shows specific information when certificate is secondary' do
-    first_certificate = create(:msa_signing_certificate)
-    defaults = {
-      usage: CERTIFICATE_USAGE::SIGNING,
-      value: second_certificate,
-      component: first_certificate.component
-    }
-    second_cert = Certificate.create(defaults)
-    visit root_path
-    click_link 'Signing certificate (secondary)'
-    expect(page).to have_content 'Wait for an email from GOV.UK Verify confirming your new signing certificate is in use'
-    expect(page).to_not have_button('Add new certificate')
+    it 'specific information when certificate is secondary' do
+      first_certificate = create(:msa_signing_certificate, component: create(:msa_component, team_id: @user.team))
+      create(:msa_signing_certificate, component: first_certificate.component)
+      visit root_path
+      click_link 'Signing certificate (secondary)'
+      expect(page).to have_content 'Wait for an email from GOV.UK Verify confirming your new signing certificate is in use'
+      expect(page).to_not have_button('Add new certificate')
+    end
   end
 end


### PR DESCRIPTION
Added summary boxes when there are two signing certificates already uploaded as per the prototype
Doesnt allow user to progress the journey if two signing certificates exist
Created tests to show that the button no longer exists to be able to upload more signing certificates if two already exist
They also test to see if the primary and secondary information is being shown
Created a method which returns true for primary or secondary signing certs
Localise all new static text