### PR TITLE
BAU: Show the user account status

### DIFF
--- a/app/assets/stylesheets/_users.scss
+++ b/app/assets/stylesheets/_users.scss
@@ -2,7 +2,7 @@
 .user-list {
   margin-bottom: 30px;
   &-item {
-    padding: 15px 150px 15px 0;
+    padding: 15px 150px 25px 0;
     border-top: 1px solid govuk-colour("mid-grey");
     position: relative;
     h3 {
@@ -35,7 +35,7 @@
   &-edit-link{
     text-align: right;
     position: absolute;
-    top: -25px;
+    top: -35px;
     right: -150px;
 
     li {
@@ -64,9 +64,9 @@
   box-shadow: inset 20px 0 0 0 rgba(255, 255, 255, 0.6);
 }
 
-.tick-cross-list-edit-link {
+.tick-cross-list-status {
   text-align: right;
   position: absolute;
-  top: -35px;
   right: -150px;
+  top: 0;
 }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -22,6 +22,7 @@ class UsersController < ApplicationController
   end
 
   def show
+    @gds = current_user.permissions.admin_management
     user_id = params['user_id']
     cognito_user = get_user(user_id: user_id)
     @team_member = as_team_member(cognito_user: cognito_user)
@@ -43,6 +44,7 @@ class UsersController < ApplicationController
     else
       cognito_user = get_user(user_id: user_id)
       @team_member = as_team_member(cognito_user: cognito_user)
+      @gds = current_user.permissions.admin_management
       flash.now[:errors] = @form.errors.full_messages.join(', ')
       render :show, status: :bad_request
     end
@@ -83,13 +85,14 @@ private
   def as_team_member(cognito_user:)
     user = cognito_user.to_h
     user_id = user[:username]
+    status = user[:user_status]
     attributes_key = user.key?(:user_attributes) ? :user_attributes : :attributes
     attributes = user[attributes_key].to_h { |attr| [attr[:name], attr[:value]] }
     given_name = attributes['given_name']
     family_name = attributes['family_name']
     email = attributes['email']
     roles = attributes['custom:roles'].split(%r{,\s*})
-    TeamMember.new(user_id: user_id, given_name: given_name, family_name: family_name, email: email, roles: roles)
+    TeamMember.new(user_id: user_id, given_name: given_name, family_name: family_name, email: email, roles: roles, status: status)
   end
 
   def setup_user_in_cognito

--- a/app/models/team_member.rb
+++ b/app/models/team_member.rb
@@ -1,12 +1,13 @@
 class TeamMember
-  attr_reader :user_id, :given_name, :family_name, :email, :roles
+  attr_reader :user_id, :given_name, :family_name, :email, :roles, :status
 
-  def initialize(user_id:, given_name:, family_name:, email:, roles:)
+  def initialize(user_id:, given_name:, family_name:, email:, roles:, status:)
     @user_id = user_id
     @email = email
     @given_name = given_name
     @family_name = family_name
     @roles = roles
+    @status = status
   end
 
   def full_name
@@ -23,5 +24,9 @@ class TeamMember
 
   def gds?
     @roles.include? ROLE::GDS
+  end
+
+  def user_status?(status)
+    @status == status
   end
 end

--- a/app/views/users/index.erb
+++ b/app/views/users/index.erb
@@ -45,9 +45,16 @@
           </div>
         <% end %>
         <% if @user.email != member.email %>
-        <li class="tick-cross-list-edit-link">
-          <%= link_to t('users.change_link'), update_user_path(member.user_id) %>
-        </li>
+          <li class="tick-cross-list-edit-link">
+            <%= link_to t('users.change_link'), update_user_path(member.user_id) %>
+          </li>
+          <% if @gds || (member.user_status?('FORCE_CHANGE_PASSWORD') || member.user_status?('RESET_REQUIRED')) %>
+            <li class="tick-cross-list-status">
+              <span class="govuk-body">
+                <%= t("users.status.#{member.status}") %>
+              </span>
+            </li>
+          <% end %>
         <% end %>
       </ul>
     </div>

--- a/app/views/users/show.erb
+++ b/app/views/users/show.erb
@@ -5,7 +5,13 @@
 
 <%= form_for @form, url: update_user_post_path, class: 'govuk-form-group' do |f| %>
 
-  <p>
+  <% if @gds || (@team_member.user_status?('FORCE_CHANGE_PASSWORD') || @team_member.user_status?('RESET_REQUIRED')) %>
+    <p class="govuk-body">
+      <%= t('users.status_label') %> <%= t("users.status.#{@team_member.status}") %>
+    </p>
+  <% end %>
+
+  <p class="govuk-body">
     <%= @team_member.email  %><a class="govuk-!-padding-left-1 govuk-link--no-visited-state" href="#">Change<span class="govuk-visually-hidden">email address</span></a>
   </p>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,6 +79,15 @@ en:
       certmgr: Manage certificates
       usermgr: Add, edit and remove team members
     you: (you)
+    status_label: "Status:"
+    status:
+      FORCE_CHANGE_PASSWORD: (invitation sent)
+      UNCONFIRMED: Unconfirmed
+      CONFIRMED: Confirmed
+      ARCHIVED: Archived
+      COMPROMISED: Compromised
+      UNKNOWN: Unknown
+      RESET_REQUIRED: (password reset required)
     admin_team: admin team
   certificates:
     caption: "%{heading}"

--- a/spec/system/visit_users_spec.rb
+++ b/spec/system/visit_users_spec.rb
@@ -33,24 +33,37 @@ RSpec.describe 'Users Page', type: :system do
     let(:cognito_users) {
       {users: [
           {username: "111",
+           user_status: 'CONFIRMED',
            attributes: [{name: "given_name", value: "Apple"},
                         {name: "family_name", value: "One"},
                         {name: "email", value: "apple.one@test.com"},
                         {name: "custom:roles", value: "usermgr"}
            ]},
           {username: "222",
+           user_status: 'FORCE_CHANGE_PASSWORD',
            attributes: [{name: "given_name", value: "Apple"},
                         {name: "family_name", value: "Two"},
                         {name: "email", value: "apple.two@test.com"},
                         {name: "custom:roles", value: "certmgr,usermgr"}
            ]},
           {username: "333",
+           user_status: 'COMPROMISED',
            attributes: [{name: "given_name", value: "Apple"},
                         {name: "family_name", value: "Three"},
                         {name: "email", value: "apple.three@test.com"},
                         {name: "custom:roles", value: "certmgr"}
-           ]}]}
+           ]},
+           {username: "444",
+            user_status: 'RESET_REQUIRED',
+            attributes: [{name: "given_name", value: "Apple"},
+                         {name: "family_name", value: "Four"},
+                         {name: "email", value: "apple.four@test.com"},
+                         {name: "custom:roles", value: "certmgr"}
+            ]}
+           ]}
     }
+
+    let(:visible_statutes) { %w(FORCE_CHANGE_PASSWORD RESET_REQUIRED)}
 
 
     before(:each) do
@@ -63,6 +76,12 @@ RSpec.describe 'Users Page', type: :system do
       visit users_path
       expect(page).to have_content t('users.title_for_team')+' '+team_apple.name
       cognito_users[:users].each do |user|
+        if visible_statutes.include?(user[:user_status])
+          expect(page).to have_content(t("users.status.#{user[:user_status]}"))
+        else
+          expect(page).not_to have_content(t("users.status.#{user[:user_status]}"))
+        end
+
         expect(page).to have_content(user[:attributes][0][:value] +' '+ user[:attributes][1][:value] )
         within("##{user[:username]}") do
           expect(page).to have_content((user[:attributes][3][:value].split(',').include?(ROLE::CERTIFICATE_MANAGER) ? 'Can' : 'Cannot' ) + ' ' + t('users.roles.certmgr'))


### PR DESCRIPTION
This is a stepping stone for enabling user admins to resend invites when the
temporary password expires.
This change exposes the user account status
("UNCONFIRMED", "CONFIRMED", "ARCHIVED", "COMPROMISED", "UNKNOWN", "RESET_REQUIRED","FORCE_CHANGE_PASSWORD")
GDS users are able to see all the statutes, non-GDS users only see the
"FORCE_CHANGE_PASSWORD" status which means the user haven't activated their account and
the "RESET_REQUIRED" status which means the admin reset a password for them.
On the UI these statutes are displayed as "(nvitation sent)" and "(password reset required)"