### PR TITLE
BAU: Display a helpful message when user's temporary password expired

### DIFF
--- a/config/initializers/remote_authenticatable.rb
+++ b/config/initializers/remote_authenticatable.rb
@@ -27,8 +27,12 @@ module Devise
             end
           rescue AuthenticationBackend::NotAuthorizedException => error
             clean_up_session
-            Rails.logger.error error
+            Rails.logger.warn error
             return fail!(:invalid_login)
+          rescue AuthenticationBackend::TemporaryPasswordExpiredException => error
+            clean_up_session
+            Rails.logger.warn error
+            return fail!(:temporary_password_expired)
           rescue StandardError => error
             Rails.logger.error error
             clean_up_session

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -19,7 +19,8 @@ en:
       unknown_cognito_error: "Something went wrong in our backend. Try again later."
       unknown_cognito_response: "Something went wrong in our backend. Try again later."
       user:
-        invalid_login: "Invalid Username or Password. Please try again."
+        invalid_login: "Invalid username or password. Please try again."
+        temporary_password_expired: "Your temporary password expired. Please contact your admin for a new one."
         unknown_cognito_response: "Unknown authentication response."
     mailer:
       confirmation_instructions:

--- a/lib/auth/authentication_backend.rb
+++ b/lib/auth/authentication_backend.rb
@@ -4,6 +4,7 @@ require 'securerandom'
 
 module AuthenticationBackend
   class NotAuthorizedException < StandardError; end
+  class TemporaryPasswordExpiredException < StandardError; end
   class UserGroupNotFoundException < StandardError; end
   class AuthenticationBackendException < StandardError; end
   class UsernameExistsException < StandardError; end
@@ -280,7 +281,11 @@ private
     )
   rescue Aws::CognitoIdentityProvider::Errors::NotAuthorizedException,
          Aws::CognitoIdentityProvider::Errors::UserNotFoundException => e
-    raise NotAuthorizedException.new(e)
+    if e.message == 'Temporary password has expired and must be reset by an administrator.'
+      raise TemporaryPasswordExpiredException.new(e)
+    else
+      raise NotAuthorizedException.new(e)
+    end
   rescue Aws::CognitoIdentityProvider::Errors::InvalidParameterException => e
     raise AuthenticationBackendException.new(e)
   end

--- a/spec/system/visit_sign_in_spec.rb
+++ b/spec/system/visit_sign_in_spec.rb
@@ -102,6 +102,15 @@ RSpec.describe 'Sign in', type: :system do
     expect(page).to have_content t('devise.failure.user.invalid_login')
   end
 
+  scenario 'user cannot sign in with an expired password' do
+    SelfService.service(:cognito_client).stub_responses(:initiate_auth, Aws::CognitoIdentityProvider::Errors::NotAuthorizedException.new(nil, 'Temporary password has expired and must be reset by an administrator.'))
+    user = FactoryBot.create(:user_manager_user)
+    sign_in(user.email, 'expiredpassword')
+
+    expect(current_path).to eql new_user_session_path
+    expect(page).to have_content t('devise.failure.user.temporary_password_expired')
+  end
+
   scenario 'user cannot access pages if not signed in' do
     visit new_msa_component_path
 


### PR DESCRIPTION
When the user is trying to login with an expired password we should
advise them accordingly.
Also changed the invalid password exception logging level from error to warning, as we don't
need to be alerted on that.