### PR TITLE
BAU: Allow users to leave the sign-in/up flow

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -31,6 +31,11 @@ class SessionsController < Devise::SessionsController
     respond_to_on_destroy
   end
 
+  def cancel
+    reset_session
+    redirect_to new_user_session_path
+  end
+
   def challenge_flash_messages
     return if session.to_h.dig('challenge_parameters', 'flash_message').nil?
 

--- a/app/policies/sessions_controller_policy.rb
+++ b/app/policies/sessions_controller_policy.rb
@@ -10,4 +10,8 @@ class SessionsControllerPolicy < ApplicationPolicy
   def destroy?
     true
   end
+
+  def cancel?
+    true
+  end
 end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -11,7 +11,10 @@
             <%= render "sign_in_form", f:f %>
         <% end %>
             <div class="actions">
-                <%= f.submit "Log in", class: "govuk-button", data: { module: "govuk-button" } %>
+                <%= f.submit t('login.login'), class: "govuk-button govuk-!-margin-right-1", data: { module: "govuk-button" } %>
+                <% unless session[:challenge_name].nil? %>
+                    <%= link_to t('login.cancel'), cancel_path , class: "govuk-button govuk-button--secondary", data: { module: "govuk-button" } %>
+                <% end %>
             </div>
         <% end %>
         <% if session[:challenge_name].nil? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,8 @@ en:
     gds: GDS
   login:
     heading: Log in
+    login: Log in
+    cancel: Cancel
     mfa_heading: Log in - One Time Password Request
     mfa_description: Please enter your one time code from your authenticator app
     new_password_heading: Set up your new password

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,4 +64,8 @@ Rails.application.routes.draw do
   post '/component/:component_type/:component_id/certificate/:certificate_id/confirmation', to: 'user_journey#confirm', as: 'confirm'
 
   get '/cookies', to: 'static#cookies'
+
+  devise_scope :user do 
+    get '/users/cancel' => "sessions#cancel", as: :cancel
+  end
 end


### PR DESCRIPTION
Currently, when user enters their password correctly, their session gets populated
and can only finish or fail the journey, no option to cancel.
Even if they visit the homepage again, the session still remembers their details so will be offering them
the TOTP prompt (or whatever step in the journey they were). The user needs to either fail
or delete their cookies in order to get out of the flow.
This adds a cancel button to all the sign-in/up flow screens to reset their session.

Also, added test and localized the strings in there.