### PR TITLE
Added validation to the signin form using a model

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,6 +9,20 @@ class SessionsController < Devise::SessionsController
   before_action :load_secret_code, only: %i(create new)
   before_action :challenge_flash_messages, only: %i(create new)
 
+  def create
+    if session[:challenge_parameters].nil?
+      sign_in_form = SignInForm.new(params['user'])
+      if sign_in_form.valid?
+        super
+      else
+        flash[:errors] = sign_in_form.errors.full_messages.join(', ')
+        redirect_to new_session_path(resource_name)
+      end
+    else
+      super
+    end
+  end
+
   def destroy
     UserSignOutEvent.create(user_id: warden.user.user_id)
     signed_out = (Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name))

--- a/app/models/sign_in_form.rb
+++ b/app/models/sign_in_form.rb
@@ -1,0 +1,13 @@
+class SignInForm
+  include ActiveModel::Model
+
+  attr_reader :email, :password
+  validates_presence_of :email, :password
+  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
+  validates :password, length: { minimum: 8 }
+
+  def initialize(params)
+    @email = params[:email]
+    @password = params[:password]
+  end
+end

--- a/spec/models/sign_in_form.rb
+++ b/spec/models/sign_in_form.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe SignInForm, type: :model do
+  context 'sign in form' do
+    it 'must have email' do
+      form = SignInForm.new({email: nil, password: 'password1'})
+      expect(form.valid?).to eq(false)
+      expect(form.errors.full_messages[0]).to eq('Email can\'t be blank')
+    end
+
+    it 'must be email formated' do
+      form = SignInForm.new({email: 'testuser', password: 'password1'})
+      expect(form.valid?).to eq(false)
+      expect(form.errors.full_messages[0]).to eq('Email is invalid')
+    end
+
+    it 'must have password' do
+      form = SignInForm.new({email: 'test@test.com', password: nil})
+      expect(form.valid?).to eq(false)
+      expect(form.errors.full_messages[0]).to eq('Password can\'t be blank')
+    end
+
+    it 'password must be more than 8 characters long' do
+      form = SignInForm.new({email: 'test@test.com', password: '1234567'})
+      expect(form.valid?).to eq(false)
+      expect(form.errors.full_messages[0]).to eq('Password is too short (minimum is 8 characters)')
+    end
+
+    it 'form must pass validation' do
+      form = SignInForm.new({email: 'test@test.com', password: 'password1'})
+      expect(form.valid?).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
Currently it's possible to submit the login form empty and it hits Cognito. We should do the validation earlier and don't rely on Cognito and be hitting Cognito unnecessarily.