### PR TITLE
Update how GDS team is displayed

### DIFF
--- a/app/views/users/index.erb
+++ b/app/views/users/index.erb
@@ -2,7 +2,16 @@
   <h1 class="govuk-heading-xl"><%= t 'team.heading' %></h1>
   <ul class="govuk-list">
     <% @teams.reverse.each do |team| %>
-      <li><%= link_to team.name, admin_users_path(team.id) %></li>
+      <li>
+      <% if team.name == TEAMS::GDS %>
+        <%= link_to team.name.upcase, admin_users_path(team.id) %>
+          <strong class="govuk-tag">
+            <%= t('users.admin_team') %>
+          </strong>
+        </li>
+      <% else team.name == TEAMS::GDS %>
+        <%= link_to team.name, admin_users_path(team.id) %>
+      <% end %>
     <% end %>
   </ul>
 <% else %>

--- a/app/views/users/index.erb
+++ b/app/views/users/index.erb
@@ -6,10 +6,10 @@
       <% if team.name == TEAMS::GDS %>
         <%= link_to team.name.upcase, admin_users_path(team.id) %>
           <strong class="govuk-tag">
-            <%= t('users.admin_team') %>
+            <%= t 'users.admin_team' %>
           </strong>
         </li>
-      <% else team.name == TEAMS::GDS %>
+      <% else %>
         <%= link_to team.name, admin_users_path(team.id) %>
       <% end %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,7 +79,7 @@ en:
       certmgr: Manage certificates
       usermgr: Add, edit and remove team members
     you: (you)
-
+    admin_team: admin team
   certificates:
     caption: "%{heading}"
     header_id: ID


### PR DESCRIPTION
Uppercasing the `gds` name to GDS and adding a badge
to highlight it's an admin team.

**Before:**
<img width="283" alt="image" src="https://user-images.githubusercontent.com/30629434/65444401-e050e700-de27-11e9-8ab5-357f000e32cc.png">

**After:**
<img width="278" alt="image" src="https://user-images.githubusercontent.com/30629434/65444414-e47d0480-de27-11e9-9adb-7728a12232e4.png">
