### PR TITLE
BAU: Add Postgres to the test Dockerfile

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -27,6 +27,7 @@ development:
 test:
   <<: *default
   database: vss_test
+  username: postgres
 
 production:
   <<: *default

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -13,6 +13,12 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
  && apt-get install -y yarn
 
 RUN apt-get install -y firefox-esr
+RUN apt-get install -y postgresql-9.6
 
-# Puma needs these dockerignored dirs to write to
-RUN mkdir -p log tmp
+USER postgres
+
+RUN  /etc/init.d/postgresql start &&\
+    psql --command "CREATE DATABASE vss_test;" -U postgres &&\
+    sed -i 's/local   all             postgres                                peer/local   all             postgres                                trust/g' /etc/postgresql/9.6/main/pg_hba.conf
+
+USER root


### PR DESCRIPTION
After the switch to postgres we need to make sure we can run the tests
in concourse (which is using the test.Dockerfile). It installs
the postgres in Dockerfile, create the vss_test database and
adjust the configuration to not require a password.

[Related pipeline change](https://github.com/alphagov/verify-terraform/pull/1063)