### PR TITLE
Do not send routing errors to Sentry

### DIFF
--- a/lib/support/raven/logger.rb
+++ b/lib/support/raven/logger.rb
@@ -28,8 +28,23 @@ module Support
       end
 
       class RavenWriter
+        UNLABELED_EVENT = '  '.freeze
+
         def write(msg = nil)
-          ::Raven.capture_exception(msg) unless msg.nil?
+          unless msg.nil? || message_is_404?(msg)
+            ::Raven.capture_exception(msg)
+          end
+        end
+
+        def message_is_404?(message)
+          message.is_a?(ActionController::RoutingError) ||
+            (
+              message.is_a?(String) &&
+                (
+                   message.start_with?('ActionController::RoutingError') ||
+                   message == UNLABELED_EVENT
+                )
+            )
         end
       end
     end

--- a/spec/support/raven/logger_spec.rb
+++ b/spec/support/raven/logger_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+require 'logger'
+require 'support/raven/logger'
+require 'action_controller/metal/exceptions'
+require 'raven'
+
+describe Support::Raven::Logger do
+  let(:logger) { Support::Raven::Logger.new }
+
+  context "#error" do
+    it 'will send exceptions to sentry' do
+      error = StandardError.new
+      expect(Raven).to receive(:capture_exception).with(error)
+      logger.error(error)
+    end
+
+    it 'will not send routing exceptions to sentry' do
+      error = ActionController::RoutingError.new(nil)
+      expect(Raven).not_to receive(:capture_exception).with(error)
+      logger.error(error)
+    end
+
+    it 'will not send whitespace to sentry' do
+      error = "  "
+      expect(Raven).to_not receive(:capture_exception).with(error)
+      logger.error(error)
+    end
+
+    it 'will not send routing error messages to sentry' do
+      error = "ActionController::RoutingError (No route matches [GET] \"/favicon.ico\")"
+      expect(Raven).to_not receive(:capture_exception).with(error)
+      logger.error(error)
+    end
+  end
+end


### PR DESCRIPTION
The default Sentry configuration is set to ignore the following:

```
AbstractController::ActionNotFound
ActionController::InvalidAuthenticityToken
ActionController::RoutingError
ActionController::UnknownAction
ActiveRecord::RecordNotFound
CGI::Session::CookieStore::TamperedWithCookie
Mongoid::Errors::DocumentNotFound
Sinatra::NotFound
ActiveJob::DeserializationError
```

However ActionController::RoutingErrors are still being sent to Sentry. This is possibly to do with the way we extend the default Rails logger with the RavenWriter.

This PR manually adds some handling for the routing specific errors. It is still potentially possible for Sentry to receive debug exceptions from the middleware. We will see how noisy this becomes.

https://trello.com/c/rJCRLBNa/646-filter-out-404s-from-sentry