### PR TITLE
XGWgKqpg: Show the clear distinction between the 3 different component types

### DIFF
--- a/app/helpers/user_journey_helper.rb
+++ b/app/helpers/user_journey_helper.rb
@@ -1,8 +1,4 @@
 module UserJourneyHelper
-  def display_component(certificate)
-    certificate.component_type == COMPONENT_TYPE::MSA ? COMPONENT_TYPE::MSA_SHORT : COMPONENT_TYPE::VSP_SHORT
-  end
-
   def primary_signing_certificate?(certificate)
     certificate == certificate.component.enabled_signing_certificates.first
   end
@@ -29,5 +25,15 @@ module UserJourneyHelper
 
   def certificate_expiry_count(msa_components, sp_components)
     (msa_components + sp_components).map(&:certificates).flatten.select(&:expires_soon?).count
+  end
+
+  def display_component(component)
+    if component.component_type == COMPONENT_TYPE::MSA
+      COMPONENT_TYPE::MSA_SHORT
+    elsif component.vsp
+      COMPONENT_TYPE::VSP_SHORT
+    else
+      COMPONENT_TYPE::SP_SHORT
+    end
   end
 end

--- a/app/views/shared/_certificate_details.html.erb
+++ b/app/views/shared/_certificate_details.html.erb
@@ -2,7 +2,7 @@
   <dt class="govuk-visually-hidden govuk-body-s">Environment</dt>
   <dd><%= certificate.component.environment.capitalize %></dd>
   <dt class="govuk-visually-hidden">Component</dt>
-  <dd><%= display_component(certificate) %></dd>
+  <dd><%= display_component(certificate.component) %></dd>
   <dt class="govuk-visually-hidden">Certificate</dt>
   <dd><%= certificate.usage.capitalize + " certificate" %></dd>
 </dl>

--- a/app/views/shared/_component_certificate_doc_links.html.erb
+++ b/app/views/shared/_component_certificate_doc_links.html.erb
@@ -1,17 +1,23 @@
 <p>
-  <%= t 'user_journey.before_you_start.find_out_more' %>
+  <%= t 'user_journey.find_out_more' %>
   <% if certificate.component_type == COMPONENT_TYPE::MSA %>
     <% if certificate.encryption? %>
-      <%= link_to t('user_journey.before_you_start.rotate_key_and_certificate', component: COMPONENT_TYPE::MSA_SHORT, certificate: CERTIFICATE_USAGE::ENCRYPTION), t('user_journey.urls.msa_encryption') %>
+      <%= link_to t('user_journey.rotate_key_and_certificate', component: COMPONENT_TYPE::MSA_SHORT, certificate: CERTIFICATE_USAGE::ENCRYPTION), t('user_journey.urls.msa_encryption') %>
     <% else %>
-      <%= link_to t('user_journey.before_you_start.rotate_key_and_certificate', component: COMPONENT_TYPE::MSA_SHORT, certificate: CERTIFICATE_USAGE::SIGNING), t('user_journey.urls.msa_signing') %>
+      <%= link_to t('user_journey.rotate_key_and_certificate', component: COMPONENT_TYPE::MSA_SHORT, certificate: CERTIFICATE_USAGE::SIGNING), t('user_journey.urls.msa_signing') %>
     <% end %>
-  <% else %>
+  <% elsif certificate.component.vsp  %>
     <% if certificate.encryption? %>
-      <%= link_to t('user_journey.before_you_start.rotate_key_and_certificate', component: COMPONENT_TYPE::VSP_SHORT, certificate: CERTIFICATE_USAGE::ENCRYPTION), t('user_journey.urls.vsp_encryption') %>
+      <%= link_to t('user_journey.rotate_key_and_certificate', component: COMPONENT_TYPE::VSP_SHORT, certificate: CERTIFICATE_USAGE::ENCRYPTION), t('user_journey.urls.vsp_encryption') %>
     <% else %>
-      <%= link_to t('user_journey.before_you_start.rotate_key_and_certificate', component: COMPONENT_TYPE::VSP_SHORT, certificate: CERTIFICATE_USAGE::SIGNING), t('user_journey.urls.vsp_signing') %>
+      <%= link_to t('user_journey.rotate_key_and_certificate', component: COMPONENT_TYPE::VSP_SHORT, certificate: CERTIFICATE_USAGE::SIGNING), t('user_journey.urls.vsp_signing') %>
+    <% end %>
+  <% else  %>
+    <% if certificate.encryption? %>
+      <%= link_to t('user_journey.rotate_key_and_certificate', component: COMPONENT_TYPE::SP_SHORT, certificate: CERTIFICATE_USAGE::ENCRYPTION), t('user_journey.urls.sp_encryption') %>
+    <% else %>
+      <%= link_to t('user_journey.rotate_key_and_certificate', component: COMPONENT_TYPE::SP_SHORT, certificate: CERTIFICATE_USAGE::SIGNING), t('user_journey.urls.sp_signing') %>
     <% end %>
   <% end %>
-  <%= t 'user_journey.before_you_start.in_documentation' %> 
+  <%= t 'user_journey.in_documentation' %> 
 </p>

--- a/app/views/shared/_component_certificate_doc_links.html.erb
+++ b/app/views/shared/_component_certificate_doc_links.html.erb
@@ -1,23 +1,8 @@
 <p>
-  <%= t 'user_journey.find_out_more' %>
-  <% if certificate.component_type == COMPONENT_TYPE::MSA %>
-    <% if certificate.encryption? %>
-      <%= link_to t('user_journey.rotate_key_and_certificate', component: COMPONENT_TYPE::MSA_SHORT, certificate: CERTIFICATE_USAGE::ENCRYPTION), t('user_journey.urls.msa_encryption') %>
-    <% else %>
-      <%= link_to t('user_journey.rotate_key_and_certificate', component: COMPONENT_TYPE::MSA_SHORT, certificate: CERTIFICATE_USAGE::SIGNING), t('user_journey.urls.msa_signing') %>
-    <% end %>
-  <% elsif certificate.component.vsp  %>
-    <% if certificate.encryption? %>
-      <%= link_to t('user_journey.rotate_key_and_certificate', component: COMPONENT_TYPE::VSP_SHORT, certificate: CERTIFICATE_USAGE::ENCRYPTION), t('user_journey.urls.vsp_encryption') %>
-    <% else %>
-      <%= link_to t('user_journey.rotate_key_and_certificate', component: COMPONENT_TYPE::VSP_SHORT, certificate: CERTIFICATE_USAGE::SIGNING), t('user_journey.urls.vsp_signing') %>
-    <% end %>
-  <% else  %>
-    <% if certificate.encryption? %>
-      <%= link_to t('user_journey.rotate_key_and_certificate', component: COMPONENT_TYPE::SP_SHORT, certificate: CERTIFICATE_USAGE::ENCRYPTION), t('user_journey.urls.sp_encryption') %>
-    <% else %>
-      <%= link_to t('user_journey.rotate_key_and_certificate', component: COMPONENT_TYPE::SP_SHORT, certificate: CERTIFICATE_USAGE::SIGNING), t('user_journey.urls.sp_signing') %>
-    <% end %>
-  <% end %>
-  <%= t 'user_journey.in_documentation' %> 
+  <%= t('user_journey.find_out_more', 
+    link: link_to(t('user_journey.rotate_key_and_certificate', 
+      component: display_component(certificate.component), 
+      certificate: certificate.usage), t("user_journey.urls.#{display_component(certificate.component)}.#{certificate.usage}"))
+    ).html_safe 
+  %>
 </p>

--- a/app/views/shared/_user_component_certificates.html.erb
+++ b/app/views/shared/_user_component_certificates.html.erb
@@ -3,7 +3,7 @@
     <table class="govuk-table">
       <h2 class="govuk-heading-m"><%= component.environment.capitalize %></h2>
       <caption class="govuk-table__caption govuk-!-margin-bottom-1">
-        <%= component.component_type == COMPONENT_TYPE::MSA ? t('user_journey.msa_long') : t('user_journey.vsp_long') %> 
+       <%= t("user_journey.component_name.#{display_component(component)}") %>
         <span class="component-supporting-text">
           <%= t 'user_journey.used_by' %>
         </span>

--- a/app/views/user_journey/before_you_start.html.erb
+++ b/app/views/user_journey/before_you_start.html.erb
@@ -2,14 +2,14 @@
 
 <h1 class="govuk-heading-l"> <%= t 'user_journey.before_you_start.title' %></h1>
 <p><%= t 'user_journey.before_you_start.rotate_certificate_read_steps' %></p>
-<p><%= t "user_journey.before_you_start.#{@certificate.component_type}", type: @certificate.usage %>
+<p><%= t "user_journey.before_you_start.#{display_component(@certificate.component)}", type: @certificate.usage %>
 <% if @certificate.signing? %>
   <%= t 'user_journey.before_you_start.create_signing_key_and_certificate' %>
 <% else %>
 <%= t 'user_journey.before_you_start.you_must' %>
   <ul class="govuk-list govuk-list--number">
     <li><%= t 'user_journey.before_you_start.create_key_and_certificate' %></li>
-    <li><%= t('user_journey.before_you_start.create_encryption_key_and_certificate', component: display_component(@certificate)) %></li>
+    <li><%= t('user_journey.before_you_start.create_encryption_key_and_certificate', component: display_component(@certificate.component)) %></li>
   </ul>
 <% end %>
 </p>
@@ -21,9 +21,9 @@
     <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
     <strong class="govuk-warning-text__text">
       <span class="govuk-warning-text__assistive"><%= t 'layout.application.warning' %></span>
-        <%= t('user_journey.before_you_start.must_update', component: display_component(@certificate))%>
+        <%= t('user_journey.before_you_start.must_update', component: display_component(@certificate.component))%>
       </strong>
   </div>
 <% end %>
 
-<%= link_to @certificate.encryption? ? t('user_journey.before_you_start.have_updated', component: display_component(@certificate)) : t('user_journey.before_you_start.continue'), upload_certificate_path, class: "govuk-button", data: { module: "govuk-button" }, role:"button" %> 
+<%= link_to @certificate.encryption? ? t('user_journey.before_you_start.have_updated', component: display_component(@certificate.component)) : t('user_journey.before_you_start.continue'), upload_certificate_path, class: "govuk-button", data: { module: "govuk-button" }, role:"button" %> 

--- a/app/views/user_journey/confirmation.html.erb
+++ b/app/views/user_journey/confirmation.html.erb
@@ -8,7 +8,7 @@
     <li><%= t 'user_journey.confirmation.msa_add_new_key_and_certificate' %></li>
   <% end %>
   <li><%= t 'user_journey.confirmation.rotate_other_certificates' %></li>
-  <li><%= t('user_journey.confirmation.received_email', usage: @certificate.usage, component: display_component(@certificate)) %></li>
+  <li><%= t('user_journey.confirmation.received_email', usage: @certificate.usage, component: display_component(@certificate.component)) %></li>
   <% if @certificate.signing? && @certificate.component_type == COMPONENT_TYPE::MSA %>
     <li><%= t 'user_journey.confirmation.tell_us_to_stop_using_old_certificate' %></li>
   <% end %>
@@ -19,7 +19,7 @@
     <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
     <strong class="govuk-warning-text__text">
       <span class="govuk-warning-text__assistive"><%= t 'layout.application.warning' %></span>
-      <%= t('user_journey.confirmation.configuration_warning', component: display_component(@certificate), date: date_to_readable_long_format(@certificate.x509.not_after)) %>
+      <%= t('user_journey.confirmation.configuration_warning', component: display_component(@certificate.component), date: date_to_readable_long_format(@certificate.x509.not_after)) %>
     </strong>
   </div>
 <% end %>

--- a/app/views/user_journey/view_certificate.html.erb
+++ b/app/views/user_journey/view_certificate.html.erb
@@ -4,10 +4,10 @@
     <div class="govuk-error-summary__body">
       <% if primary_signing_certificate?(@certificate) %>
         <p><%= t 'user_journey.we_will_email_you' %></p>
-        <p><%= t('user_journey.add_new_signing_key_warning', component: display_component(@certificate), date: date_to_readable_long_format(@certificate.x509.not_after)) %></p>
+        <p><%= t('user_journey.add_new_signing_key_warning', component: display_component(@certificate.component), date: date_to_readable_long_format(@certificate.x509.not_after)) %></p>
       <% elsif secondary_signing_certificate?(@certificate) %>
         <p><%= t 'user_journey.how_long_it_takes' %></p>
-        <p><%= t('user_journey.delete_old_signing_key_and_cert', component: display_component(@certificate)) %></p>
+        <p><%= t('user_journey.delete_old_signing_key_and_cert', component: display_component(@certificate.component)) %></p>
       <% end %>
       <p><%= render 'shared/component_certificate_doc_links', certificate: @certificate %></p>
     </div>
@@ -15,7 +15,7 @@
 <% end %>
 
 <h1 class="govuk-heading-l">
-  <%= @certificate.component.component_type == COMPONENT_TYPE::MSA ? t('user_journey.certificate.msa_heading') : t('user_journey.certificate.vsp_heading') %>
+  <%= t("user_journey.certificate.component_name.#{display_component(@certificate.component)}") %>
   <%= t('user_journey.certificate.certificate', type: @certificate.usage ) %>
   <% if @certificate.signing? && @certificate.component.enabled_signing_certificates.length == 2 %>
     <%= t "user_journey.#{position(@certificate)}" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -225,16 +225,18 @@ en:
     delete_old_signing_key_and_cert: Then you can delete the old signing key and certificate from your %{component} configuration.
     connection_broken_or_compromised: What to do if your connection is broken or compromised
     certificates_expiring: "%{number} certificates are expiring soon."
-    find_out_more: Find out more about 
+    find_out_more: Find out more about %{link} in the documentation.
     rotate_key_and_certificate: rotating your %{component} %{certificate} key and certificate
-    in_documentation: in the documentation.
     urls:
-      msa_encryption: https://prototype-docs.cloudapps.digital/rotating-your-keys-and-certificates/msa-encryption/#rotate-your-msa-encryption-key-and-certificate
-      msa_signing: https://prototype-docs.cloudapps.digital/rotating-your-keys-and-certificates/msa-signing/#rotate-your-msa-signing-key-and-certificate
-      vsp_encryption: https://prototype-docs.cloudapps.digital/rotating-your-keys-and-certificates/vsp-encryption/#rotate-your-vsp-encryption-key-and-certificate
-      vsp_signing: https://prototype-docs.cloudapps.digital/rotating-your-keys-and-certificates/vsp-signing/#rotate-your-vsp-signing-key-and-certificate
-      sp_encryption: https://prototype-docs.cloudapps.digital/rotating-your-keys-and-certificates/service-provider-encryption/#rotate-your-service-provider-encryption-key-and-certificate
-      sp_signing: https://prototype-docs.cloudapps.digital/rotating-your-keys-and-certificates/service-provider-signing/#rotate-your-service-provider-signing-key-and-certificate
+      MSA:
+        encryption: https://prototype-docs.cloudapps.digital/rotating-your-keys-and-certificates/msa-encryption/#rotate-your-msa-encryption-key-and-certificate
+        signing: https://prototype-docs.cloudapps.digital/rotating-your-keys-and-certificates/msa-signing/#rotate-your-msa-signing-key-and-certificate
+      VSP:
+        encryption: https://prototype-docs.cloudapps.digital/rotating-your-keys-and-certificates/vsp-encryption/#rotate-your-vsp-encryption-key-and-certificate
+        signing: https://prototype-docs.cloudapps.digital/rotating-your-keys-and-certificates/vsp-signing/#rotate-your-vsp-signing-key-and-certificate
+      SP: 
+        encryption: https://prototype-docs.cloudapps.digital/rotating-your-keys-and-certificates/service-provider-encryption/#rotate-your-service-provider-encryption-key-and-certificate
+        signing: https://prototype-docs.cloudapps.digital/rotating-your-keys-and-certificates/service-provider-signing/#rotate-your-service-provider-signing-key-and-certificate
       connection_broken_or_compromised: https://prototype-docs.cloudapps.digital/emergency-procedures/#emergency-procedures
     before_you_start:
       title: Before you start

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -203,8 +203,10 @@ en:
     edit:
       heading: Associate team to
   user_journey:
-    msa_long: Matching Service Adapter
-    vsp_long: Verify Service Provider
+    component_name:
+      MSA: Matching Service Adapter
+      VSP: Verify Service Provider
+      SP: Service Provider
     used_by: used by
     certificate: Certificate
     status: Status
@@ -223,28 +225,35 @@ en:
     delete_old_signing_key_and_cert: Then you can delete the old signing key and certificate from your %{component} configuration.
     connection_broken_or_compromised: What to do if your connection is broken or compromised
     certificates_expiring: "%{number} certificates are expiring soon."
+    find_out_more: Find out more about 
+    rotate_key_and_certificate: rotating your %{component} %{certificate} key and certificate
+    in_documentation: in the documentation.
     urls:
       msa_encryption: https://prototype-docs.cloudapps.digital/rotating-your-keys-and-certificates/msa-encryption/#rotate-your-msa-encryption-key-and-certificate
       msa_signing: https://prototype-docs.cloudapps.digital/rotating-your-keys-and-certificates/msa-signing/#rotate-your-msa-signing-key-and-certificate
       vsp_encryption: https://prototype-docs.cloudapps.digital/rotating-your-keys-and-certificates/vsp-encryption/#rotate-your-vsp-encryption-key-and-certificate
       vsp_signing: https://prototype-docs.cloudapps.digital/rotating-your-keys-and-certificates/vsp-signing/#rotate-your-vsp-signing-key-and-certificate
+      sp_encryption: https://prototype-docs.cloudapps.digital/rotating-your-keys-and-certificates/service-provider-encryption/#rotate-your-service-provider-encryption-key-and-certificate
+      sp_signing: https://prototype-docs.cloudapps.digital/rotating-your-keys-and-certificates/service-provider-signing/#rotate-your-service-provider-signing-key-and-certificate
       connection_broken_or_compromised: https://prototype-docs.cloudapps.digital/emergency-procedures/#emergency-procedures
     before_you_start:
       title: Before you start
       rotate_certificate_read_steps: The process for rotating each certificate is slightly different. Read the steps on each page carefully, even if you’ve rotated certificates before.
-      MsaComponent: Before you upload your Matching Service Adapter (MSA) %{type} certificate,
-      SpComponent: Before you upload your Verify Service Provider (VSP) %{type} certificate,
+      MSA: Before you upload your Matching Service Adapter (MSA) %{type} certificate,
+      VSP: Before you upload your Verify Service Provider (VSP) %{type} certificate,
+      SP: Before you upload your Service Provider (SP) %{type} certificate,
       you_must: "you must:"
       create_signing_key_and_certificate: "you must create a new signing key and certificate."
       create_key_and_certificate: Create a new key and certificate
       create_encryption_key_and_certificate: Add your new encryption key and certificate to your %{component} configuration
-      find_out_more: Find out more about
-      rotate_key_and_certificate: rotating your %{component} %{certificate} key and certificate
-      in_documentation: in the documentation.
       must_update: You must update your %{component} configuration before going to the next step, or your service's connection to GOV.UK Verify will break.
       continue: Continue
       have_updated: I have updated my %{component} configuration
     certificate:
+      component_name: 
+        MSA: "Matching Service Adapter: "
+        VSP: "Verify Service Provider: "
+        SP: "Service Provider: "
       check_certificate_title: Check you've uploaded the right certificate
       contains_the_following: "The certificate you uploaded contains the following information:"
       date: Date
@@ -258,8 +267,6 @@ en:
       use_certificate: Use this certificate
       upload_different_certificate: Upload a different certificate
       certificate: "%{type} certificate"
-      msa_heading: "Matching Service Adapter: "
-      vsp_heading: "Verify Service Provider: "
       replace: Replace certificate
       add_new: Add new certificate
       upload_new: Upload your new %{certificate} certificate

--- a/spec/factories/certificate.rb
+++ b/spec/factories/certificate.rb
@@ -7,6 +7,11 @@ FactoryBot.define do
       component { create(:msa_component) }
     end
 
+    factory :vsp_encryption_certificate, class: Certificate do
+      usage { CERTIFICATE_USAGE::ENCRYPTION }
+      component { create(:sp_component, vsp: :true) }
+    end
+
     factory :sp_encryption_certificate, class: Certificate do
       usage { CERTIFICATE_USAGE::ENCRYPTION }
       component { create(:sp_component) }
@@ -17,38 +22,14 @@ FactoryBot.define do
       component { create(:msa_component) }
     end
 
+    factory :vsp_signing_certificate, class: Certificate do
+      usage { CERTIFICATE_USAGE::SIGNING }
+      component { create(:sp_component, vsp: :true) }
+    end
+
     factory :sp_signing_certificate, class: Certificate do
       usage { CERTIFICATE_USAGE::SIGNING }
       component { create(:sp_component) }
     end
   end
-<<<<<<< HEAD
 end
-=======
-  factory :vsp_encryption_certificate, class: Certificate do
-    usage { CERTIFICATE_USAGE::ENCRYPTION }
-    value { PKI.new.generate_encoded_cert(expires_in: 9.months) }
-    component { create(:sp_component, vsp: :true) }
-  end
-  factory :sp_encryption_certificate, class: Certificate do
-    usage { CERTIFICATE_USAGE::ENCRYPTION }
-    value { PKI.new.generate_encoded_cert(expires_in: 9.months) }
-    component { create(:sp_component) }
-  end
-  factory :msa_signing_certificate, class: Certificate do
-    usage { CERTIFICATE_USAGE::SIGNING }
-    value { PKI.new.generate_encoded_cert(expires_in: 9.months) }
-    component { create(:msa_component) }
-  end
-  factory :vsp_signing_certificate, class: Certificate do
-    usage { CERTIFICATE_USAGE::SIGNING }
-    value { PKI.new.generate_encoded_cert(expires_in: 9.months) }
-    component { create(:sp_component, vsp: :true) }
-  end
-  factory :sp_signing_certificate, class: Certificate do
-    usage { CERTIFICATE_USAGE::SIGNING }
-    value { PKI.new.generate_encoded_cert(expires_in: 9.months) }
-    component { create(:sp_component) }
-  end
-end
->>>>>>> XGWgKqpg: Show the clear distinction between the 3 different component types

--- a/spec/factories/certificate.rb
+++ b/spec/factories/certificate.rb
@@ -22,4 +22,33 @@ FactoryBot.define do
       component { create(:sp_component) }
     end
   end
+<<<<<<< HEAD
 end
+=======
+  factory :vsp_encryption_certificate, class: Certificate do
+    usage { CERTIFICATE_USAGE::ENCRYPTION }
+    value { PKI.new.generate_encoded_cert(expires_in: 9.months) }
+    component { create(:sp_component, vsp: :true) }
+  end
+  factory :sp_encryption_certificate, class: Certificate do
+    usage { CERTIFICATE_USAGE::ENCRYPTION }
+    value { PKI.new.generate_encoded_cert(expires_in: 9.months) }
+    component { create(:sp_component) }
+  end
+  factory :msa_signing_certificate, class: Certificate do
+    usage { CERTIFICATE_USAGE::SIGNING }
+    value { PKI.new.generate_encoded_cert(expires_in: 9.months) }
+    component { create(:msa_component) }
+  end
+  factory :vsp_signing_certificate, class: Certificate do
+    usage { CERTIFICATE_USAGE::SIGNING }
+    value { PKI.new.generate_encoded_cert(expires_in: 9.months) }
+    component { create(:sp_component, vsp: :true) }
+  end
+  factory :sp_signing_certificate, class: Certificate do
+    usage { CERTIFICATE_USAGE::SIGNING }
+    value { PKI.new.generate_encoded_cert(expires_in: 9.months) }
+    component { create(:sp_component) }
+  end
+end
+>>>>>>> XGWgKqpg: Show the clear distinction between the 3 different component types

--- a/spec/system/visit_index_page_spec.rb
+++ b/spec/system/visit_index_page_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe 'IndexPage', type: :system do
     expect(table_row_content).to have_content 'DEPLOYING'
   end
 
-  it 'shows missing tag if encyrption certificate value has not been uploaded' do
+  it 'shows missing tag if encryption certificate value has not been uploaded' do
     sp_component = create(:sp_component)
     visit root_path
     expect(page).to have_content 'Encryption certificate'

--- a/spec/system/visit_user_journey_before_you_start_page_spec.rb
+++ b/spec/system/visit_user_journey_before_you_start_page_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Before you start page', type: :system do
     )
   end
 
-  context 'encyrption journey' do 
+  context 'encryption journey' do 
     it 'shows before you start page for msa encryption and successfully goes to next page' do
       msa_component = msa_encryption_certificate.component
       visit before_you_start_path(msa_component.component_type, msa_component.id, msa_component.encryption_certificate_id)

--- a/spec/system/visit_user_journey_before_you_start_page_spec.rb
+++ b/spec/system/visit_user_journey_before_you_start_page_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'Before you start page', type: :system do
 
   let(:msa_encryption_certificate) { create(:msa_encryption_certificate) }
   let(:sp_encryption_certificate) { create(:sp_encryption_certificate) }
+  let(:vsp_encryption_certificate) { create(:vsp_encryption_certificate) }
 
   before(:each) do
     login_certificate_manager_user
@@ -16,39 +17,64 @@ RSpec.describe 'Before you start page', type: :system do
       component: msa_encryption_certificate.component,
       encryption_certificate_id: msa_encryption_certificate.id
     )
+    ReplaceEncryptionCertificateEvent.create(
+      component: vsp_encryption_certificate.component,
+      encryption_certificate_id: vsp_encryption_certificate.id
+    )
   end
 
-  it 'shows before you start page for msa encryption and successfully goes to next page' do
-    msa_component = msa_encryption_certificate.component
-    visit before_you_start_path(msa_component.component_type, msa_component.id, msa_component.encryption_certificate_id)
-    expect(page).to have_content 'Matching Service Adapter (MSA) encryption certificate'
-    click_link 'I have updated my MSA configuration'
-    expect(current_path).to eql upload_certificate_path(msa_component.component_type, msa_component.id, msa_component.encryption_certificate_id)
+  context 'encyrption journey' do 
+    it 'shows before you start page for msa encryption and successfully goes to next page' do
+      msa_component = msa_encryption_certificate.component
+      visit before_you_start_path(msa_component.component_type, msa_component.id, msa_component.encryption_certificate_id)
+      expect(page).to have_content 'Matching Service Adapter (MSA) encryption certificate'
+      click_link 'I have updated my MSA configuration'
+      expect(current_path).to eql upload_certificate_path(msa_component.component_type, msa_component.id, msa_component.encryption_certificate_id)
+    end
+
+    it 'shows before you start page for vsp encryption and successfully goes to next page' do
+      vsp_component = vsp_encryption_certificate.component
+      visit before_you_start_path(vsp_component.component_type, vsp_component.id, vsp_component.encryption_certificate_id)
+      expect(page).to have_content 'Verify Service Provider (VSP) encryption certificate'
+      click_link 'I have updated my VSP configuration'
+      expect(current_path).to eql upload_certificate_path(vsp_component.component_type, vsp_component.id, vsp_component.encryption_certificate_id)
+    end
+
+    it 'shows before you start page for sp encryption and successfully goes to next page' do
+      sp_component = sp_encryption_certificate.component
+      visit before_you_start_path(sp_component.component_type, sp_component.id, sp_component.encryption_certificate_id)
+      expect(page).to have_content 'Service Provider (SP) encryption certificate'
+      click_link 'I have updated my SP configuration'
+      expect(current_path).to eql upload_certificate_path(sp_component.component_type, sp_component.id, sp_component.encryption_certificate_id)
+    end
   end
 
-  it 'shows before you start page for sp encryption and successfully goes to next page' do
-    sp_component = sp_encryption_certificate.component
-    visit before_you_start_path(sp_component.component_type, sp_component.id, sp_component.encryption_certificate_id)
-    expect(page).to have_content 'Verify Service Provider (VSP) encryption certificate'
-    click_link 'I have updated my VSP configuration'
-    expect(current_path).to eql upload_certificate_path(sp_component.component_type, sp_component.id, sp_component.encryption_certificate_id)
-  end
+  context 'signing journey' do
+    it 'shows before you start page for msa signing and successfully goes to next page' do
+      certificate = create(:msa_signing_certificate)
+      msa_component = certificate.component
+      visit before_you_start_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
+      expect(page).to have_content 'Matching Service Adapter (MSA) signing certificate'
+      click_link 'Continue'
+      expect(current_path).to eql upload_certificate_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
+    end
 
-  it 'shows before you start page for msa signing and successfully goes to next page' do
-    certificate = create(:msa_signing_certificate)
-    msa_component = certificate.component
-    visit before_you_start_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
-    expect(page).to have_content 'Matching Service Adapter (MSA) signing certificate'
-    click_link 'Continue'
-    expect(current_path).to eql upload_certificate_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
-  end
+    it 'shows before you start page for vsp signing and successfully goes to next page' do
+      certificate = create(:vsp_signing_certificate)
+      vsp_component = certificate.component
+      visit before_you_start_path(vsp_component.component_type, vsp_component.id, vsp_component.signing_certificates[0])
+      expect(page).to have_content 'Verify Service Provider (VSP) signing certificate'
+      click_link 'Continue'
+      expect(current_path).to eql upload_certificate_path(vsp_component.component_type, vsp_component.id, vsp_component.signing_certificates[0])
+    end
 
-  it 'shows before you start page for sp signing and successfully goes to next page' do
-    certificate = create(:sp_signing_certificate)
-    sp_component = certificate.component
-    visit before_you_start_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])
-    expect(page).to have_content 'Verify Service Provider (VSP) signing certificate'
-    click_link 'Continue'
-    expect(current_path).to eql upload_certificate_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])
+    it 'shows before you start page for sp signing and successfully goes to next page' do
+      certificate = create(:sp_signing_certificate)
+      sp_component = certificate.component
+      visit before_you_start_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])
+      expect(page).to have_content 'Service Provider (SP) signing certificate'
+      click_link 'Continue'
+      expect(current_path).to eql upload_certificate_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])
+    end
   end
 end

--- a/spec/system/visit_user_journey_check_your_certificate_page_spec.rb
+++ b/spec/system/visit_user_journey_check_your_certificate_page_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Check your certificate page', type: :system do
       fill_in 'certificate_value', with: msa_encryption_certificate.value
       click_button 'Continue'
       expect(current_path).to eql check_your_certificate_path(msa_component.component_type, msa_component.id, msa_component.encryption_certificate_id)
-      expect(page).to have_content 'MSA'
+      expect(page).to have_content COMPONENT_TYPE::MSA_SHORT
       expect(page).to have_content 'Encryption'
       click_button 'Use this certificate'
       expect(current_path).to eql confirmation_path(msa_component.component_type, msa_component.id, msa_component.encryption_certificate_id)
@@ -42,7 +42,7 @@ RSpec.describe 'Check your certificate page', type: :system do
       fill_in 'certificate_value', with: vsp_encryption_certificate.value
       click_button 'Continue'
       expect(current_path).to eql check_your_certificate_path(vsp_component.component_type, vsp_component.id, vsp_component.encryption_certificate_id)
-      expect(page).to have_content 'VSP'
+      expect(page).to have_content COMPONENT_TYPE::VSP_SHORT
       expect(page).to have_content 'Encryption'
       click_button 'Use this certificate'
       expect(current_path).to eql confirmation_path(vsp_component.component_type, vsp_component.id, vsp_component.encryption_certificate_id)
@@ -54,7 +54,7 @@ RSpec.describe 'Check your certificate page', type: :system do
       fill_in 'certificate_value', with: sp_encryption_certificate.value
       click_button 'Continue'
       expect(current_path).to eql check_your_certificate_path(sp_component.component_type, sp_component.id, sp_component.encryption_certificate_id)
-      expect(page).to have_content 'SP'
+      expect(page).to have_content COMPONENT_TYPE::SP_SHORT
       expect(page).to have_content 'Encryption'
       click_button 'Use this certificate'
       expect(current_path).to eql confirmation_path(sp_component.component_type, sp_component.id, sp_component.encryption_certificate_id)
@@ -69,7 +69,7 @@ RSpec.describe 'Check your certificate page', type: :system do
       fill_in 'certificate_value', with: msa_signing_certificate.value
       click_button 'Continue'
       expect(current_path).to eql check_your_certificate_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
-      expect(page).to have_content 'MSA'
+      expect(page).to have_content COMPONENT_TYPE::MSA_SHORT
       expect(page).to have_content 'Signing'
       click_button 'Use this certificate'
       expect(current_path).to eql confirmation_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
@@ -82,7 +82,7 @@ RSpec.describe 'Check your certificate page', type: :system do
       fill_in 'certificate_value', with: vsp_signing_certificate.value
       click_button 'Continue'
       expect(current_path).to eql check_your_certificate_path(vsp_component.component_type, vsp_component.id, vsp_component.signing_certificates[0])
-      expect(page).to have_content 'VSP'
+      expect(page).to have_content COMPONENT_TYPE::VSP_SHORT
       expect(page).to have_content 'Signing'
       click_button 'Use this certificate'
       expect(current_path).to eql confirmation_path(vsp_component.component_type, vsp_component.id, vsp_component.signing_certificates[0])
@@ -95,7 +95,7 @@ RSpec.describe 'Check your certificate page', type: :system do
       fill_in 'certificate_value', with: sp_signing_certificate.value
       click_button 'Continue'
       expect(current_path).to eql check_your_certificate_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])
-      expect(page).to have_content 'SP'
+      expect(page).to have_content COMPONENT_TYPE::SP_SHORT
       expect(page).to have_content 'Signing'
       click_button 'Use this certificate'
       expect(current_path).to eql confirmation_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])

--- a/spec/system/visit_user_journey_check_your_certificate_page_spec.rb
+++ b/spec/system/visit_user_journey_check_your_certificate_page_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'Check your certificate page', type: :system do
 
   let(:msa_encryption_certificate) { create(:msa_encryption_certificate) }
   let(:sp_encryption_certificate) { create(:sp_encryption_certificate) }
+  let(:vsp_encryption_certificate) { create(:vsp_encryption_certificate) }
 
   before(:each) do
     login_certificate_manager_user
@@ -16,8 +17,13 @@ RSpec.describe 'Check your certificate page', type: :system do
       component: msa_encryption_certificate.component,
       encryption_certificate_id: msa_encryption_certificate.id
     )
+    ReplaceEncryptionCertificateEvent.create(
+      component: vsp_encryption_certificate.component,
+      encryption_certificate_id: vsp_encryption_certificate.id
+    )
   end
-  context 'shows check your certificate page for' do
+
+  context 'encryption journey' do
     it 'msa encryption and successfully goes to next page' do
       msa_component = msa_encryption_certificate.component
       visit upload_certificate_path(msa_component.component_type, msa_component.id, msa_component.encryption_certificate_id)
@@ -30,16 +36,69 @@ RSpec.describe 'Check your certificate page', type: :system do
       expect(current_path).to eql confirmation_path(msa_component.component_type, msa_component.id, msa_component.encryption_certificate_id)
     end
 
+    it 'vsp encryption and successfully goes to next page' do
+      vsp_component = vsp_encryption_certificate.component
+      visit upload_certificate_path(vsp_component.component_type, vsp_component.id, vsp_component.encryption_certificate_id)
+      fill_in 'certificate_value', with: vsp_encryption_certificate.value
+      click_button 'Continue'
+      expect(current_path).to eql check_your_certificate_path(vsp_component.component_type, vsp_component.id, vsp_component.encryption_certificate_id)
+      expect(page).to have_content 'VSP'
+      expect(page).to have_content 'Encryption'
+      click_button 'Use this certificate'
+      expect(current_path).to eql confirmation_path(vsp_component.component_type, vsp_component.id, vsp_component.encryption_certificate_id)
+    end
+
     it 'sp encryption and successfully goes to next page' do
       sp_component = sp_encryption_certificate.component
       visit upload_certificate_path(sp_component.component_type, sp_component.id, sp_component.encryption_certificate_id)
       fill_in 'certificate_value', with: sp_encryption_certificate.value
       click_button 'Continue'
       expect(current_path).to eql check_your_certificate_path(sp_component.component_type, sp_component.id, sp_component.encryption_certificate_id)
-      expect(page).to have_content 'VSP'
+      expect(page).to have_content 'SP'
       expect(page).to have_content 'Encryption'
       click_button 'Use this certificate'
       expect(current_path).to eql confirmation_path(sp_component.component_type, sp_component.id, sp_component.encryption_certificate_id)
+    end
+  end
+
+  context 'signing journey' do
+    it 'expect msa component, signing certificate and successfully goes to next page' do
+      msa_signing_certificate = create(:msa_signing_certificate)
+      msa_component = msa_signing_certificate.component
+      visit upload_certificate_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
+      fill_in 'certificate_value', with: msa_signing_certificate.value
+      click_button 'Continue'
+      expect(current_path).to eql check_your_certificate_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
+      expect(page).to have_content 'MSA'
+      expect(page).to have_content 'Signing'
+      click_button 'Use this certificate'
+      expect(current_path).to eql confirmation_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
+    end
+
+    it 'expect vsp component, signing certificate and successfully goes to next page' do
+      vsp_signing_certificate = create(:vsp_signing_certificate)
+      vsp_component = vsp_signing_certificate.component
+      visit upload_certificate_path(vsp_component.component_type, vsp_component.id, vsp_component.signing_certificates[0])
+      fill_in 'certificate_value', with: vsp_signing_certificate.value
+      click_button 'Continue'
+      expect(current_path).to eql check_your_certificate_path(vsp_component.component_type, vsp_component.id, vsp_component.signing_certificates[0])
+      expect(page).to have_content 'VSP'
+      expect(page).to have_content 'Signing'
+      click_button 'Use this certificate'
+      expect(current_path).to eql confirmation_path(vsp_component.component_type, vsp_component.id, vsp_component.signing_certificates[0])
+    end
+  
+    it 'expect sp component, signing certificate and successfully goes to next page' do
+      sp_signing_certificate = create(:sp_signing_certificate)
+      sp_component = sp_signing_certificate.component
+      visit upload_certificate_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])
+      fill_in 'certificate_value', with: sp_signing_certificate.value
+      click_button 'Continue'
+      expect(current_path).to eql check_your_certificate_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])
+      expect(page).to have_content 'SP'
+      expect(page).to have_content 'Signing'
+      click_button 'Use this certificate'
+      expect(current_path).to eql confirmation_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])
     end
   end
 end

--- a/spec/system/visit_user_journey_confirmation_page_spec.rb
+++ b/spec/system/visit_user_journey_confirmation_page_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Confirmation page', type: :system do
     it 'encryption and successfully goes to next page' do
       msa_component = msa_encryption_certificate.component
       visit confirmation_path(msa_component.component_type, msa_component.id, msa_component.encryption_certificate_id)
-      expect(page).to have_content 'MSA'
+      expect(page).to have_content COMPONENT_TYPE::MSA_SHORT
       expect(page).to have_content 'delete the old encryption key and certificate from your MSA configuration'
       click_link 'Rotate more certificates'
       expect(current_path).to eql root_path
@@ -37,7 +37,7 @@ RSpec.describe 'Confirmation page', type: :system do
       certificate = create(:msa_signing_certificate)
       msa_component = certificate.component
       visit confirmation_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
-      expect(page).to have_content 'MSA'
+      expect(page).to have_content COMPONENT_TYPE::MSA_SHORT
       expect(page).to have_content 'delete the old signing key and certificate from your MSA configuration'
       click_link 'Rotate more certificates'
       expect(current_path).to eql root_path
@@ -48,7 +48,7 @@ RSpec.describe 'Confirmation page', type: :system do
     it 'encryption and successfully goes to next page' do
       vsp_component = vsp_encryption_certificate.component
       visit confirmation_path(vsp_component.component_type, vsp_component.id, vsp_component.encryption_certificate_id)
-      expect(page).to have_content 'VSP'
+      expect(page).to have_content COMPONENT_TYPE::VSP_SHORT
       expect(page).to have_content 'delete the old encryption key and certificate from your VSP configuration'
       click_link 'Rotate more certificates'
       expect(current_path).to eql root_path
@@ -58,7 +58,7 @@ RSpec.describe 'Confirmation page', type: :system do
       certificate = create(:vsp_signing_certificate)
       vsp_component = certificate.component
       visit confirmation_path(vsp_component.component_type, vsp_component.id, vsp_component.signing_certificates[0])
-      expect(page).to have_content 'VSP'
+      expect(page).to have_content COMPONENT_TYPE::VSP_SHORT
       expect(page).to have_content 'delete the old signing key and certificate from your VSP configuration'
       click_link 'Rotate more certificates'
       expect(current_path).to eql root_path
@@ -69,7 +69,7 @@ RSpec.describe 'Confirmation page', type: :system do
     it 'encryption and successfully goes to next page' do
       sp_component = sp_encryption_certificate.component
       visit confirmation_path(sp_component.component_type, sp_component.id, sp_component.encryption_certificate_id)
-      expect(page).to have_content 'SP'
+      expect(page).to have_content COMPONENT_TYPE::SP_SHORT
       expect(page).to have_content 'delete the old encryption key and certificate from your SP configuration'
       click_link 'Rotate more certificates'
       expect(current_path).to eql root_path
@@ -79,7 +79,7 @@ RSpec.describe 'Confirmation page', type: :system do
       certificate = create(:sp_signing_certificate)
       sp_component = certificate.component
       visit confirmation_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])
-      expect(page).to have_content 'SP'
+      expect(page).to have_content COMPONENT_TYPE::SP_SHORT
       expect(page).to have_content 'delete the old signing key and certificate from your SP configuration'
       click_link 'Rotate more certificates'
       expect(current_path).to eql root_path

--- a/spec/system/visit_user_journey_confirmation_page_spec.rb
+++ b/spec/system/visit_user_journey_confirmation_page_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'Confirmation page', type: :system do
 
   let(:msa_encryption_certificate) { create(:msa_encryption_certificate) }
   let(:sp_encryption_certificate) { create(:sp_encryption_certificate) }
+  let(:vsp_encryption_certificate) { create(:vsp_encryption_certificate) }
 
   before(:each) do
     login_certificate_manager_user
@@ -15,6 +16,10 @@ RSpec.describe 'Confirmation page', type: :system do
     ReplaceEncryptionCertificateEvent.create(
       component: msa_encryption_certificate.component,
       encryption_certificate_id: msa_encryption_certificate.id
+    )
+    ReplaceEncryptionCertificateEvent.create(
+      component: vsp_encryption_certificate.component,
+      encryption_certificate_id: vsp_encryption_certificate.id
     )
   end
 
@@ -39,12 +44,33 @@ RSpec.describe 'Confirmation page', type: :system do
     end
   end
 
+  context 'shows confirmation page for vsp' do
+    it 'encryption and successfully goes to next page' do
+      vsp_component = vsp_encryption_certificate.component
+      visit confirmation_path(vsp_component.component_type, vsp_component.id, vsp_component.encryption_certificate_id)
+      expect(page).to have_content 'VSP'
+      expect(page).to have_content 'delete the old encryption key and certificate from your VSP configuration'
+      click_link 'Rotate more certificates'
+      expect(current_path).to eql root_path
+    end
+
+    it 'signing and successfully goes to next page' do
+      certificate = create(:vsp_signing_certificate)
+      vsp_component = certificate.component
+      visit confirmation_path(vsp_component.component_type, vsp_component.id, vsp_component.signing_certificates[0])
+      expect(page).to have_content 'VSP'
+      expect(page).to have_content 'delete the old signing key and certificate from your VSP configuration'
+      click_link 'Rotate more certificates'
+      expect(current_path).to eql root_path
+    end
+  end
+
   context 'shows confirmation page for sp' do
     it 'encryption and successfully goes to next page' do
       sp_component = sp_encryption_certificate.component
       visit confirmation_path(sp_component.component_type, sp_component.id, sp_component.encryption_certificate_id)
-      expect(page).to have_content 'VSP'
-      expect(page).to have_content 'delete the old encryption key and certificate from your VSP configuration'
+      expect(page).to have_content 'SP'
+      expect(page).to have_content 'delete the old encryption key and certificate from your SP configuration'
       click_link 'Rotate more certificates'
       expect(current_path).to eql root_path
     end
@@ -53,8 +79,8 @@ RSpec.describe 'Confirmation page', type: :system do
       certificate = create(:sp_signing_certificate)
       sp_component = certificate.component
       visit confirmation_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])
-      expect(page).to have_content 'VSP'
-      expect(page).to have_content 'delete the old signing key and certificate from your VSP configuration'
+      expect(page).to have_content 'SP'
+      expect(page).to have_content 'delete the old signing key and certificate from your SP configuration'
       click_link 'Rotate more certificates'
       expect(current_path).to eql root_path
     end

--- a/spec/system/visit_user_journey_upload_certificate_page_spec.rb
+++ b/spec/system/visit_user_journey_upload_certificate_page_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Upload certificate page', type: :system do
     it 'encryption and successfully goes to next page' do
       msa_component = msa_encryption_certificate.component
       visit upload_certificate_path(msa_component.component_type, msa_component.id, msa_component.encryption_certificate_id)
-      expect(page).to have_content 'MSA'
+      expect(page).to have_content COMPONENT_TYPE::MSA_SHORT
       expect(page).to have_content 'Upload your new encryption certificate'
       fill_in 'certificate_value', with: msa_encryption_certificate.value
       click_button 'Continue'
@@ -38,7 +38,7 @@ RSpec.describe 'Upload certificate page', type: :system do
       certificate = create(:msa_signing_certificate)
       msa_component = certificate.component
       visit upload_certificate_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
-      expect(page).to have_content 'MSA'
+      expect(page).to have_content COMPONENT_TYPE::MSA_SHORT
       expect(page).to have_content 'Upload your new signing certificate'
       fill_in 'certificate_value', with: certificate.value
       click_button 'Continue'
@@ -50,7 +50,7 @@ RSpec.describe 'Upload certificate page', type: :system do
     it 'encryption and successfully goes to next page' do
       vsp_component = vsp_encryption_certificate.component
       visit upload_certificate_path(vsp_component.component_type, vsp_component.id, vsp_component.encryption_certificate_id)
-      expect(page).to have_content 'VSP'
+      expect(page).to have_content COMPONENT_TYPE::VSP_SHORT
       expect(page).to have_content 'Upload your new encryption certificate'
       fill_in 'certificate_value', with: vsp_encryption_certificate.value
       click_button 'Continue'
@@ -61,7 +61,7 @@ RSpec.describe 'Upload certificate page', type: :system do
       certificate = create(:vsp_signing_certificate)
       vsp_component = certificate.component
       visit upload_certificate_path(vsp_component.component_type, vsp_component.id, vsp_component.signing_certificates[0])
-      expect(page).to have_content 'VSP'
+      expect(page).to have_content COMPONENT_TYPE::VSP_SHORT
       expect(page).to have_content 'Upload your new signing certificate'
       fill_in 'certificate_value', with: certificate.value
       click_button 'Continue'
@@ -73,7 +73,7 @@ RSpec.describe 'Upload certificate page', type: :system do
     it 'encryption and successfully goes to next page' do
       sp_component = sp_encryption_certificate.component
       visit upload_certificate_path(sp_component.component_type, sp_component.id, sp_component.encryption_certificate_id)
-      expect(page).to have_content 'SP'
+      expect(page).to have_content COMPONENT_TYPE::SP_SHORT
       expect(page).to have_content 'Upload your new encryption certificate'
       fill_in 'certificate_value', with: sp_encryption_certificate.value
       click_button 'Continue'
@@ -84,7 +84,7 @@ RSpec.describe 'Upload certificate page', type: :system do
       certificate = create(:sp_signing_certificate)
       sp_component = certificate.component
       visit upload_certificate_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])
-      expect(page).to have_content 'SP'
+      expect(page).to have_content COMPONENT_TYPE::SP_SHORT
       expect(page).to have_content 'Upload your new signing certificate'
       fill_in 'certificate_value', with: certificate.value
       click_button 'Continue'

--- a/spec/system/visit_user_journey_upload_certificate_page_spec.rb
+++ b/spec/system/visit_user_journey_upload_certificate_page_spec.rb
@@ -5,10 +5,10 @@ RSpec.describe 'Upload certificate page', type: :system do
 
   let(:msa_encryption_certificate) { create(:msa_encryption_certificate) }
   let(:sp_encryption_certificate) { create(:sp_encryption_certificate) }
+  let(:vsp_encryption_certificate) { create(:vsp_encryption_certificate) }
 
   before(:each) do
     login_certificate_manager_user
-
     ReplaceEncryptionCertificateEvent.create(
       component: sp_encryption_certificate.component,
       encryption_certificate_id: sp_encryption_certificate.id
@@ -17,7 +17,12 @@ RSpec.describe 'Upload certificate page', type: :system do
       component: msa_encryption_certificate.component,
       encryption_certificate_id: msa_encryption_certificate.id
     )
+    ReplaceEncryptionCertificateEvent.create(
+      component: vsp_encryption_certificate.component,
+      encryption_certificate_id: vsp_encryption_certificate.id
+    )
   end
+
   context 'shows upload page for msa' do
     it 'encryption and successfully goes to next page' do
       msa_component = msa_encryption_certificate.component
@@ -40,11 +45,35 @@ RSpec.describe 'Upload certificate page', type: :system do
       expect(current_path).to eql check_your_certificate_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
     end
   end
+
+  context 'shows upload page for vsp' do
+    it 'encryption and successfully goes to next page' do
+      vsp_component = vsp_encryption_certificate.component
+      visit upload_certificate_path(vsp_component.component_type, vsp_component.id, vsp_component.encryption_certificate_id)
+      expect(page).to have_content 'VSP'
+      expect(page).to have_content 'Upload your new encryption certificate'
+      fill_in 'certificate_value', with: vsp_encryption_certificate.value
+      click_button 'Continue'
+      expect(current_path).to eql check_your_certificate_path(vsp_component.component_type, vsp_component.id, vsp_component.encryption_certificate_id)
+    end
+
+    it 'signing and successfully goes to next page' do
+      certificate = create(:vsp_signing_certificate)
+      vsp_component = certificate.component
+      visit upload_certificate_path(vsp_component.component_type, vsp_component.id, vsp_component.signing_certificates[0])
+      expect(page).to have_content 'VSP'
+      expect(page).to have_content 'Upload your new signing certificate'
+      fill_in 'certificate_value', with: certificate.value
+      click_button 'Continue'
+      expect(current_path).to eql check_your_certificate_path(vsp_component.component_type, vsp_component.id, vsp_component.signing_certificates[0])
+    end
+  end
+
   context 'shows upload page for sp' do
     it 'encryption and successfully goes to next page' do
       sp_component = sp_encryption_certificate.component
       visit upload_certificate_path(sp_component.component_type, sp_component.id, sp_component.encryption_certificate_id)
-      expect(page).to have_content 'VSP'
+      expect(page).to have_content 'SP'
       expect(page).to have_content 'Upload your new encryption certificate'
       fill_in 'certificate_value', with: sp_encryption_certificate.value
       click_button 'Continue'
@@ -55,7 +84,7 @@ RSpec.describe 'Upload certificate page', type: :system do
       certificate = create(:sp_signing_certificate)
       sp_component = certificate.component
       visit upload_certificate_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])
-      expect(page).to have_content 'VSP'
+      expect(page).to have_content 'SP'
       expect(page).to have_content 'Upload your new signing certificate'
       fill_in 'certificate_value', with: certificate.value
       click_button 'Continue'

--- a/spec/system/visit_user_journey_view_certificate_page_spec.rb
+++ b/spec/system/visit_user_journey_view_certificate_page_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe 'View certificate page', type: :system do
   include CertificateSupport
   let(:msa_encryption_certificate) { create(:msa_encryption_certificate) }
   let(:sp_encryption_certificate) { create(:sp_encryption_certificate) }  
+  let(:vsp_encryption_certificate) { create(:vsp_encryption_certificate) }  
 
   before(:each) do
     @user = login_certificate_manager_user
@@ -15,7 +16,12 @@ RSpec.describe 'View certificate page', type: :system do
       component: msa_encryption_certificate.component,
       encryption_certificate_id: msa_encryption_certificate.id
     )
+    ReplaceEncryptionCertificateEvent.create(
+      component: vsp_encryption_certificate.component,
+      encryption_certificate_id: vsp_encryption_certificate.id
+    )
   end
+
   context 'shows existing msa' do
     it 'encryption certificate information and navigates to next page' do
       msa_component = msa_encryption_certificate.component
@@ -37,9 +43,28 @@ RSpec.describe 'View certificate page', type: :system do
 
   context 'shows existing vsp' do
     it 'encryption certificate information and navigates to next page' do
+      vsp_component = vsp_encryption_certificate.component
+      visit view_certificate_path(vsp_component.component_type, vsp_component.id, vsp_component.encryption_certificate_id)
+      expect(page).to have_content 'Verify Service Provider: encryption certificate'
+      click_link 'Replace certificate'
+      expect(current_path).to eql before_you_start_path(vsp_component.component_type, vsp_component.id, vsp_component.encryption_certificate_id)
+    end
+
+    it 'signing certificate information and navigates to next page' do
+      vsp_signing_certificate = create(:vsp_signing_certificate)
+      vsp_component = vsp_signing_certificate.component
+      visit view_certificate_path(vsp_component.component_type, vsp_component.id, vsp_component.signing_certificates[0])
+      expect(page).to have_content 'Verify Service Provider: signing certificate'
+      click_link 'Add new certificate'
+      expect(current_path).to eql before_you_start_path(vsp_component.component_type, vsp_component.id, vsp_component.signing_certificates[0])
+    end
+  end
+
+  context 'shows existing sp' do
+    it 'encryption certificate information and navigates to next page' do
       sp_component = sp_encryption_certificate.component
       visit view_certificate_path(sp_component.component_type, sp_component.id, sp_component.encryption_certificate_id)
-      expect(page).to have_content 'Verify Service Provider: encryption certificate'
+      expect(page).to have_content 'Service Provider: encryption certificate'
       click_link 'Replace certificate'
       expect(current_path).to eql before_you_start_path(sp_component.component_type, sp_component.id, sp_component.encryption_certificate_id)
     end
@@ -48,7 +73,7 @@ RSpec.describe 'View certificate page', type: :system do
       sp_signing_certificate = create(:sp_signing_certificate)
       sp_component = sp_signing_certificate.component
       visit view_certificate_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])
-      expect(page).to have_content 'Verify Service Provider: signing certificate'
+      expect(page).to have_content 'Service Provider: signing certificate'
       click_link 'Add new certificate'
       expect(current_path).to eql before_you_start_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])
     end


### PR DESCRIPTION
The user journey currently only changes context for the MSA and VSP. It is missing the service provider. For now i will add the option SP.
Also create tests to show the separate SP and VSP journeys

Doing this will help in the follow up stories to implement the updated content on the prototype