### PR TITLE
Use correct error styles in user journey form

### DIFF
--- a/app/controllers/user_journey_controller.rb
+++ b/app/controllers/user_journey_controller.rb
@@ -45,11 +45,9 @@ class UserJourneyController < ApplicationController
       end
     end
 
-    @upload = UploadCertificateEvent.new(
-      component_id: params[component_key(params)],
-      component_type: component_name_from_params(params)
-    )
-    Rails.logger.info(merge_errors(@upload, extractor, @new_certificate))
+    # For the purposes of the form :(
+    @upload = extractor
+    Rails.logger.info(merge_errors(@upload, @new_certificate))
     render :upload_certificate
   end
 

--- a/app/models/certificate_extractor.rb
+++ b/app/models/certificate_extractor.rb
@@ -2,7 +2,8 @@ class CertificateExtractor
   include ActiveModel::Model
   include CertificateConcern
 
-  validate :file_content_type, :contents, if: :file_upload?
+  validate :file_content_type, if: :file_upload?
+  validate :contents, if: :no_errors?
 
   MIME_X509_CA = 'application/x-x509-ca-cert'.freeze
   MIME_PEM = 'application/x-pem-file'.freeze
@@ -26,9 +27,13 @@ private
     @file_upload ||= params['upload-certificate'] == 'file'
   end
 
+  def no_errors?
+    file_upload? && errors.empty?
+  end
+
   def file_content_type
     unless VALID_CONTENT_TYPES.include?(params[:certificate].dig(:cert_file)&.content_type)
-      errors.add(:certificate, I18n.t('certificates.errors.invalid_file_type'))
+      errors.add(:cert_file, I18n.t('certificates.errors.invalid_file_type'))
     end
   end
 
@@ -38,6 +43,6 @@ private
       to_x509(File.read(tempfile)) if tempfile
     end
   rescue OpenSSL::X509::CertificateError
-    errors.add(:certificate, I18n.t('certificates.errors.invalid'))
+    errors.add(:cert_file, I18n.t('certificates.errors.invalid'))
   end
 end

--- a/app/views/shared/_upload_errors.html.erb
+++ b/app/views/shared/_upload_errors.html.erb
@@ -1,0 +1,19 @@
+<% if @upload.errors&.any? %>
+  <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
+    <h2 class="govuk-error-summary__title" id="error-summary-title">
+      <%= t 'shared.errors.problem' %>
+    </h2>
+    <div class="govuk-error-summary__body">
+      <ul class="govuk-list govuk-error-summary__list">
+        <% @upload.errors.each do |key| %>
+          <li data-turbolinks="false">
+            <%=
+              link_to "#{@upload.errors&.full_messages_for(key).first}" ,
+              "#certificate_#{params[:certificate].key?(:cert_file) ? 'cert_file' : 'value'}"
+            %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+   </div>
+<% end %>

--- a/app/views/user_journey/upload_certificate.html.erb
+++ b/app/views/user_journey/upload_certificate.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-form-group">
   <%= form_for @upload, url: submit_path, as: :certificate, multipart: true do |f| %>
-    <%= error_message_on(f.object.errors, :certificate) %>
+    <%= render 'shared/upload_errors' %>
     <fieldset class="govuk-fieldset" aria-describedby="upload-certificate-conditional-hint">
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
         <h1 class="govuk-fieldset__heading">
@@ -11,25 +11,30 @@
       </legend>
       <div class="govuk-radios govuk-radios--conditional govuk-!-margin-bottom-5" data-module="govuk-radios">
         <div class="govuk-radios__item">
-          <input class="govuk-radios__input" id="upload-certificate-conditional" name="upload-certificate" type="radio" value="file" data-aria-controls="conditional-upload-certificate-conditional">
+          <input class="govuk-radios__input" id="upload-certificate-conditional" name="upload-certificate"
+            type="radio" value="file" data-aria-controls="conditional-upload-certificate-conditional"
+            <%= checked('file') %>>
           <label class="govuk-label govuk-radios__label" for="upload-certificate-conditional">
             <%= t 'user_journey.certificate.upload_certificate_file_header' %>
           </label>
         </div>
         <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-upload-certificate-conditional">
           <div class="govuk-form-group">
-            <%= f.file_field :cert_file, class: "govuk-file-upload" %>
+            <%= f.file_field :cert_file, class: "govuk-file-upload #{error_class('file')}" %>
           </div>
         </div>
         <div class="govuk-radios__item">
-          <input class="govuk-radios__input" id="upload-certificate-conditional-2" name="upload-certificate" type="radio" value="string" data-aria-controls="conditional-upload-certificate-conditional-2">
+          <input class="govuk-radios__input" id="upload-certificate-conditional-2" name="upload-certificate"
+            type="radio" value="string" data-aria-controls="conditional-upload-certificate-conditional-2"
+            <%= checked('string') %>>
           <label class="govuk-label govuk-radios__label" for="upload-certificate-conditional-2">
             <%= t 'user_journey.certificate.paste_certificate' %>
           </label>
         </div>
         <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-upload-certificate-conditional-2">
           <div class="govuk-form-group">
-            <%= f.text_area :value, class: "govuk-textarea#{@upload.errors.key?(:certificate) ? ' govuk-textarea--error' : ''}", rows: "20" %>
+            <%= f.text_area :value, class: "govuk-textarea #{error_class('string')}",
+                value: "#{text_box_value}", rows: "20" %>
           </div>
         </div>
       </div>

--- a/spec/controllers/user_journey_controller_spec.rb
+++ b/spec/controllers/user_journey_controller_spec.rb
@@ -170,8 +170,10 @@ RSpec.describe UserJourneyController, type: :controller do
              }
            })
 
-      expect(response).to redirect_to :upload_certificate
-      expect(flash[:error]).to include(I18n.t('certificates.errors.valid_too_long'))
+      expect(subject).to render_template(:upload_certificate)
+      expect(
+        assigns(:upload).errors.full_messages.first
+      ).to include(I18n.t('certificates.errors.valid_too_long'))
     end
 
     it 'should redirect to upload certificate page when certificate file is invalid' do
@@ -189,8 +191,10 @@ RSpec.describe UserJourneyController, type: :controller do
              }
            })
 
-      expect(response).to redirect_to :upload_certificate
-      expect(flash[:error]).to include(I18n.t('certificates.errors.invalid_file_type'))
+      expect(subject).to render_template(:upload_certificate)
+      expect(
+        assigns(:upload).errors.full_messages.first
+      ).to include(I18n.t('certificates.errors.invalid_file_type'))
     end
 
     it 'should redirect to upload certificate page with valid file extension but invalid content' do
@@ -208,8 +212,10 @@ RSpec.describe UserJourneyController, type: :controller do
              }
            })
 
-      expect(response).to redirect_to :upload_certificate
-      expect(flash[:error]).to include(I18n.t('certificates.errors.invalid'))
+      expect(subject).to render_template(:upload_certificate)
+      expect(
+        assigns(:upload).errors.full_messages.first
+      ).to include(I18n.t('certificates.errors.invalid'))
     end
   end
 
@@ -262,8 +268,10 @@ RSpec.describe UserJourneyController, type: :controller do
              certificate: { value: msa_encryption_cert.value, component: msa_component }
            })
 
-      expect(response).to redirect_to :upload_certificate
-      expect(flash[:error]).to include(I18n.t('certificates.errors.invalid_file_type'))
+      expect(subject).to render_template(:upload_certificate)
+      expect(
+        assigns(:upload).errors.full_messages.first
+      ).to include(I18n.t('certificates.errors.invalid_file_type'))
     end
   end
 
@@ -277,15 +285,17 @@ RSpec.describe UserJourneyController, type: :controller do
            })
 
       expect(subject).to render_template(:upload_certificate)
-      expect(flash[:error]).to include(I18n.t('certificates.errors.invalid'))
+      expect(
+        assigns(:upload).errors.full_messages.first
+      ).to include(I18n.t('certificates.errors.invalid'))
     end
   end
 
   context 'Enforcement of component team restrictions' do
     it 'prevents rendering of the upload certificate page when team is not matching' do
       certmgr_stub_auth
-      foreign_team = FactoryBot.create(:team, id: SecureRandom.uuid)
-      foreign_component = FactoryBot.create(:sp_component, team_id: foreign_team.id)
+      foreign_team = create(:team, id: SecureRandom.uuid)
+      foreign_component = create(:sp_component, team_id: foreign_team.id)
       get :upload_certificate,
           params: {
             component_type: foreign_component.component_type,
@@ -306,7 +316,7 @@ RSpec.describe UserJourneyController, type: :controller do
             component_id: 'bad id',
             certificate_id: msa_encryption_cert.id
           }
-          expect(subject).to render_template(:upload_certificate)
+      expect(subject).to render_template(:upload_certificate)
     end
   end
 end


### PR DESCRIPTION
Previously we were using the Rails built in flash messages to show the users any errors in validation when they were uploading a certificate.

We now use the correct GOV.UK styling to represent the errors better. We also show the user which part of the form error'd.

## Before

<img width="985" alt="Screen Shot 2019-09-27 at 18 02 44" src="https://user-images.githubusercontent.com/3466862/65787752-8e72ce80-e151-11e9-9c4e-3220637a613b.png">

## After

<img width="985" alt="Screen Shot 2019-09-30 at 16 09 23" src="https://user-images.githubusercontent.com/3466862/65891558-a25e4080-e39c-11e9-806f-ebe8ff77f434.png">

<img width="977" alt="Screen Shot 2019-09-30 at 16 09 13" src="https://user-images.githubusercontent.com/3466862/65891560-a25e4080-e39c-11e9-8288-3381948dffff.png">


https://trello.com/c/r7C6c9PC/587-fix-all-form-validation