### PR TITLE
Speed up the local startup time

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.
-  config.assets.debug = true
+  config.assets.debug = false
 
   # Suppress logger output for asset requests.
   config.assets.quiet = true


### PR DESCRIPTION
By disabling the assets.debug, the startup (first request) time is 10x quicker.
Can be easily turned on if needed for debugging.