### PR TITLE
p6d47NhK: Enforce component restrictions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,7 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :check_authorization
   before_action :check_team_authorization
+  before_action :check_component_authorization
   before_action :check_max_session_time
 
 protected
@@ -39,6 +40,17 @@ protected
 
   def check_team_authorization(team_id: params[:team_id])
     authorize Team.find_by_id(team_id) unless team_id.nil? || !Team.exists?(team_id)
+  rescue Pundit::NotAuthorizedError
+    flash[:warn] = t('shared.errors.authorisation')
+    redirect_to root_path, status: :forbidden
+  end
+
+  def check_component_authorization(component_id: params['component_id'], component_type: params['component_type'])
+    if component_id.present?
+      component = klass_component(component_type).find_by_id(component_id)
+      team = component.team
+      authorize team unless team.nil?
+    end
   rescue Pundit::NotAuthorizedError
     flash[:warn] = t('shared.errors.authorisation')
     redirect_to root_path, status: :forbidden

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -16,6 +16,14 @@ class GroupPolicy < ApplicationPolicy
   alias_method :update?, :team_authorized?
   alias_method :destroy?, :team_authorized?
   alias_method :invite?, :team_authorized?
+  alias_method :before_you_start?, :team_authorized?
+  alias_method :view_certificate?, :team_authorized?
+  alias_method :upload_certificate?, :team_authorized?
+  alias_method :upload?, :team_authorized?
+  alias_method :check_your_certificate?, :team_authorized?
+  alias_method :submit?, :team_authorized?
+  alias_method :confirmation?, :team_authorized?
+  alias_method :confirm?, :team_authorized?
 
 private
 

--- a/spec/support/auth_support.rb
+++ b/spec/support/auth_support.rb
@@ -14,9 +14,10 @@ module AuthSupport
     stub_auth
   end
 
-  def certmgr_stub_auth
+  def certmgr_stub_auth(team = nil)
     @request.env["devise.mapping"] = Devise.mappings[:user]
-    @user = FactoryBot.create(:certificate_manager_user)
+    if (team.nil?) then team = FactoryBot.create(:team) end
+    @user = FactoryBot.create(:certificate_manager_user, team: team.id)
     stub_auth
   end
 

--- a/spec/support/auth_support.rb
+++ b/spec/support/auth_support.rb
@@ -16,7 +16,7 @@ module AuthSupport
 
   def certmgr_stub_auth(team = nil)
     @request.env["devise.mapping"] = Devise.mappings[:user]
-    if (team.nil?) then team = FactoryBot.create(:team) end
+    team = FactoryBot.create(:team) if team.nil?
     @user = FactoryBot.create(:certificate_manager_user, team: team.id)
     stub_auth
   end

--- a/spec/system/visit_user_journey_before_you_start_page_spec.rb
+++ b/spec/system/visit_user_journey_before_you_start_page_spec.rb
@@ -3,9 +3,10 @@ require 'rails_helper'
 RSpec.describe 'Before you start page', type: :system do
   include CertificateSupport
 
-  let(:msa_encryption_certificate) { create(:msa_encryption_certificate) }
-  let(:sp_encryption_certificate) { create(:sp_encryption_certificate) }
-  let(:vsp_encryption_certificate) { create(:vsp_encryption_certificate) }
+  let(:user) { login_certificate_manager_user }
+  let(:msa_encryption_certificate) { create(:msa_encryption_certificate, component: create(:msa_component, team_id: user.team)) }
+  let(:sp_encryption_certificate) { create(:sp_encryption_certificate, component: create(:sp_component, team_id: user.team)) }
+  let(:vsp_encryption_certificate) { create(:vsp_encryption_certificate, component: create(:sp_component, vsp: true, team_id: user.team)) }
 
   before(:each) do
     login_certificate_manager_user
@@ -51,7 +52,7 @@ RSpec.describe 'Before you start page', type: :system do
 
   context 'signing journey' do
     it 'shows before you start page for msa signing and successfully goes to next page' do
-      certificate = create(:msa_signing_certificate)
+      certificate = create(:msa_signing_certificate, component: create(:msa_component, team_id: user.team))
       msa_component = certificate.component
       visit before_you_start_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
       expect(page).to have_content 'Matching Service Adapter (MSA) signing certificate'
@@ -60,7 +61,7 @@ RSpec.describe 'Before you start page', type: :system do
     end
 
     it 'shows before you start page for vsp signing and successfully goes to next page' do
-      certificate = create(:vsp_signing_certificate)
+      certificate = create(:vsp_signing_certificate, component: create(:sp_component, vsp: true, team_id: user.team))
       vsp_component = certificate.component
       visit before_you_start_path(vsp_component.component_type, vsp_component.id, vsp_component.signing_certificates[0])
       expect(page).to have_content 'Verify Service Provider (VSP) signing certificate'
@@ -69,7 +70,7 @@ RSpec.describe 'Before you start page', type: :system do
     end
 
     it 'shows before you start page for sp signing and successfully goes to next page' do
-      certificate = create(:sp_signing_certificate)
+      certificate = create(:sp_signing_certificate, component: create(:sp_component, team_id: user.team))
       sp_component = certificate.component
       visit before_you_start_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])
       expect(page).to have_content 'Service Provider (SP) signing certificate'

--- a/spec/system/visit_user_journey_check_your_certificate_page_spec.rb
+++ b/spec/system/visit_user_journey_check_your_certificate_page_spec.rb
@@ -3,12 +3,12 @@ require 'rails_helper'
 RSpec.describe 'Check your certificate page', type: :system do
   include CertificateSupport
 
-  let(:msa_encryption_certificate) { create(:msa_encryption_certificate) }
-  let(:sp_encryption_certificate) { create(:sp_encryption_certificate) }
-  let(:vsp_encryption_certificate) { create(:vsp_encryption_certificate) }
+  let(:user) { login_certificate_manager_user }
+  let(:msa_encryption_certificate) { create(:msa_encryption_certificate, component: create(:msa_component, team_id: user.team)) }
+  let(:sp_encryption_certificate) { create(:sp_encryption_certificate, component: create(:sp_component, team_id: user.team)) }
+  let(:vsp_encryption_certificate) { create(:vsp_encryption_certificate, component: create(:sp_component, vsp: true, team_id: user.team)) }
 
   before(:each) do
-    login_certificate_manager_user
     ReplaceEncryptionCertificateEvent.create(
       component: sp_encryption_certificate.component,
       encryption_certificate_id: sp_encryption_certificate.id
@@ -63,7 +63,7 @@ RSpec.describe 'Check your certificate page', type: :system do
 
   context 'signing journey' do
     it 'expect msa component, signing certificate and successfully goes to next page' do
-      msa_signing_certificate = create(:msa_signing_certificate)
+      msa_signing_certificate = create(:msa_signing_certificate, component: create(:msa_component, team_id: user.team))
       msa_component = msa_signing_certificate.component
       visit upload_certificate_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
       fill_in 'certificate_value', with: msa_signing_certificate.value
@@ -76,7 +76,7 @@ RSpec.describe 'Check your certificate page', type: :system do
     end
 
     it 'expect vsp component, signing certificate and successfully goes to next page' do
-      vsp_signing_certificate = create(:vsp_signing_certificate)
+      vsp_signing_certificate = create(:vsp_signing_certificate, component: create(:sp_component, vsp: true, team_id: user.team))
       vsp_component = vsp_signing_certificate.component
       visit upload_certificate_path(vsp_component.component_type, vsp_component.id, vsp_component.signing_certificates[0])
       fill_in 'certificate_value', with: vsp_signing_certificate.value
@@ -89,7 +89,7 @@ RSpec.describe 'Check your certificate page', type: :system do
     end
   
     it 'expect sp component, signing certificate and successfully goes to next page' do
-      sp_signing_certificate = create(:sp_signing_certificate)
+      sp_signing_certificate = create(:sp_signing_certificate, component: create(:sp_component, team_id: user.team))
       sp_component = sp_signing_certificate.component
       visit upload_certificate_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])
       fill_in 'certificate_value', with: sp_signing_certificate.value

--- a/spec/system/visit_user_journey_confirmation_page_spec.rb
+++ b/spec/system/visit_user_journey_confirmation_page_spec.rb
@@ -3,12 +3,12 @@ require 'rails_helper'
 RSpec.describe 'Confirmation page', type: :system do
   include CertificateSupport
 
-  let(:msa_encryption_certificate) { create(:msa_encryption_certificate) }
-  let(:sp_encryption_certificate) { create(:sp_encryption_certificate) }
-  let(:vsp_encryption_certificate) { create(:vsp_encryption_certificate) }
+  let(:user) { login_certificate_manager_user }
+  let(:msa_encryption_certificate) { create(:msa_encryption_certificate, component: create(:msa_component, team_id: user.team)) }
+  let(:sp_encryption_certificate) { create(:sp_encryption_certificate, component: create(:sp_component, team_id: user.team)) }
+  let(:vsp_encryption_certificate) { create(:vsp_encryption_certificate, component: create(:sp_component, vsp: true, team_id: user.team)) }
 
   before(:each) do
-    login_certificate_manager_user
     ReplaceEncryptionCertificateEvent.create(
       component: sp_encryption_certificate.component,
       encryption_certificate_id: sp_encryption_certificate.id
@@ -34,7 +34,7 @@ RSpec.describe 'Confirmation page', type: :system do
     end
 
     it 'signing and successfully goes to next page' do
-      certificate = create(:msa_signing_certificate)
+      certificate = create(:msa_signing_certificate, component: create(:msa_component, team_id: user.team))
       msa_component = certificate.component
       visit confirmation_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
       expect(page).to have_content COMPONENT_TYPE::MSA_SHORT
@@ -55,7 +55,7 @@ RSpec.describe 'Confirmation page', type: :system do
     end
 
     it 'signing and successfully goes to next page' do
-      certificate = create(:vsp_signing_certificate)
+      certificate = create(:vsp_signing_certificate, component: create(:sp_component, vsp: true, team_id: user.team))
       vsp_component = certificate.component
       visit confirmation_path(vsp_component.component_type, vsp_component.id, vsp_component.signing_certificates[0])
       expect(page).to have_content COMPONENT_TYPE::VSP_SHORT
@@ -76,7 +76,7 @@ RSpec.describe 'Confirmation page', type: :system do
     end
 
     it 'signing and successfully goes to next page' do
-      certificate = create(:sp_signing_certificate)
+      certificate = create(:sp_signing_certificate, component: create(:sp_component, team_id: user.team))
       sp_component = certificate.component
       visit confirmation_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])
       expect(page).to have_content COMPONENT_TYPE::SP_SHORT

--- a/spec/system/visit_user_journey_upload_certificate_page_spec.rb
+++ b/spec/system/visit_user_journey_upload_certificate_page_spec.rb
@@ -3,9 +3,10 @@ require 'rails_helper'
 RSpec.describe 'Upload certificate page', type: :system do
   include CertificateSupport
 
-  let(:msa_encryption_certificate) { create(:msa_encryption_certificate) }
-  let(:sp_encryption_certificate) { create(:sp_encryption_certificate) }
-  let(:vsp_encryption_certificate) { create(:vsp_encryption_certificate) }
+  let(:user) { login_certificate_manager_user }
+  let(:msa_encryption_certificate) { create(:msa_encryption_certificate, component: create(:msa_component, team_id: user.team)) }
+  let(:sp_encryption_certificate) { create(:sp_encryption_certificate, component: create(:sp_component, team_id: user.team)) }
+  let(:vsp_encryption_certificate) { create(:vsp_encryption_certificate, component: create(:sp_component, vsp: true, team_id: user.team)) }
 
   before(:each) do
     login_certificate_manager_user
@@ -35,7 +36,7 @@ RSpec.describe 'Upload certificate page', type: :system do
     end
 
     it 'signing and successfully goes to next page' do
-      certificate = create(:msa_signing_certificate)
+      certificate = create(:msa_signing_certificate, component: create(:msa_component, team_id: user.team))
       msa_component = certificate.component
       visit upload_certificate_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
       expect(page).to have_content COMPONENT_TYPE::MSA_SHORT
@@ -58,7 +59,7 @@ RSpec.describe 'Upload certificate page', type: :system do
     end
 
     it 'signing and successfully goes to next page' do
-      certificate = create(:vsp_signing_certificate)
+      certificate = create(:vsp_signing_certificate, component: create(:sp_component, vsp:true, team_id: user.team))
       vsp_component = certificate.component
       visit upload_certificate_path(vsp_component.component_type, vsp_component.id, vsp_component.signing_certificates[0])
       expect(page).to have_content COMPONENT_TYPE::VSP_SHORT
@@ -81,7 +82,7 @@ RSpec.describe 'Upload certificate page', type: :system do
     end
 
     it 'signing and successfully goes to next page' do
-      certificate = create(:sp_signing_certificate)
+      certificate = create(:sp_signing_certificate, component: create(:sp_component, team_id: user.team))
       sp_component = certificate.component
       visit upload_certificate_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])
       expect(page).to have_content COMPONENT_TYPE::SP_SHORT

--- a/spec/system/visit_user_journey_view_certificate_page_spec.rb
+++ b/spec/system/visit_user_journey_view_certificate_page_spec.rb
@@ -2,12 +2,13 @@ require 'rails_helper'
 
 RSpec.describe 'View certificate page', type: :system do
   include CertificateSupport
-  let(:msa_encryption_certificate) { create(:msa_encryption_certificate) }
-  let(:sp_encryption_certificate) { create(:sp_encryption_certificate) }  
-  let(:vsp_encryption_certificate) { create(:vsp_encryption_certificate) }  
+
+  let(:user) { login_certificate_manager_user }
+  let(:msa_encryption_certificate) { create(:msa_encryption_certificate, component: create(:msa_component, team_id: user.team)) }
+  let(:sp_encryption_certificate) { create(:sp_encryption_certificate, component: create(:sp_component, team_id: user.team)) }  
+  let(:vsp_encryption_certificate) { create(:vsp_encryption_certificate, component: create(:sp_component, vsp: true, team_id: user.team)) }  
 
   before(:each) do
-    @user = login_certificate_manager_user
     ReplaceEncryptionCertificateEvent.create(
       component: sp_encryption_certificate.component,
       encryption_certificate_id: sp_encryption_certificate.id
@@ -32,7 +33,7 @@ RSpec.describe 'View certificate page', type: :system do
     end
 
     it 'signing certificate information and navigates to next page' do
-      msa_signing_certificate = create(:msa_signing_certificate)
+      msa_signing_certificate = create(:msa_signing_certificate, component: create(:msa_component, team_id: user.team))
       msa_component = msa_signing_certificate.component
       visit view_certificate_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
       expect(page).to have_content 'Matching Service Adapter: signing certificate'
@@ -51,7 +52,7 @@ RSpec.describe 'View certificate page', type: :system do
     end
 
     it 'signing certificate information and navigates to next page' do
-      vsp_signing_certificate = create(:vsp_signing_certificate)
+      vsp_signing_certificate = create(:vsp_signing_certificate, component: create(:sp_component, vsp: true, team_id: user.team))
       vsp_component = vsp_signing_certificate.component
       visit view_certificate_path(vsp_component.component_type, vsp_component.id, vsp_component.signing_certificates[0])
       expect(page).to have_content 'Verify Service Provider: signing certificate'
@@ -70,7 +71,7 @@ RSpec.describe 'View certificate page', type: :system do
     end
 
     it 'signing certificate information and navigates to next page' do
-      sp_signing_certificate = create(:sp_signing_certificate)
+      sp_signing_certificate = create(:sp_signing_certificate, component: create(:sp_component, team_id: user.team))
       sp_component = sp_signing_certificate.component
       visit view_certificate_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])
       expect(page).to have_content 'Service Provider: signing certificate'
@@ -81,7 +82,7 @@ RSpec.describe 'View certificate page', type: :system do
 
   context 'show signing' do
     it 'specific information when certificate is primary' do
-      first_certificate = create(:msa_signing_certificate, component: create(:msa_component, team_id: @user.team))
+      first_certificate = create(:msa_signing_certificate, component: create(:msa_component, team_id: user.team))
       create(:msa_signing_certificate, component: first_certificate.component)
       visit root_path
       click_link 'Signing certificate (primary)'
@@ -90,7 +91,7 @@ RSpec.describe 'View certificate page', type: :system do
     end
 
     it 'specific information when certificate is secondary' do
-      first_certificate = create(:msa_signing_certificate, component: create(:msa_component, team_id: @user.team))
+      first_certificate = create(:msa_signing_certificate, component: create(:msa_component, team_id: user.team))
       create(:msa_signing_certificate, component: first_certificate.component)
       visit root_path
       click_link 'Signing certificate (secondary)'


### PR DESCRIPTION
* Add a check which enforces that when dealing with a component, the logged in user must have the same team as that component.
* This prevents accessing other teams' components via URL editing.
* Lots of tests needed to be updated to accommodate this restriction.