### PR TITLE
Updated ruborules to ignore string literals

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,4 @@
 Style/ConditionalAssignment:
   Enabled: false
+Style/StringLiterals:
+  Enabled: false

--- a/app/controllers/certificates_controller.rb
+++ b/app/controllers/certificates_controller.rb
@@ -7,7 +7,7 @@ class CertificatesController < ApplicationController
     component_type = component_name_from_params(params)
     @upload = UploadCertificateEvent.new(
       component_id: component_id,
-      component_type: component_type
+      component_type: component_type,
     )
   end
 
@@ -19,7 +19,7 @@ class CertificatesController < ApplicationController
       if @upload.certificate.encryption?
         ReplaceEncryptionCertificateEvent.create(
           component: component,
-          encryption_certificate_id: @upload.certificate.id
+          encryption_certificate_id: @upload.certificate.id,
         )
       end
 
@@ -39,7 +39,7 @@ class CertificatesController < ApplicationController
       flash[:notice] = error_message
     end
     redirect_to polymorphic_url(
-      klass_component(certificate.component_type).find_by_id(certificate.component_id)
+      klass_component(certificate.component_type).find_by_id(certificate.component_id),
     )
   end
 
@@ -52,18 +52,18 @@ class CertificatesController < ApplicationController
       flash[:notice] = error_message
     end
     redirect_to polymorphic_url(
-      klass_component(certificate.component_type).find_by_id(certificate.component_id)
+      klass_component(certificate.component_type).find_by_id(certificate.component_id),
     )
   end
 
   def replace
     component = klass_component(
-      component_name_from_params(params)
+      component_name_from_params(params),
     ).find_by_id(params[:component])
     certificate = Certificate.find_by_id(params[:id])
     event = ReplaceEncryptionCertificateEvent.create(
       component: component,
-      encryption_certificate_id: certificate.id
+      encryption_certificate_id: certificate.id,
     )
     unless event.valid?
       error_message = event.errors.full_messages
@@ -82,7 +82,7 @@ private
           .permit(:value, :usage)
           .merge(
             component_id: component_id,
-            component_type: component_type
+            component_type: component_type,
           )
   end
 end

--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -7,7 +7,7 @@ class HealthcheckController < ApplicationController
     checks = [
       Healthcheck::CognitoCheck,
       Healthcheck::DbCheck,
-      Healthcheck::StorageCheck
+      Healthcheck::StorageCheck,
     ]
     result = Healthcheck::Checker.new(checks).run
 

--- a/app/controllers/msa_components_controller.rb
+++ b/app/controllers/msa_components_controller.rb
@@ -31,7 +31,7 @@ class MsaComponentsController < ApplicationController
     msa_component = MsaComponent.find_by_id(params[:id])
     msa_component.team_id = params.dig(:component, :team_id)
     event = ChangeComponentEvent.create(
-      component: msa_component
+      component: msa_component,
     )
     unless event.valid?
       error_message = event.errors.full_messages

--- a/app/controllers/password_controller.rb
+++ b/app/controllers/password_controller.rb
@@ -18,7 +18,7 @@ class PasswordController < ApplicationController
       change_password(
         current_password: @password_form.old_password,
         new_password: @password_form.password,
-        access_token: current_user.access_token
+        access_token: current_user.access_token,
       )
       flash[:notice] = t('password.password_changed')
       redirect_to profile_path

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -29,7 +29,7 @@ class ProfileController < ApplicationController
       role_str = params[:assume_roles][:role_selection].join(',')
       if params[:assume_roles][:role_selection].include?(ROLE::GDS)
         CognitoStubClient.update_user(
-          role: role_str, email_domain: TEAMS::GDS_EMAIL_DOMAIN
+          role: role_str, email_domain: TEAMS::GDS_EMAIL_DOMAIN,
         )
       else
         CognitoStubClient.update_user(role: role_str)

--- a/app/controllers/sp_components_controller.rb
+++ b/app/controllers/sp_components_controller.rb
@@ -31,7 +31,7 @@ class SpComponentsController < ApplicationController
     spcomponent = SpComponent.find_by_id(params[:id])
     spcomponent.team_id = params.dig(:component, :team_id)
     event = ChangeComponentEvent.create(
-      component: spcomponent
+      component: spcomponent,
     )
     unless event.valid?
       error_message = event.errors.full_messages

--- a/app/controllers/user_journey_controller.rb
+++ b/app/controllers/user_journey_controller.rb
@@ -22,7 +22,7 @@ class UserJourneyController < ApplicationController
     component_type = component_name_from_params(params)
     @upload = UploadCertificateEvent.new(
       component_id: component_id,
-      component_type: component_type
+      component_type: component_type,
     )
   end
 
@@ -35,7 +35,7 @@ class UserJourneyController < ApplicationController
       @new_certificate = Certificate.new(
         usage: @certificate.usage,
         value: @new_certificate_value,
-        component: @component
+        component: @component,
       )
 
       if @new_certificate.valid? && valid_x509?(@new_certificate)
@@ -58,7 +58,7 @@ class UserJourneyController < ApplicationController
       usage: @certificate.usage,
       value: new_certificate_value,
       component_id: params[:component_id],
-      component_type: params[:component_type]
+      component_type: params[:component_type],
     )
 
     if @upload.valid?
@@ -67,7 +67,7 @@ class UserJourneyController < ApplicationController
       if @upload.certificate.encryption?
         ReplaceEncryptionCertificateEvent.create(
           component: component,
-          encryption_certificate_id: @upload.certificate.id
+          encryption_certificate_id: @upload.certificate.id,
         )
       end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -97,7 +97,7 @@ private
       email: @form.email,
       given_name: @form.given_name,
       family_name: @form.family_name,
-      roles: @form.roles
+      roles: @form.roles,
     )
   end
 

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -31,7 +31,7 @@ class Component < Aggregate
       event_id: event_id,
       connected_services: service_providers.map(&:services_to_metadata).flatten,
       matching_service_adapters: MsaComponent.all_components_for_metadata.map(&:to_metadata),
-      service_providers: service_providers.map(&:to_metadata)
+      service_providers: service_providers.map(&:to_metadata),
     }
   end
 
@@ -45,7 +45,7 @@ class Component < Aggregate
     services.map do |service|
       {
         entity_id: service.entity_id,
-        service_provider_id: service.sp_component_id
+        service_provider_id: service.sp_component_id,
       }
     end
   end
@@ -58,7 +58,7 @@ class Component < Aggregate
     {
       name: name,
       encryption_certificate: encryption_certificate&.to_metadata,
-      signing_certificates: enabled_signing_certificates.map(&:to_metadata)
+      signing_certificates: enabled_signing_certificates.map(&:to_metadata),
     }.merge(additional_metadata)
   end
 end

--- a/app/models/healthcheck/storage_check.rb
+++ b/app/models/healthcheck/storage_check.rb
@@ -12,7 +12,7 @@ module Healthcheck
               bucket: bucket,
               key: FILES::HEALTHCHECK,
               body: '',
-              server_side_encryption: 'AES256'
+              server_side_encryption: 'AES256',
             )
           end
         rescue Aws::S3::Errors::ServiceError
@@ -28,7 +28,7 @@ module Healthcheck
     def healthcheck_file_exists?(bucket)
       SelfService.service(:storage_client).get_object(
         bucket: bucket,
-        key: FILES::HEALTHCHECK
+        key: FILES::HEALTHCHECK,
       )
     rescue Aws::S3::Errors::NoSuchKey
       false

--- a/app/models/new_msa_component_event.rb
+++ b/app/models/new_msa_component_event.rb
@@ -20,7 +20,7 @@ class NewMsaComponentEvent < AggregatedEvent
       team_id: team_id,
       environment: environment,
       entity_id: entity_id,
-      created_at: created_at
+      created_at: created_at,
     }
   end
 

--- a/app/models/new_service_event.rb
+++ b/app/models/new_service_event.rb
@@ -14,7 +14,7 @@ class NewServiceEvent < AggregatedEvent
       sp_component_id: sp_component_id,
       msa_component_id: msa_component_id,
       name: name,
-      created_at: created_at
+      created_at: created_at,
     }
   end
 end

--- a/app/models/new_sp_component_event.rb
+++ b/app/models/new_sp_component_event.rb
@@ -24,7 +24,7 @@ class NewSpComponentEvent < AggregatedEvent
       environment: environment,
       component_type: COMPONENT_TYPE::SP,
       vsp: component_type == COMPONENT_TYPE::VSP,
-      created_at: created_at
+      created_at: created_at,
     }
   end
 

--- a/app/models/new_team_event.rb
+++ b/app/models/new_team_event.rb
@@ -18,7 +18,7 @@ class NewTeamEvent < AggregatedEvent
     {
       name: name,
       team_alias: team_alias,
-      created_at: created_at
+      created_at: created_at,
     }
   end
 

--- a/app/models/publish_services_metadata_event.rb
+++ b/app/models/publish_services_metadata_event.rb
@@ -18,7 +18,7 @@ class PublishServicesMetadataEvent < Event
       bucket: hub_environment_bucket,
       key: FILES::CONFIG_METADATA,
       body: StringIO.new(metadata.to_json),
-      server_side_encryption: 'AES256'
+      server_side_encryption: 'AES256',
     )
   rescue Aws::S3::Errors::ServiceError
     Rails.logger.error("Failed to publish config metadata for event #{event_id}")

--- a/app/models/remote_authenticatable.rb
+++ b/app/models/remote_authenticatable.rb
@@ -105,10 +105,10 @@ module Devise
               family_name: record.family_name,
               session_start_time: record.session_start_time,
               team: record.team,
-              cognito_groups: groups
+              cognito_groups: groups,
             },
             # Used for salt in serialize_from_session, causes error if missing
-            nil
+            nil,
           ]
         end
       end

--- a/app/models/trigger_metadata_event_callback.rb
+++ b/app/models/trigger_metadata_event_callback.rb
@@ -2,7 +2,7 @@ class TriggerMetadataEventCallback
   def after_save(model)
     PublishServicesMetadataEvent.create(
       event_id: model.id,
-      environment: environment(model)
+      environment: environment(model),
     )
   end
 

--- a/app/models/upload_certificate_event.rb
+++ b/app/models/upload_certificate_event.rb
@@ -24,7 +24,7 @@ class UploadCertificateEvent < AggregatedEvent
       value: self.value,
       component_id: self.component_id,
       component_type: self.component_type,
-      created_at: self.created_at
+      created_at: self.created_at,
     }
   end
 

--- a/lib/auth/authentication_backend.rb
+++ b/lib/auth/authentication_backend.rb
@@ -36,7 +36,7 @@ module AuthenticationBackend
   def request_password_reset(params)
     client.forgot_password(
       client_id: cognito_client_id,
-      username: params[:email]
+      username: params[:email],
     )
   rescue Aws::CognitoIdentityProvider::Errors::NotAuthorizedException => e
     Rails.logger.error("User #{params[:email]} is not set up properly but is trying to reset their password")
@@ -54,7 +54,7 @@ module AuthenticationBackend
       client_id: cognito_client_id,
       username: params[:email],
       confirmation_code: params[:code],
-      password: params[:password]
+      password: params[:password],
       )
   rescue Aws::CognitoIdentityProvider::Errors::CodeMismatchException => e
     raise NotAuthorizedException.new(e)
@@ -67,7 +67,7 @@ module AuthenticationBackend
     client.create_group(
       group_name: name,
       description: description,
-      user_pool_id: user_pool_id
+      user_pool_id: user_pool_id,
     )
   rescue Aws::CognitoIdentityProvider::Errors::InvalidParameterException => e
     raise AuthenticationBackendException.new(e)
@@ -88,14 +88,14 @@ module AuthenticationBackend
   def enrol_totp_device(access_token:, totp_code:)
     client.verify_software_token(
       access_token: access_token,
-      user_code: totp_code
+      user_code: totp_code,
     )
     client.set_user_mfa_preference(
       access_token: access_token,
       software_token_mfa_settings: {
         enabled: true,
-        preferred_mfa: true
-      }
+        preferred_mfa: true,
+      },
     )
   rescue Aws::CognitoIdentityProvider::Errors::ServiceError => e
     raise AuthenticationBackendException.new(e)
@@ -111,23 +111,23 @@ module AuthenticationBackend
       user_attributes: [
         {
           name: 'email',
-          value: email
+          value: email,
         },
         {
           name: 'given_name',
-          value: given_name
+          value: given_name,
         },
         {
           name: 'family_name',
-          value: family_name
+          value: family_name,
         },
         {
           name: 'custom:roles',
-          value: roles.join(",")
-        }
+          value: roles.join(","),
+        },
       ],
       username: email,
-      user_pool_id: user_pool_id
+      user_pool_id: user_pool_id,
   )
   rescue Aws::CognitoIdentityProvider::Errors::AliasExistsException,
          Aws::CognitoIdentityProvider::Errors::UsernameExistsException => e
@@ -140,7 +140,7 @@ module AuthenticationBackend
     client.admin_add_user_to_group(
       user_pool_id: user_pool_id,
       username: username,
-      group_name: group
+      group_name: group,
     )
   rescue Aws::CognitoIdentityProvider::Errors::ServiceError => e
     raise AuthenticationBackendException.new(e)
@@ -149,7 +149,7 @@ module AuthenticationBackend
   def get_users(limit: 60)
     client.list_users(
       user_pool_id: user_pool_id,
-      limit: limit
+      limit: limit,
     )
   rescue Aws::CognitoIdentityProvider::Errors::ServiceError => e
     raise AuthenticationBackendException.new(e)
@@ -173,7 +173,7 @@ module AuthenticationBackend
     client.admin_update_user_attributes(
       user_pool_id: user_pool_id,
       username: user_id,
-      user_attributes: [{ name: "custom:roles", value: roles.join(',') }]
+      user_attributes: [{ name: "custom:roles", value: roles.join(',') }],
     )
   rescue Aws::CognitoIdentityProvider::Errors::ServiceError => e
     raise AuthenticationBackendException.new(e.message)
@@ -191,7 +191,7 @@ module AuthenticationBackend
   def get_group(group_name:)
     client.get_group(
       group_name: group_name,
-      user_pool_id: user_pool_id
+      user_pool_id: user_pool_id,
     )
   rescue Aws::CognitoIdentityProvider::Errors::ResourceNotFoundException => e
     raise UserGroupNotFoundException.new(e)
@@ -210,7 +210,7 @@ module AuthenticationBackend
     client.change_password(
       previous_password: current_password,
       proposed_password: new_password,
-      access_token: access_token
+      access_token: access_token,
     )
   rescue Aws::CognitoIdentityProvider::Errors::NotAuthorizedException => e
     raise InvalidOldPasswordError.new(e)
@@ -255,7 +255,7 @@ private
     {
       email: params[:email],
       cognito_response: cognito_response,
-      secret_code: token_resp.secret_code
+      secret_code: token_resp.secret_code,
     }
   end
 
@@ -268,8 +268,8 @@ private
       auth_flow: 'USER_PASSWORD_AUTH',
       auth_parameters: {
         'USERNAME' => email,
-        'PASSWORD' => password
-      }
+        'PASSWORD' => password,
+      },
     )
   rescue Aws::CognitoIdentityProvider::Errors::NotAuthorizedException,
          Aws::CognitoIdentityProvider::Errors::UserNotFoundException => e
@@ -310,7 +310,7 @@ private
       session_id: params[:cognito_session_id],
       challenge_name: "#{params[:challenge_name]}_RETRY",
       challenge_parameters: params[:challenge_parameters],
-      flash_message: { code: e.code, message: e.message }
+      flash_message: { code: e.code, message: e.message },
     }
     ChallengeResponse.new(response_hash)
   rescue Aws::CognitoIdentityProvider::Errors::InvalidParameterException,
@@ -323,7 +323,7 @@ private
       client_id: cognito_client_id,
       session: session,
       challenge_name: challenge_name,
-      challenge_responses: challenge_responses
+      challenge_responses: challenge_responses,
     )
   end
 

--- a/lib/auth/cognito_chooser.rb
+++ b/lib/auth/cognito_chooser.rb
@@ -37,7 +37,7 @@ class CognitoChooser
     register_jwks
     register_client(
       client: Aws::CognitoIdentityProvider::Client.new,
-      is_stub: false
+      is_stub: false,
     )
   end
 
@@ -46,7 +46,7 @@ class CognitoChooser
     register_client(client: Aws::CognitoIdentityProvider::Client.new(
       region: Rails.configuration.aws_region,
       access_key_id: aws_access_key,
-      secret_access_key: aws_secret_key
+      secret_access_key: aws_secret_key,
     ), is_stub: false)
   end
 
@@ -55,7 +55,7 @@ class CognitoChooser
     Rails.configuration.cognito_client_id = SecureRandom.uuid
     Rails.configuration.cognito_user_pool_id = SecureRandom.uuid
     register_client(
-      client: CognitoStubClient.stub_client
+      client: CognitoStubClient.stub_client,
     )
   end
 

--- a/lib/auth/cognito_stub_client.rb
+++ b/lib/auth/cognito_stub_client.rb
@@ -19,7 +19,7 @@ class CognitoStubClient
       'iat' => Time.now.to_i,
       'family_name' => 'Targaryen',
       'email' => "daenerys.targaryen@#{email_domain}",
-      'mfa' => true
+      'mfa' => true,
     }
   end
 
@@ -30,14 +30,14 @@ class CognitoStubClient
   def self.setup_user(user_hash)
     SelfService.service(:cognito_client).stub_responses(
       :respond_to_auth_challenge,
-      challenge_name: nil, authentication_result: { access_token: 'valid-token', id_token: user_hash_to_jwt(user_hash) }
+      challenge_name: nil, authentication_result: { access_token: 'valid-token', id_token: user_hash_to_jwt(user_hash) },
     )
     SelfService.service(:cognito_client).stub_responses(
       :initiate_auth,
       challenge_name: nil,
       session: "",
       challenge_parameters: { "FRIENDLY_DEVICE_NAME" => "Authy", "USER_ID_FOR_SRP" => "" },
-      authentication_result: { access_token: 'valid-token', id_token: user_hash_to_jwt(user_hash) }
+      authentication_result: { access_token: 'valid-token', id_token: user_hash_to_jwt(user_hash) },
     )
   end
 

--- a/lib/auth/initial_seeder.rb
+++ b/lib/auth/initial_seeder.rb
@@ -52,7 +52,7 @@ class InitialSeeder
       email: admin_email,
       given_name: 'Jakub',
       family_name: 'Miarka',
-      roles: [TEAMS::GDS]
+      roles: [TEAMS::GDS],
     )
     add_user_to_group(username: admin_email, group: TEAMS::GDS)
   end

--- a/lib/storage/storage_registrar.rb
+++ b/lib/storage/storage_registrar.rb
@@ -16,7 +16,7 @@ class StorageRegistrar
   def register_production_client
     SelfService.register_service(
       name: :storage_client,
-      client: Aws::S3::Client.new(logger: Rails.logger, log_level: :info)
+      client: Aws::S3::Client.new(logger: Rails.logger, log_level: :info),
     )
   end
 
@@ -28,7 +28,7 @@ class StorageRegistrar
 
     SelfService.register_service(
       name: :storage_client,
-      client: s3_client
+      client: s3_client,
     )
   end
 
@@ -39,7 +39,7 @@ class StorageRegistrar
 
     SelfService.register_service(
       name: :storage_client,
-      client: s3_client
+      client: s3_client,
     )
   end
 end


### PR DESCRIPTION
We have kept the other changed rule which is about trailing commas
after the last element in hashes and arrays.  Have run govuk-lint-ruby
over lib and app with autocorrect enabled to fix this issue in
our repo.