### PR TITLE
BAU: Fix the failing healthcheck

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -75,6 +75,9 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
+  # Skip the HTTPS redirect on the healtheck as it returns 301 Permanent Redirect
+  config.ssl_options = { redirect: { exclude: -> request { request.path =~ /healthcheck/ } } }
+
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
   config.log_level = :debug


### PR DESCRIPTION
Our healthcheck has been consistently failing due to 301 Permanent Redirect.
It seems to be caused by the change we introduced to force SSL.
This disables the redirect (301) on the healthcheck endpoint.