### PR TITLE
More adjustments for password reset

### DIFF
--- a/app/controllers/password_controller.rb
+++ b/app/controllers/password_controller.rb
@@ -46,8 +46,7 @@ class PasswordController < ApplicationController
     if @form.valid?
       session[:email] = @form.email
       request_password_reset(@form.to_h)
-      @form = PasswordRecoveryForm.new
-      render :user_code
+      redirect_to reset_password_path
     else
       flash.now[:errors] = @form.errors.full_messages.join(', ')
       render :forgot_form, status: :bad_request
@@ -60,10 +59,10 @@ class PasswordController < ApplicationController
 
   def process_code
     if session[:email].nil? && params[:password_recovery_form][:email].nil?
-      flash.now[:errors] = t('email_missing')
-      render :forgot_form, status: :bad_request
+      flash.now[:errors] = t('password.email_missing')
+      redirect_to forgot_password_path
     else
-      @form = PasswordRecoveryForm.new(params[:password_recovery_form])
+      @form = PasswordRecoveryForm.new(params[:password_recovery_form] || {})
       @form.email = session[:email] if @form.email.nil?
       if @form.valid?
         reset_password(@form.to_h)

--- a/app/controllers/password_controller.rb
+++ b/app/controllers/password_controller.rb
@@ -58,11 +58,11 @@ class PasswordController < ApplicationController
   end
 
   def process_code
-    if session[:email].nil? && params[:password_recovery_form][:email].nil?
+    if session[:email].nil? && params&.dig(:password_recovery_form, :email).nil?
       flash.now[:errors] = t('password.email_missing')
       redirect_to forgot_password_path
     else
-      @form = PasswordRecoveryForm.new(params[:password_recovery_form] || {})
+      @form = PasswordRecoveryForm.new(params[:password_recovery_form])
       @form.email = session[:email] if @form.email.nil?
       if @form.valid?
         reset_password(@form.to_h)

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -15,8 +15,8 @@
             </div>
         <% end %>
         <% if session[:challenge_name].nil? %>
-            <div>
-                <%= link_to t('password.forgot_link'), forgot_password_path %>
+            <p class="govuk-body">
+                <%= link_to t('password.forgot_link'), forgot_password_path, class: 'govuk-link' %>
             </div>
         <% end %>
     </div>

--- a/app/views/password/_password_recovery_form.erb
+++ b/app/views/password/_password_recovery_form.erb
@@ -1,9 +1,9 @@
-<h1 class="govuk-heading-l"><%= t 'password.change_password_heading' %></h1>
+<h1 class="govuk-heading-l"><%= t 'password.reset_password_heading' %></h1>
 
 <%= form_for @form, url: reset_password_path do |f| %>
   <fieldset class="govuk-fieldset" aria-describedby="changed-password-hint">
     <span id="changed-password-hint" class="govuk-hint">
-      <%= t 'password.change_password_legend' %>
+      <%= t 'password.reset_password_legend' %>
     </span>
     <% if session[:email].nil? %>
       <div class="govuk-form-group">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -127,22 +127,24 @@ en:
     assume_roles_heading: "Switch Roles"
     assume_roles_legend: "Select which role(s) you wish to assume?"
   password:
-    forgot_link: "Forgotten your password?"
-    forgot_password_legend: "Enter your e-mail address below and we'll send you an e-mail with a code you can use to change your password."
+    forgot_link: Forgotten your password?
+    forgot_password_legend: Enter your e-mail address below and we'll send you an e-mail with a code you can use to change your password.
     your_email_lbl: "Your e-mail address:"
-    request_reset: "Send Code"
-    change_password_heading: "Change Your Password"
-    change_password: "Change Password"
-    password_changed: "Password changed successfully"
-    change_password_legend: "You can change your password by entering your current password followed by a new password in the space provide and the same new password again in the confirmation space."
+    request_reset: Send code
+    change_password_heading: Change your password
+    reset_password_heading: Set your new password
+    change_password: Change password
+    password_changed: Password changed successfully
+    change_password_legend: You can change your password by entering your current password followed by a new password in the space provide and the same new password again in the confirmation space.
+    reset_password_legend: You can reset your password by entering the code you have received via email. 
     current_password_lbl: "Current password:"
     new_password_lbl: "New password:"
     confirm_password_lbl: "Confirm new password:"
-    change_password_btn: "Change Password"
-    password_recovered: "Your password has now been changed.  Please login with your new password"
+    change_password_btn: Change password
+    password_recovered: Your password has now been changed. Please login with your new password
     errors:
-      email_missing: "Your e-mail address is missing"
-      old_password_mismatch: "Your old password does not match the one we have on record"
+      email_missing: Your e-mail address is missing
+      old_password_mismatch: Your old password does not match the one we have on record
       invalid_password: The password does not match the password requirements
       code_expired: The confirmation code expired, please request a new one
       code_invalid: The confirmation code is invalid, please try again

--- a/spec/controllers/password_controller_spec.rb
+++ b/spec/controllers/password_controller_spec.rb
@@ -39,18 +39,21 @@ RSpec.describe PasswordController, type: :controller do
     let(:email) { 'test@test.com' }
 
     it 'sends code to user if form valid' do
+      expect_any_instance_of(AuthenticationBackend).to receive(:request_password_reset)
       post :send_code, params: { forgotten_password_form: { 'email': 'test@test.com' } }
-      expect(response).to have_http_status(:success)
-      expect(subject).to render_template(:user_code)
+      expect(response).to have_http_status(:redirect)
+      expect(subject).to redirect_to(reset_password_path)
     end
 
     it 'does not send code to user if params missing' do
+      expect_any_instance_of(AuthenticationBackend).not_to receive(:request_password_reset)
       post :send_code
       expect(response).to have_http_status(:bad_request)
       expect(subject).to render_template(:forgot_form)
     end
 
     it 'does not send code to user if email missing' do
+      expect_any_instance_of(AuthenticationBackend).not_to receive(:request_password_reset)
       post :send_code, params: { forgotten_password_form: { 'blah': 'blah' } }
       expect(response).to have_http_status(:bad_request)
       expect(subject).to render_template(:forgot_form)
@@ -63,8 +66,8 @@ RSpec.describe PasswordController, type: :controller do
       )
       expect(Rails.logger).to receive(:error).with("User #{email} has made to many attempts to reset their password")
       post :send_code, params: { forgotten_password_form: { 'email': email } }
-      expect(response).to have_http_status(:success)
-      expect(subject).to render_template(:user_code)
+      expect(response).to have_http_status(:redirect)
+      expect(subject).to redirect_to(reset_password_path)
     end
 
     it 'renders the user_code page on UserBadStateError' do
@@ -74,8 +77,8 @@ RSpec.describe PasswordController, type: :controller do
       )
       expect(Rails.logger).to receive(:error).with("User #{email} is not set up properly but is trying to reset their password")
       post :send_code, params: { forgotten_password_form: { 'email': email } }
-      expect(response).to have_http_status(:success)
-      expect(subject).to render_template(:user_code)
+      expect(response).to have_http_status(:redirect)
+      expect(subject).to redirect_to(reset_password_path)
     end
 
     it 'renders the user_code page on UserGroupNotFoundException' do
@@ -85,8 +88,8 @@ RSpec.describe PasswordController, type: :controller do
       )
       expect(Rails.logger).to receive(:error).with("User #{email} is not present but is trying to reset their password")
       post :send_code, params: { forgotten_password_form: { 'email': email } }
-      expect(response).to have_http_status(:success)
-      expect(subject).to render_template(:user_code)
+      expect(response).to have_http_status(:redirect)
+      expect(subject).to redirect_to(reset_password_path)
     end
 
     it 'renders the user_code page on any exceptions' do
@@ -95,13 +98,14 @@ RSpec.describe PasswordController, type: :controller do
         payload: 'ServiceError'
       )
       post :send_code, params: { forgotten_password_form: { 'email': email } }
-      expect(response).to have_http_status(:success)
-      expect(subject).to render_template(:user_code)
+      expect(response).to have_http_status(:redirect)
+      expect(subject).to redirect_to(reset_password_path)
     end
   end
 
   context 'resetting password' do
     it 'user redirected to new session with success message' do
+      expect_any_instance_of(AuthenticationBackend).to receive(:reset_password)
       post :process_code, params: { password_recovery_form: { 'email': 'test@test.com', 'code': '123456', 'password': 'password', 'password_confirmation': 'password' } }
       expect(response).to have_http_status(:redirect)
       expect(subject).to redirect_to(new_user_session_path)

--- a/spec/controllers/password_controller_spec.rb
+++ b/spec/controllers/password_controller_spec.rb
@@ -156,5 +156,11 @@ RSpec.describe PasswordController, type: :controller do
       expect(subject).to redirect_to(new_user_session_path)
       expect(flash[:notice]).to be_nil
     end
+
+    it 'user redirected to the forgotten password page when params missing' do
+      post :process_code
+      expect(response).to have_http_status(:redirect)
+      expect(subject).to redirect_to(forgot_password_path)
+    end
   end
 end

--- a/spec/system/visit_pasword_reset_page_spec.rb
+++ b/spec/system/visit_pasword_reset_page_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe 'Forgotten password flow', type: :system do
+
+  it 'successfully renders the forgotten password page' do
+    visit forgot_password_path
+
+    expect(page).to have_field 'forgotten_password_form_email'
+    expect(page).to have_content t('password.forgot_link')
+  end
+
+  it 'successfully renders the password reset page' do
+    visit reset_password_path
+
+    expect(page).to have_field 'password_recovery_form[code]'
+    expect(page).to have_field 'password_recovery_form[password]'
+    expect(page).to have_field 'password_recovery_form[password_confirmation]'
+    expect(page).to have_content t('password.reset_password_heading')
+  end
+
+  it 'successfully goes through' do
+    visit forgot_password_path
+    fill_in 'forgotten_password_form_email', with: 'test@test.com'
+    click_button t('password.request_reset')
+    fill_in 'password_recovery_form[code]', with: '1234'
+    fill_in 'password_recovery_form[password]', with: '12345678'
+    fill_in 'password_recovery_form[password_confirmation]', with: '12345678'
+    click_button t('password.change_password_btn')
+    expect(current_path).to eql new_user_session_path
+  end
+end


### PR DESCRIPTION
- Fixed the content, which was referring to password changes instead of password reset
- Removed unnecessary double quotes
- Fixed the styling for the 'Forgotten password' link to use govuk styles and size
- Added system test to test rendering and flow
- Changed the behaviour so users are able to refresh the page without the need to request a new code