### PR TITLE
Update Devise version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
     colorize (0.8.1)
     concurrent-ruby (1.1.5)
     crass (1.0.4)
-    devise (4.7.0)
+    devise (4.7.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0)


### PR DESCRIPTION
Severe vulnerability - [CVE-2019-16109](https://nvd.nist.gov/vuln/detail/CVE-2019-16109)