### PR TITLE
BAU: Set the email_verified attribute when creating users

### DIFF
--- a/lib/auth/authentication_backend.rb
+++ b/lib/auth/authentication_backend.rb
@@ -121,6 +121,10 @@ module AuthenticationBackend
           value: email,
         },
         {
+          name: 'email_verified',
+          value: 'True',
+        },
+        {
           name: 'given_name',
           value: given_name,
         },


### PR DESCRIPTION
In order for users to reset their own password, the email address needs to be verified.
This makes sure the attribute is set when creating the user.