### PR TITLE
Remove 'unsafe-inline' from script-src in csp header

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,22 +8,23 @@
     <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload', nonce: true %>
     <%= favicon_link_tag        asset_path('govuk-frontend/govuk/assets/images/favicon.ico'), sizes: "16x16 32x32 48x48" %>
 
-    <link rel="mask-icon" href="<%= asset_path('govuk-frontend/govuk/assets/images/govuk-mask-icon.svg')%>" color="blue">  
-    <link rel="apple-touch-icon" href="<%= asset_path('govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-180x180.png')%>" sizes="180x180"> 
-    <link rel="apple-touch-icon" href="<%= asset_path('govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-167x167.png')%>" sizes="167x167"> 
-    <link rel="apple-touch-icon" href="<%= asset_path('govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-152x152.png')%>" sizes="152x152"> 
-    <link rel="apple-touch-icon" href="<%= asset_path('govuk-frontend/govuk/assets/images/govuk-apple-touch-icon.png')%>"> 
-    
+    <link rel="mask-icon" href="<%= asset_path('govuk-frontend/govuk/assets/images/govuk-mask-icon.svg')%>" color="blue">
+    <link rel="apple-touch-icon" href="<%= asset_path('govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-180x180.png')%>" sizes="180x180">
+    <link rel="apple-touch-icon" href="<%= asset_path('govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-167x167.png')%>" sizes="167x167">
+    <link rel="apple-touch-icon" href="<%= asset_path('govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-152x152.png')%>" sizes="152x152">
+    <link rel="apple-touch-icon" href="<%= asset_path('govuk-frontend/govuk/assets/images/govuk-apple-touch-icon.png')%>">
+
 </head>
 
   <body class="govuk-template__body ">
 
-    <script>
+    <%= javascript_tag nonce: true do %>
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
-    </script>
+    <% end %>
+
 
     <a href="#main-content" class="govuk-skip-link"><%= t 'layout.application.skip_link' %></a>
 
@@ -104,7 +105,8 @@
         </div>
       </div>
     </footer>
-
-    <script>window.GOVUKFrontend.initAll()</script>
+    <%= javascript_tag nonce: true do %>
+      window.GOVUKFrontend.initAll()
+    <% end %>
   </body>
 </html>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -12,12 +12,14 @@ Rails.application.configure do
     policy.font_src    :self, ENV["ASSET_HOST"]
     policy.img_src     :self, ENV["ASSET_HOST"]
     policy.object_src  :none
-    policy.script_src  :self, :unsafe_inline, ENV["ASSET_HOST"]
+    policy.script_src  :self, ENV["ASSET_HOST"]
     policy.style_src   :self, ENV["ASSET_HOST"]
 
     # Specify URI for violation reports
     # policy.report_uri "/csp-violation-report-endpoint"
   end
+
+  config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }
 
   config.cache_classes = true
 


### PR DESCRIPTION
- 'Sign' inline javascripts with an unguessable random value (a nonce)
- Use the nonce to whitelist the scripts
- This increases protection against XSS