### PR TITLE
Validate the certificates in the user journey flow

### DIFF
--- a/app/controllers/user_journey_controller.rb
+++ b/app/controllers/user_journey_controller.rb
@@ -3,6 +3,7 @@ class UserJourneyController < ApplicationController
   include ControllerConcern
   include ComponentConcern
   include CertificateConcern
+  include X509Validator
 
   before_action :find_certificate, except: :index
 
@@ -37,8 +38,9 @@ class UserJourneyController < ApplicationController
         component: @component
       )
 
-      if @new_certificate.valid?
-        render 'user_journey/check_your_certificate' and return # rubocop:disable Style/AndOr
+      if @new_certificate.valid? && valid_x509?(@new_certificate)
+        render 'user_journey/check_your_certificate'
+        return
       end
     end
 

--- a/app/controllers/user_journey_controller.rb
+++ b/app/controllers/user_journey_controller.rb
@@ -27,7 +27,7 @@ class UserJourneyController < ApplicationController
   end
 
   def submit
-    extractor = CertificateExtractor.new(params[:certificate])
+    extractor = CertificateExtractor.new(params)
 
     if extractor.valid?
       @new_certificate_value = extractor.call

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -1,6 +1,6 @@
 class Certificate < Aggregate
   include CertificateConcern
-  validates_inclusion_of :usage, in: %w[signing encryption]
+  validates_inclusion_of :usage, in: [CERTIFICATE_USAGE::SIGNING, CERTIFICATE_USAGE::ENCRYPTION]
   validates_presence_of :usage, :value, :component
   belongs_to :component, polymorphic: true
 

--- a/app/models/certificate_extractor.rb
+++ b/app/models/certificate_extractor.rb
@@ -2,37 +2,42 @@ class CertificateExtractor
   include ActiveModel::Model
   include CertificateConcern
 
-  validate :file_content_type, :contents, if: :cert_file
+  validate :file_content_type, :contents, if: :file_upload?
 
   MIME_X509_CA = 'application/x-x509-ca-cert'.freeze
   MIME_PEM = 'application/x-pem-file'.freeze
   VALID_CONTENT_TYPES = [MIME_X509_CA, MIME_PEM].freeze
 
-  def initialize(certificate)
-    @value = certificate[:value]
-    @cert_file = certificate[:cert_file]
+  def initialize(params)
+    @params = params
   end
 
   def call
-    return value unless cert_file
-    contents.to_s
+    return params[:certificate][:value] unless file_upload?
+
+    contents&.to_s
   end
 
 private
 
-  attr_reader :cert_file, :value
+  attr_reader :params
+
+  def file_upload?
+    @file_upload ||= params['upload-certificate'] == 'file'
+  end
 
   def file_content_type
-    unless VALID_CONTENT_TYPES.include?(cert_file.content_type)
+    unless VALID_CONTENT_TYPES.include?(params[:certificate].dig(:cert_file)&.content_type)
       errors.add(:certificate, I18n.t('certificates.errors.invalid_file_type'))
     end
   end
 
   def contents
     @contents ||= begin
-      to_x509(File.read(cert_file.tempfile))
-    rescue OpenSSL::X509::CertificateError
-      errors.add(:certificate, I18n.t('certificates.errors.invalid'))
+      tempfile = params[:certificate].dig(:cert_file)&.tempfile
+      to_x509(File.read(tempfile)) if tempfile
     end
+  rescue OpenSSL::X509::CertificateError
+    errors.add(:certificate, I18n.t('certificates.errors.invalid'))
   end
 end

--- a/app/models/certificate_validator.rb
+++ b/app/models/certificate_validator.rb
@@ -2,10 +2,6 @@ class CertificateValidator < ActiveModel::EachValidator
   include X509Validator
 
   def validate_each(record, _attribute, value)
-    x509 = x509_certificate(record, value)
-    return false if x509.nil?
-
-    certificate_has_appropriate_not_after(record, x509)
-    certificate_key_is_supported(record, x509)
+    valid_x509?(record, value)
   end
 end

--- a/app/models/certificate_validator.rb
+++ b/app/models/certificate_validator.rb
@@ -1,53 +1,11 @@
 class CertificateValidator < ActiveModel::EachValidator
+  include X509Validator
+
   def validate_each(record, _attribute, value)
     x509 = x509_certificate(record, value)
     return false if x509.nil?
 
     certificate_has_appropriate_not_after(record, x509)
     certificate_key_is_supported(record, x509)
-  end
-
-  def load_value_as_x509_cert(value)
-    OpenSSL::X509::Certificate.new(value)
-  rescue OpenSSL::X509::CertificateError, TypeError
-    nil
-  end
-
-  def load_decoded_value_as_x509_cert(value)
-    load_value_as_x509_cert(Base64.decode64(value)) unless value.nil?
-  end
-
-  def load_as_x509_certificate(value)
-    load_value_as_x509_cert(value) || load_decoded_value_as_x509_cert(value)
-  end
-
-  def x509_certificate(record, value)
-    load_as_x509_certificate(value).tap do |x509|
-      record.errors.add(:certificate, I18n.t('certificates.errors.invalid')) if x509.nil?
-    end
-  end
-
-  def certificate_has_appropriate_not_after(record, x509)
-    if x509.not_after < Time.now
-      record.errors.add(:certificate, I18n.t('certificates.errors.expired'))
-    elsif x509.not_after < Time.now + 30.days
-      record.errors.add(:certificate, I18n.t('certificates.errors.expires_soon'))
-    elsif x509.not_after > Time.now + 1.year
-      record.errors.add(:certificate, I18n.t('certificates.errors.valid_too_long'))
-    end
-  end
-
-  def certificate_key_is_supported(record, x509)
-    if x509.public_key.is_a?(OpenSSL::PKey::RSA)
-      certificate_is_strong(record, x509)
-    else
-      record.errors.add(:certificate, I18n.t('certificates.errors.not_rsa'))
-    end
-  end
-
-  def certificate_is_strong(record, x509)
-    return if x509.public_key.params['n'].num_bits >= 2048
-
-    record.errors.add(:certificate, I18n.t('certificates.errors.small_key'))
   end
 end

--- a/app/models/concerns/certificate_concern.rb
+++ b/app/models/concerns/certificate_concern.rb
@@ -1,9 +1,20 @@
 module CertificateConcern
   extend ActiveSupport::Concern
 
+  BEGIN_CERT = '-----BEGIN CERTIFICATE-----'.freeze
+  END_CERT = '-----END CERTIFICATE-----'.freeze
+
   def to_x509(value)
     OpenSSL::X509::Certificate.new(value)
   rescue # rubocop:disable Style/RescueStandardError
     OpenSSL::X509::Certificate.new(Base64.decode64(value))
+  rescue # rubocop:disable Style/RescueStandardError
+    OpenSSL::X509::Certificate.new(strip_cert(value))
+  end
+
+  def strip_cert(value)
+    if value.include?(BEGIN_CERT) && value.include?(END_CERT)
+      value.split(BEGIN_CERT).last.split(END_CERT).first
+    end
   end
 end

--- a/app/models/x509_validator.rb
+++ b/app/models/x509_validator.rb
@@ -1,4 +1,12 @@
 module X509Validator
+  def valid_x509?(record, value = nil)
+    x509_cert = x509_certificate(record, value || record.value)
+    return false if x509_cert.nil?
+
+    certificate_has_appropriate_not_after(record, x509_cert).nil? &&
+      certificate_key_is_supported(record, x509_cert).nil?
+  end
+
   def x509_certificate(record, value)
     load_as_x509_certificate(value).tap do |x509|
       record.errors.add(:certificate, I18n.t('certificates.errors.invalid')) if x509.nil?

--- a/app/models/x509_validator.rb
+++ b/app/models/x509_validator.rb
@@ -1,0 +1,45 @@
+module X509Validator
+  def x509_certificate(record, value)
+    load_as_x509_certificate(value).tap do |x509|
+      record.errors.add(:certificate, I18n.t('certificates.errors.invalid')) if x509.nil?
+    end
+  end
+
+  def load_value_as_x509_cert(value)
+    OpenSSL::X509::Certificate.new(value)
+  rescue OpenSSL::X509::CertificateError, TypeError
+    nil
+  end
+
+  def certificate_has_appropriate_not_after(record, x509)
+    if x509.not_after < Time.now
+      record.errors.add(:certificate, I18n.t('certificates.errors.expired'))
+    elsif x509.not_after < Time.now + 30.days
+      record.errors.add(:certificate, I18n.t('certificates.errors.expires_soon'))
+    elsif x509.not_after > Time.now + 1.year
+      record.errors.add(:certificate, I18n.t('certificates.errors.valid_too_long'))
+    end
+  end
+
+  def load_decoded_value_as_x509_cert(value)
+    load_value_as_x509_cert(Base64.decode64(value)) unless value.nil?
+  end
+
+  def load_as_x509_certificate(value)
+    load_value_as_x509_cert(value) || load_decoded_value_as_x509_cert(value)
+  end
+
+  def certificate_key_is_supported(record, x509)
+    if x509.public_key.is_a?(OpenSSL::PKey::RSA)
+      certificate_is_strong(record, x509)
+    else
+      record.errors.add(:certificate, I18n.t('certificates.errors.not_rsa'))
+    end
+  end
+
+  def certificate_is_strong(record, x509)
+    return if x509.public_key.params['n'].num_bits >= 2048
+
+    record.errors.add(:certificate, I18n.t('certificates.errors.small_key'))
+  end
+end

--- a/app/views/user_journey/upload_certificate.html.erb
+++ b/app/views/user_journey/upload_certificate.html.erb
@@ -11,21 +11,18 @@
       </legend>
       <div class="govuk-radios govuk-radios--conditional govuk-!-margin-bottom-5" data-module="govuk-radios">
         <div class="govuk-radios__item">
-          <input class="govuk-radios__input" id="upload-certificate-conditional" name="upload-certificate" type="radio" value="certficate" data-aria-controls="conditional-upload-certificate-conditional">
+          <input class="govuk-radios__input" id="upload-certificate-conditional" name="upload-certificate" type="radio" value="file" data-aria-controls="conditional-upload-certificate-conditional">
           <label class="govuk-label govuk-radios__label" for="upload-certificate-conditional">
             <%= t 'user_journey.certificate.upload_certificate_file_header' %>
           </label>
         </div>
         <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-upload-certificate-conditional">
           <div class="govuk-form-group">
-            <label class="govuk-label" for="file-upload">
-              <%= t 'user_journey.certificate.upload_certificate_file_body' %>
-            </label>
-            <%= f.file_field :cert_file, class: "govuk-file-upload", id: "file-upload" %>
+            <%= f.file_field :cert_file, class: "govuk-file-upload" %>
           </div>
         </div>
         <div class="govuk-radios__item">
-          <input class="govuk-radios__input" id="upload-certificate-conditional-2" name="upload-certificate" type="radio" value="certificate" data-aria-controls="conditional-upload-certificate-conditional-2">
+          <input class="govuk-radios__input" id="upload-certificate-conditional-2" name="upload-certificate" type="radio" value="string" data-aria-controls="conditional-upload-certificate-conditional-2">
           <label class="govuk-label govuk-radios__label" for="upload-certificate-conditional-2">
             <%= t 'user_journey.certificate.paste_certificate' %>
           </label>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -90,7 +90,7 @@ en:
       not_rsa: is not RSA
       small_key: key size is less than 2048 bits
       not_signing: signing certificate is needed
-      invalid_file_type: invalid file type
+      invalid_file_type: is an invalid file type
   profile:
     title: "User Information"
     welcome: Welcome
@@ -248,7 +248,7 @@ en:
       VSP:
         encryption: https://prototype-docs.cloudapps.digital/rotating-your-keys-and-certificates/vsp-encryption/#rotate-your-vsp-encryption-key-and-certificate
         signing: https://prototype-docs.cloudapps.digital/rotating-your-keys-and-certificates/vsp-signing/#rotate-your-vsp-signing-key-and-certificate
-      SP: 
+      SP:
         encryption: https://prototype-docs.cloudapps.digital/rotating-your-keys-and-certificates/service-provider-encryption/#rotate-your-service-provider-encryption-key-and-certificate
         signing: https://prototype-docs.cloudapps.digital/rotating-your-keys-and-certificates/service-provider-signing/#rotate-your-service-provider-signing-key-and-certificate
       connection_broken_or_compromised: https://prototype-docs.cloudapps.digital/emergency-procedures/#emergency-procedures
@@ -266,7 +266,7 @@ en:
       continue: Continue
       have_updated: I have updated my %{component} configuration
     certificate:
-      component_name: 
+      component_name:
         MSA: "Matching Service Adapter: "
         VSP: "Verify Service Provider: "
         SP: "Service Provider: "

--- a/spec/controllers/user_journey_controller_spec.rb
+++ b/spec/controllers/user_journey_controller_spec.rb
@@ -210,6 +210,26 @@ RSpec.describe UserJourneyController, type: :controller do
       expect(response).to redirect_to :upload_certificate
       expect(flash[:error]).to include(I18n.t('certificates.errors.invalid_file_type'))
     end
+
+    it 'should redirect to upload certificate page with valid file extension but invalid content' do
+      certmgr_stub_auth
+      post :submit,
+           params: {
+             component_type: msa_component.component_type,
+             component_id: msa_component.id,
+             certificate_id: msa_encryption_cert.id,
+             certificate: {
+               cert_file: upload_file(
+                 name: 'invalid.crt',
+                 type: CertificateExtractor::MIME_PEM,
+                 content: 'Whats it going to be then, eh?'
+               )
+             }
+           }
+
+      expect(response).to redirect_to :upload_certificate
+      expect(flash[:error]).to include(I18n.t('certificates.errors.invalid'))
+    end
   end
 
   context 'confirm with invalid certificate' do

--- a/spec/controllers/user_journey_controller_spec.rb
+++ b/spec/controllers/user_journey_controller_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe UserJourneyController, type: :controller do
   include AuthSupport
   include CertificateSupport
+
   let(:msa_component) { create(:msa_component) }
   let(:msa_encryption_cert) { create(:msa_encryption_certificate) }
 

--- a/spec/models/certificate_extractor_spec.rb
+++ b/spec/models/certificate_extractor_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe CertificateExtractor, type: :model do
+  include TempFileHelpers
+
   let(:cert) { PKI.new.generate_signed_cert }
 
   context 'file type validation' do
@@ -87,21 +89,5 @@ RSpec.describe CertificateExtractor, type: :model do
 
   def create_extractor(value: '', cert_file: nil)
     CertificateExtractor.new(value: value, cert_file: cert_file)
-  end
-
-  def upload_file(name:, type:, content:)
-    ActionDispatch::Http::UploadedFile.new(
-      filename: name,
-      head: 'Content-Disposition: form-data; name=certificate[cert_file]',
-      type: type,
-      tempfile: create_tempfile(name: name, content: content)
-    )
-  end
-
-  def create_tempfile(name:, content:)
-    Tempfile.new(name).tap do |f|
-      f.write(content)
-      f.close
-    end
   end
 end

--- a/spec/models/certificate_extractor_spec.rb
+++ b/spec/models/certificate_extractor_spec.rb
@@ -7,12 +7,17 @@ RSpec.describe CertificateExtractor, type: :model do
 
   context 'file type validation' do
     it 'fails validation for invalid file types' do
-      extractor = create_extractor(
-        cert_file: upload_file(
-          name: 'invalid.txt',
-          type: 'text/rtf',
-          content: 'In a hole in the ground there lived a hobbit'
-        )
+      extractor =  CertificateExtractor.new(
+        {
+          'upload-certificate' => 'file',
+          certificate: {
+            cert_file: upload_file(
+              name: 'invalid.txt',
+              type: 'text/rtf',
+              content: 'In a hole in the ground there lived a hobbit'
+            )
+          }
+        }
       )
 
       expect(extractor).to_not be_valid
@@ -25,12 +30,17 @@ RSpec.describe CertificateExtractor, type: :model do
                     "RK+Lh9x5eJPo5CAZ3/ANBE0sTK0ZsDGMak2m1g73VHqIxFTz0Ta1d+NAj" \
                     "wnLe4nOb7/eEJbDPkk05ShhBrJGBKKxb8n104o/PdzbFMIyNjJzBM2o5y" \
                     "-----END RSA PRIVATE KEY-----"
-      extractor = create_extractor(
-        cert_file: upload_file(
-          name: 'invalid.key',
-          type: 'application/pkcs8',
-          content: private_key
-        )
+      extractor =  CertificateExtractor.new(
+        {
+          'upload-certificate' =>'file',
+          certificate: {
+            cert_file: upload_file(
+              name: 'invalid.key',
+              type: 'application/pkcs8',
+              content: private_key
+            )
+          }
+        }
       )
 
       expect(extractor).to_not be_valid
@@ -40,31 +50,49 @@ RSpec.describe CertificateExtractor, type: :model do
 
   context 'no cert file provided' do
     it 'passes back the string value' do
-      expect(create_extractor(value: 'John Wick').call).to eq('John Wick')
+      extractor =  CertificateExtractor.new({
+        'upload-certificate' => 'string',
+        certificate: { value: 'John Wick' }
+      })
+
+      expect(extractor.call).to eq('John Wick')
     end
   end
 
   context 'valid certificate file provided' do
-    it 'validates .crt files' do
-      extractor = create_extractor(
-        cert_file: upload_file(
-          name: 'valid.crt',
-          type: CertificateExtractor::MIME_X509_CA,
-          content: cert.to_text + cert.public_key.to_s
-        )
+    it 'validates and extracts .crt files' do
+      extractor =  CertificateExtractor.new(
+        {
+          'upload-certificate' => 'file',
+          certificate: {
+            cert_file: upload_file(
+              name: 'valid.crt',
+              type: CertificateExtractor::MIME_X509_CA,
+              content: cert.to_text + cert.to_pem
+            )
+          }
+        }
       )
+      extracted_cert = extractor.call
 
       expect(extractor).to be_valid
       expect(extractor.errors.full_messages).to be_empty
+      expect(extracted_cert).to_not include(cert.to_text)
+      expect(extracted_cert).to include(cert.to_pem)
     end
 
     it 'validates and extracts .pem files' do
-      extractor = create_extractor(
-        cert_file: upload_file(
-          name: 'valid.pem',
-          type: CertificateExtractor::MIME_PEM,
-          content: cert.to_pem
-        )
+      extractor =  CertificateExtractor.new(
+        {
+          'upload-certificate' => 'file',
+          certificate: {
+            cert_file: upload_file(
+              name: 'valid.pem',
+              type: CertificateExtractor::MIME_PEM,
+              content: cert.to_pem
+            )
+          }
+        }
       )
 
       expect(extractor).to be_valid
@@ -73,21 +101,22 @@ RSpec.describe CertificateExtractor, type: :model do
     end
 
     it 'validates and extracts .der files' do
-      extractor = create_extractor(
-        cert_file: upload_file(
-          name: 'valid.der',
-          type: CertificateExtractor::MIME_X509_CA,
-          content: Base64.strict_encode64(cert.to_der)
-        )
+      extractor =  CertificateExtractor.new(
+        {
+          'upload-certificate' => 'file',
+          certificate: {
+            cert_file: upload_file(
+              name: 'valid.der',
+              type: CertificateExtractor::MIME_X509_CA,
+              content: Base64.strict_encode64(cert.to_der)
+            )
+          }
+        }
       )
 
       expect(extractor).to be_valid
       expect(extractor.errors.full_messages).to be_empty
       expect(extractor.call).to include(cert.to_pem)
     end
-  end
-
-  def create_extractor(value: '', cert_file: nil)
-    CertificateExtractor.new(value: value, cert_file: cert_file)
   end
 end

--- a/spec/support/helpers/temp_file_helpers.rb
+++ b/spec/support/helpers/temp_file_helpers.rb
@@ -1,0 +1,15 @@
+module TempFileHelpers
+  def upload_file(name:, type:, content:)
+    Rack::Test::UploadedFile.new(
+      create_tempfile(name: name, content: content).path,
+      type
+    )
+  end
+
+  def create_tempfile(name:, content:)
+    Tempfile.new.tap do |f|
+      f.write(content)
+      f.close
+    end
+  end
+end


### PR DESCRIPTION
## Move certificate validation into a module

We need to be able to use this in a couple of different places and not always directly linked to an event model.

## Use Rack::Test::UploadedFile for temporary files

While the ActionDispatch is used when actually interacting with the controllers it seems the Rack::Test::UploadedFile is the one which is generally used during testing.

Also move the upload_file creation out to a helper module as we will be using it for controller tests as well.

## Validate certificates in user journey flow

We need to be able to validate certificates separate from the event models. As the user moves between pages in the user journey we need to be able to validate the certificate twice; once when they upload/paste a certificate, and then again after they have viewed it and submitted it.

We do not want to trigger validation on the Certificate model itself as this would mean that validation would occur up to four times while they progress through the journey, as opposed to just to the two we require.

## Correctly cater for multiple user inputs in certificate upload

We only want to choose the option that the user has defined when they click on the forms radio button.

Also we now correctly strip out the actual certificate from a fully generated .crt file as well as fail validation when it's the correct file type but an invalid certificate content.

## Examples

<img width="856" alt="Screen Shot 2019-09-18 at 17 13 29" src="https://user-images.githubusercontent.com/3466862/65165901-98048400-da37-11e9-9f21-af35c99000b5.png">


<img width="844" alt="Screen Shot 2019-09-18 at 17 09 27" src="https://user-images.githubusercontent.com/3466862/65165658-20cef000-da37-11e9-9dac-8b8d0cf6a58c.png">

https://trello.com/c/sKzuMNrn/671-validate-uploaded-certs-the-same-as-pasted-certs