### PR TITLE
Update how GDS users are displayed

### DIFF
--- a/app/models/team_member.rb
+++ b/app/models/team_member.rb
@@ -20,4 +20,8 @@ class TeamMember
   def user_manager?
     @roles.include? ROLE::USER_MANAGER
   end
+
+  def gds?
+    @roles.include? ROLE::GDS
+  end
 end

--- a/app/views/profile/show.html.erb
+++ b/app/views/profile/show.html.erb
@@ -155,7 +155,7 @@
                   <% role_string = "ROLE::#{role}".constantize %>
                   <% is_checked = @user.roles.split(',').include?(role_string) %>
                     <div class="govuk-checkboxes__item">
-                      <%= f.check_box 'role_selection', { :checked => is_checked,:multiple => true, :class => "govuk-checkboxes__input" }, role_string, nil  %>
+                      <%= f.check_box 'role_selection', { checked: is_checked, multiple: true, class: 'govuk-checkboxes__input' }, role_string, nil  %>
                       
                       <label class="govuk-label govuk-checkboxes__label" for="assume_roles_role_selection_<%= role_string %>">
                         <% if role.to_s == 'GDS' %><%= role %><% else %><%= role.to_s.titlecase %><% end %>

--- a/app/views/users/index.erb
+++ b/app/views/users/index.erb
@@ -9,7 +9,7 @@
   <% if @gds %>
     <%= link_to t('common.back'), users_path, class: 'govuk-back-link' %>
   <% end %>
-  <h1 class="govuk-heading-l"><%= t 'users.title_for_team' %> <%= @team.name %></h1>
+  <h1 class="govuk-heading-l"><%= t 'users.title_for_team' %> <%= @team.name == TEAMS::GDS ? TEAMS::GDS.upcase : @team.name %></h1>
 
   <div class="user-list">
     <% @team_members.each do |member| %>
@@ -19,21 +19,22 @@
     <span class="hint govuk-body govuk-!-padding-left-1"><%= @user.email == member.email ? t('users.you') : member.email %></span>
     </h3>
       <ul class="govuk-list tick-cross-list">
-        <div class="tick-cross-list-permissions">
-
-          <li>
-            <span class="tick-cross-<%= member.cert_manager? ? 'tick' : 'cross' %>">
-                  <span class="govuk-visually-hidden"><%= member.cert_manager? ? t('users.permissions.can') : t('users.permissions.cannot') %></span>
-              <%= t 'users.roles.certmgr' %>
-            </span>
-          </li>
-          <li>
-            <span class="tick-cross-<%= member.user_manager? ? 'tick' : 'cross' %>">
-                  <span class="govuk-visually-hidden"><%= member.user_manager? ? t('users.permissions.can') : t('users.permissions.cannot') %></span>
-             <%= t 'users.roles.usermgr' %>
-            </span>
-          </li>
-        </div>
+        <% unless member.gds? %>
+          <div class="tick-cross-list-permissions">
+            <li>
+              <span class="tick-cross-<%= member.cert_manager? ? 'tick' : 'cross' %>">
+                <span class="govuk-visually-hidden"><%= member.cert_manager? ? t('users.permissions.can') : t('users.permissions.cannot') %></span>
+                <%= t 'users.roles.certmgr' %>
+              </span>
+            </li>
+            <li>
+              <span class="tick-cross-<%= member.user_manager? ? 'tick' : 'cross' %>">
+                <span class="govuk-visually-hidden"><%= member.user_manager? ? t('users.permissions.can') : t('users.permissions.cannot') %></span>
+                <%= t 'users.roles.usermgr' %>
+              </span>
+            </li>
+          </div>
+        <% end %>
         <% if @user.email != member.email %>
         <li class="tick-cross-list-edit-link">
           <%= link_to t('users.change_link'), update_user_path(member.user_id) %>

--- a/app/views/users/show.erb
+++ b/app/views/users/show.erb
@@ -29,11 +29,11 @@
         </span>
         <div class="govuk-checkboxes">
           <div class="govuk-checkboxes__item">
-            <%= f.check_box(:roles, { :class => 'govuk-checkboxes__input', :multiple => true }, ROLE::CERTIFICATE_MANAGER, nil) %>
+            <%= f.check_box(:roles, { class: 'govuk-checkboxes__input', multiple: true }, ROLE::CERTIFICATE_MANAGER, nil) %>
             <%= f.label :roles, t("users.roles.#{ROLE::CERTIFICATE_MANAGER}"), class: 'govuk-label govuk-checkboxes__label' %>
           </div>
           <div class="govuk-checkboxes__item">
-            <%= f.check_box(:roles, { :class => 'govuk-checkboxes__input', :multiple => true }, ROLE::USER_MANAGER, nil) %>
+            <%= f.check_box(:roles, { class: 'govuk-checkboxes__input', multiple: true }, ROLE::USER_MANAGER, nil) %>
             <%= f.label :roles, t("users.roles.#{ROLE::USER_MANAGER}"), class: 'govuk-label govuk-checkboxes__label' %>
           </div>
         </div>

--- a/app/views/users/show.erb
+++ b/app/views/users/show.erb
@@ -18,29 +18,30 @@
     </li>
   </ul>
 
-
-  <div class="govuk-form-group">
-  <fieldset class="govuk-fieldset">
-    <legend class="govuk-fieldset__legend">
-      <%= t('users.permissions.legend') %>
-    </legend>
-    <span id="new-team-member-hint" class="govuk-hint">
-    <%= t('users.show.select_one') %>
-    </span>
-    <div class="govuk-checkboxes">
-      <div class="govuk-checkboxes__item">
-        <%= f.check_box(:roles, { :class => 'govuk-checkboxes__input', :multiple => true }, ROLE::CERTIFICATE_MANAGER, nil) %>
-        <%= f.label :roles, t("users.roles.#{ROLE::CERTIFICATE_MANAGER}"), class: 'govuk-label govuk-checkboxes__label' %>
-      </div>
-      <div class="govuk-checkboxes__item">
-        <%= f.check_box(:roles, { :class => 'govuk-checkboxes__input', :multiple => true }, ROLE::USER_MANAGER, nil) %>
-        <%= f.label :roles, t("users.roles.#{ROLE::USER_MANAGER}"), class: 'govuk-label govuk-checkboxes__label' %>
-      </div>
+  <% unless @team_member.gds? %>
+    <div class="govuk-form-group">
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend">
+          <%= t('users.permissions.legend') %>
+        </legend>
+        <span id="new-team-member-hint" class="govuk-hint">
+        <%= t('users.show.select_one') %>
+        </span>
+        <div class="govuk-checkboxes">
+          <div class="govuk-checkboxes__item">
+            <%= f.check_box(:roles, { :class => 'govuk-checkboxes__input', :multiple => true }, ROLE::CERTIFICATE_MANAGER, nil) %>
+            <%= f.label :roles, t("users.roles.#{ROLE::CERTIFICATE_MANAGER}"), class: 'govuk-label govuk-checkboxes__label' %>
+          </div>
+          <div class="govuk-checkboxes__item">
+            <%= f.check_box(:roles, { :class => 'govuk-checkboxes__input', :multiple => true }, ROLE::USER_MANAGER, nil) %>
+            <%= f.label :roles, t("users.roles.#{ROLE::USER_MANAGER}"), class: 'govuk-label govuk-checkboxes__label' %>
+          </div>
+        </div>
+      </fieldset>
     </div>
-  </fieldset>
-</div>
 
-  <div class="actions">
-    <%= f.submit t('users.update.button'), class: "govuk-button", data: { module: "govuk-button" } %>
-  </div>
+    <div class="actions">
+      <%= f.submit t('users.update.button'), class: "govuk-button", data: { module: "govuk-button" } %>
+    </div>
+  <% end %>
 <% end %>


### PR DESCRIPTION
On the list of users we should not show the different permissions for
GDS users, as they have all of them.
Also capitalized the name of the team when GDS.

**Before:**
<img width="744" alt="image" src="https://user-images.githubusercontent.com/30629434/65443584-489ec900-de26-11e9-8fd8-f64dffe50066.png">

**After:**
<img width="759" alt="image" src="https://user-images.githubusercontent.com/30629434/65443596-50f70400-de26-11e9-9d30-da0bd9a66dd6.png">
