### PR TITLE
ml6syFrY: Remove the GDS role option from the invite to a non-GDS team

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,10 +2,9 @@ require 'auth/authentication_backend'
 
 class UsersController < ApplicationController
   include AuthenticationBackend
-  layout "main_layout"
+  layout 'main_layout'
 
   def index
-    @user = current_user
     @gds = current_user.permissions.team_management
     if @gds
       @teams = Team.all
@@ -15,6 +14,9 @@ class UsersController < ApplicationController
   end
 
   def invite
+    if current_user.permissions.admin_management
+      @gds_team = Team.find_by_id(params[:team_id])&.name == TEAMS::GDS
+    end
     @form = InviteUserForm.new({})
   end
 
@@ -31,7 +33,7 @@ class UsersController < ApplicationController
 private
 
   def team_valid?
-    if Team.exists?(params[:team_id]) || params[:team_id] == '0'
+    if Team.exists?(params[:team_id])
       true
     else
       @form.errors.add(t('invite.error.team.missing'))

--- a/app/models/invite_user_form.rb
+++ b/app/models/invite_user_form.rb
@@ -17,6 +17,10 @@ class InviteUserForm
 private
 
   def email_is_valid
+    if roles&.include?(ROLE::GDS) && !email.ends_with?(TEAMS::GDS_EMAIL_DOMAIN)
+      errors.add(:email, I18n.t('users.invite.errors.invalid_gds_email'))
+    end
+
     errors.add(:email, I18n.t('users.invite.errors.invalid_email')) unless EmailValidator.valid?(email, strict_mode: true)
   end
 

--- a/app/views/users/invite.erb
+++ b/app/views/users/invite.erb
@@ -17,27 +17,42 @@
     <%= f.text_field :family_name, class: "govuk-input" %>
   </div>
 
-  <div class="govuk-form-group">
-  <fieldset class="govuk-fieldset">
-    <div class="govuk-checkboxes">
-      <div class="govuk-checkboxes__item">
-        <%= f.check_box(:roles, { :class => 'govuk-checkboxes__input', :multiple => true }, ROLE::CERTIFICATE_MANAGER, nil) %>
-        <%= f.label :roles, t("users.roles.#{ROLE::CERTIFICATE_MANAGER}"), class: 'govuk-label govuk-checkboxes__label' %>
-      </div>
-      <div class="govuk-checkboxes__item">
-        <%= f.check_box(:roles, { :class => 'govuk-checkboxes__input', :multiple => true }, ROLE::USER_MANAGER, nil) %>
-        <%= f.label :roles, t("users.roles.#{ROLE::USER_MANAGER}"), class: 'govuk-label govuk-checkboxes__label' %>
-      </div>
-      <!-- TODO: hide or move away for non-gds users -->
-      <div class="govuk-checkboxes__item">
-        <%= f.check_box(:roles, { :class => 'govuk-checkboxes__input', :multiple => true }, ROLE::GDS, nil) %>
-        <%= f.label :roles, 'GDS', class: 'govuk-label govuk-checkboxes__label' %>
-      </div>
+  <% if @gds_team %>
+    <div class="govuk-form-group">
+      <fieldset class="govuk-fieldset">
+        <div class="govuk-checkboxes">
+          <div class="govuk-checkboxes__item">
+            <%= f.check_box(:roles, { :class => 'govuk-checkboxes__input', :multiple => true, :checked => true, :disabled => true }, ROLE::GDS, nil) %>
+            <%= f.label :roles, 'GDS', class: 'govuk-label govuk-checkboxes__label' %>
+          </div>
+        </div>
+      </fieldset>
     </div>
-  </fieldset>
-</div>
+    <div class="govuk-warning-text">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text">
+        <span class="govuk-warning-text__assistive"><%= t 'layout.application.warning' %></span>
+          <%= t 'users.invite.gds_warning' %>
+      </strong>
+    </div>
+  <% else %>
+    <div class="govuk-form-group">
+      <fieldset class="govuk-fieldset">
+        <div class="govuk-checkboxes">
+          <div class="govuk-checkboxes__item">
+            <%= f.check_box(:roles, { :class => 'govuk-checkboxes__input', :multiple => true }, ROLE::CERTIFICATE_MANAGER, nil) %>
+            <%= f.label :roles, t("users.roles.#{ROLE::CERTIFICATE_MANAGER}"), class: 'govuk-label govuk-checkboxes__label' %>
+          </div>
+          <div class="govuk-checkboxes__item">
+            <%= f.check_box(:roles, { :class => 'govuk-checkboxes__input', :multiple => true }, ROLE::USER_MANAGER, nil) %>
+            <%= f.label :roles, t("users.roles.#{ROLE::USER_MANAGER}"), class: 'govuk-label govuk-checkboxes__label' %>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+  <% end %>
+  
 
-  <!-- TODO: Add team once ready -->
 
   <div class="actions">
     <%= f.submit t('users.invite.button'), class: "govuk-button", data: { module: "govuk-button" } %>

--- a/app/views/users/invite.erb
+++ b/app/views/users/invite.erb
@@ -22,7 +22,7 @@
       <fieldset class="govuk-fieldset">
         <div class="govuk-checkboxes">
           <div class="govuk-checkboxes__item">
-            <%= f.check_box(:roles, { :class => 'govuk-checkboxes__input', :multiple => true, :checked => true, :disabled => true }, ROLE::GDS, nil) %>
+            <%= f.check_box(:roles, { class: 'govuk-checkboxes__input', multiple: true, checked: true, disabled: true }, ROLE::GDS, nil) %>
             <%= f.label :roles, 'GDS', class: 'govuk-label govuk-checkboxes__label' %>
           </div>
         </div>
@@ -32,7 +32,7 @@
       <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
       <strong class="govuk-warning-text__text">
         <span class="govuk-warning-text__assistive"><%= t 'layout.application.warning' %></span>
-          <%= t 'users.invite.gds_warning' %>
+        <%= t 'users.invite.gds_warning' %>
       </strong>
     </div>
   <% else %>
@@ -40,11 +40,11 @@
       <fieldset class="govuk-fieldset">
         <div class="govuk-checkboxes">
           <div class="govuk-checkboxes__item">
-            <%= f.check_box(:roles, { :class => 'govuk-checkboxes__input', :multiple => true }, ROLE::CERTIFICATE_MANAGER, nil) %>
+            <%= f.check_box(:roles, { class: 'govuk-checkboxes__input', multiple: true }, ROLE::CERTIFICATE_MANAGER, nil) %>
             <%= f.label :roles, t("users.roles.#{ROLE::CERTIFICATE_MANAGER}"), class: 'govuk-label govuk-checkboxes__label' %>
           </div>
           <div class="govuk-checkboxes__item">
-            <%= f.check_box(:roles, { :class => 'govuk-checkboxes__input', :multiple => true }, ROLE::USER_MANAGER, nil) %>
+            <%= f.check_box(:roles, { class: 'govuk-checkboxes__input', multiple: true }, ROLE::USER_MANAGER, nil) %>
             <%= f.label :roles, t("users.roles.#{ROLE::USER_MANAGER}"), class: 'govuk-label govuk-checkboxes__label' %>
           </div>
         </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,10 +54,12 @@ en:
       title: Invite a new user
       button: Invite user
       button_to: Invite user to
+      gds_warning: You're inviting a GDS user with full permissions to the system
       success: An invitation has been sent to the new user's email address
       errors:
         already_exists: This email address is already being used, enter a unique one
         invalid_email: Enter an email address in the correct format
+        invalid_gds_email: GDS team requires a GDS email address
         invalid_role: "%{role} is not a valid role"
         generic_error: Something went wrong when creating the user, try again
         team_missing: This team does not exist

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,7 +54,7 @@ en:
       title: Invite a new user
       button: Invite user
       button_to: Invite user to
-      gds_warning: You're inviting a GDS user with full permissions to the system
+      gds_warning: You're inviting a GDS user with full permissions to the service
       success: An invitation has been sent to the new user's email address
       errors:
         already_exists: This email address is already being used, enter a unique one

--- a/spec/models/invite_user_form_spec.rb
+++ b/spec/models/invite_user_form_spec.rb
@@ -14,7 +14,15 @@ RSpec.describe InviteUserForm, type: :model do
     expect(InviteUserForm.new({email: 'test@test.test', given_name: 'First Name', family_name: 'Surname', roles: [ROLE::CERTIFICATE_MANAGER, 'blah'] })).to_not be_valid
   end
 
-  it 'is not valid with a valid email' do
+  it 'is not valid with an invalid email' do
     expect(InviteUserForm.new({email: 'notanemailaddress', given_name: 'First Name', family_name: 'Surname' })).to_not be_valid
+  end
+
+  it 'is not valid when GDS role is being assigned to a non-GDS email' do
+    expect(InviteUserForm.new({email: 'test@test.test', given_name: 'First Name', family_name: 'Surname', roles: [ROLE::GDS] })).to_not be_valid
+  end
+
+  it 'is valid when GDS role is being assigned to a GDS email' do
+    expect(InviteUserForm.new({email: 'test@digital.cabinet-office.gov.uk', given_name: 'First Name', family_name: 'Surname', roles: [ROLE::GDS] })).to be_valid
   end
 end


### PR DESCRIPTION
- Removed the option to select a GDS role on a non-GDS team
- Added a textual warning when inviting a GDS user (with all permissions)
- Added validation to allow GDS roles to be assigned only to people with a GDS email address
- Removed some redundant code

**Before regardless of a team the user is being invited to:**
<img width="664" alt="image" src="https://user-images.githubusercontent.com/30629434/64979233-35807c00-d8af-11e9-8c91-65bd1ea9fd75.png">


**After when inviting to a non-GDS team:**
<img width="659" alt="image" src="https://user-images.githubusercontent.com/30629434/64979290-53e67780-d8af-11e9-8865-5681be243cb2.png">

**After when inviting to a GDS team:**
<img width="673" alt="image" src="https://user-images.githubusercontent.com/30629434/64979296-5779fe80-d8af-11e9-94d0-24d1500da9b5.png">
