### PR TITLE
BAU: Wrap the full certificate in a preformatted tag

### DIFF
--- a/app/assets/stylesheets/_user_journey.scss
+++ b/app/assets/stylesheets/_user_journey.scss
@@ -2,24 +2,25 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
-.component-supporting-text{
+.component-supporting-text {
   font-weight: 300;
 }
 .govuk-details__code {
   background-color: govuk-colour("light-grey");
   border: 1px solid $govuk-border-colour;
-  padding: 0 15px;
-  margin-top: 15px;
   overflow-x: auto;
-  white-space: pre-wrap;
   word-wrap: break-word;
+
+  pre {
+    margin-top: 0;
+  }
 }
-.secondary-link{
+.secondary-link {
   display: inline-block;
   padding: 9px 10px 6px 10px;
   font-size: 1.1875rem;
 }
-.secondary-link__confirmation{
+.secondary-link__confirmation {
   padding: 9px 10px 6px 0px;
 }
 .certificate-details {

--- a/app/views/shared/_user_certificate_view.html.erb
+++ b/app/views/shared/_user_certificate_view.html.erb
@@ -31,6 +31,6 @@
     </span>
   </summary>
   <div class="govuk-details__text govuk-details__code">
-    <%= certificate.x509.to_text %>
+    <pre><%= certificate.x509.to_text %></pre>
   </div>
 </details>


### PR DESCRIPTION
So it is more readable.

**Before:**
<img width="774" alt="image" src="https://user-images.githubusercontent.com/30629434/66200642-76db9e80-e699-11e9-9676-932b890876e8.png">

**After:**
<img width="761" alt="image" src="https://user-images.githubusercontent.com/30629434/66200658-7cd17f80-e699-11e9-98ae-c78c879942b6.png">
