### PR TITLE
Fix the issue when inviting GDS users

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -61,6 +61,7 @@ class UsersController < ApplicationController
       invite_user
     else
       flash.now[:errors] = @form.errors.full_messages.join(', ')
+      @gds_team = Team.find_by_id(params[:team_id])&.name == TEAMS::GDS
       render :invite, status: :bad_request
     end
   end
@@ -119,6 +120,7 @@ private
 
     if e
       Rails.logger.error e
+      @gds_team = team.name == TEAMS::GDS
       render :invite, status: :bad_request
     else
       UserInvitedEvent.create(data:

--- a/app/views/users/invite.erb
+++ b/app/views/users/invite.erb
@@ -22,7 +22,7 @@
       <fieldset class="govuk-fieldset">
         <div class="govuk-checkboxes">
           <div class="govuk-checkboxes__item">
-            <%= f.check_box(:roles, { class: 'govuk-checkboxes__input', multiple: true, checked: true, disabled: true }, ROLE::GDS, nil) %>
+            <%= f.check_box(:roles, { class: 'govuk-checkboxes__input', multiple: true, checked: true }, ROLE::GDS, nil) %>
             <%= f.label :roles, 'GDS', class: 'govuk-label govuk-checkboxes__label' %>
           </div>
         </div>


### PR DESCRIPTION
For GDS invites, the roles selector is disabled and thus not sending the value
as part of the request which then fails validation. This change makes sure the value is getting passed and also when a validation fails it shows the right options.