### PR TITLE
Add an integrity checker

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -67,9 +67,12 @@ Rails.application.configure do
   config.cognito_client_id = ENV['AWS_COGNITO_CLIENT_ID']
   config.cognito_user_pool_id = ENV['AWS_COGNITO_USER_POOL_ID']
 
-  # To seed Cognito (uncomment, if needed to be run):
-  # config.after_initialize do
+  # To seed Cognito and check data integrity (uncomment, if needed to be run):
+  config.after_initialize do
   #   require 'auth/initial_seeder'
   #   InitialSeeder.new
-  # end
+  #
+     require 'data/integrity_checker'
+     IntegrityChecker.new
+  end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -138,5 +138,8 @@ Rails.application.configure do
   config.after_initialize do
     require 'auth/initial_seeder'
     InitialSeeder.new unless ENV['DISABLE_COGNITO_SEEDING'].present?
+
+    require 'data/integrity_checker'
+    IntegrityChecker.new
   end
 end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -21,7 +21,7 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+workers ENV.fetch("WEB_CONCURRENCY") { 1 }
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code

--- a/lib/auth/authentication_backend.rb
+++ b/lib/auth/authentication_backend.rb
@@ -170,6 +170,13 @@ module AuthenticationBackend
     []
   end
 
+  def list_groups(limit: 60)
+    client.list_groups(
+      user_pool_id: user_pool_id,
+      limit: limit,
+    )
+  end
+
   def get_user(user_id:)
     client.admin_get_user(user_pool_id: user_pool_id, username: user_id)
   rescue Aws::CognitoIdentityProvider::Errors::ServiceError => e

--- a/lib/data/integrity_checker.rb
+++ b/lib/data/integrity_checker.rb
@@ -1,0 +1,29 @@
+require 'auth/authentication_backend'
+# The purpose of this is to make sure any existing Cognito groups
+# have a corresponding local team in DB. If not, it creates them.
+
+class IntegrityChecker
+  include AuthenticationBackend
+
+  def initialize
+    return if SelfService.service(:cognito_stub)
+
+    Rails.logger.info('Checking the data integrity...')
+    check_groups_vs_teams
+  end
+
+  def check_groups_vs_teams
+    cognito_groups = list_groups
+    return if cognito_groups.empty?
+
+    cognito_groups.groups.each do |group|
+      Rails.logger.info("Checking if #{group.group_name} group has a corresponding team in DB...")
+      if Team.exists?(team_alias: group.group_name)
+        Rails.logger.info("OK - #{group.group_name} group has a corresponding team in DB...")
+      else
+        Rails.logger.warn("#{group.group_name} group does not have a corresponding team in DB! Creating...")
+        NewTeamEvent.create(name: group.description)
+      end
+    end
+  end
+end

--- a/lib/data/integrity_checker.rb
+++ b/lib/data/integrity_checker.rb
@@ -22,7 +22,8 @@ class IntegrityChecker
         Rails.logger.info("OK - #{group.group_name} group has a corresponding team in DB...")
       else
         Rails.logger.warn("#{group.group_name} group does not have a corresponding team in DB! Creating...")
-        NewTeamEvent.create(name: group.description)
+        name = group.description.present? ? group.description : group.group_name
+        NewTeamEvent.create(name: name)
       end
     end
   end

--- a/spec/lib/data/integrity_checker_spec.rb
+++ b/spec/lib/data/integrity_checker_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+require 'data/integrity_checker'
+
+RSpec.describe IntegrityChecker do
+  include CognitoSupport
+
+  let(:groups) {
+    { groups: [
+      {
+        group_name: 'testteam1',
+        user_pool_id: 'one',
+        description: 'test team1',
+        role_arn: nil,
+        precedence: nil,
+        last_modified_date: Time.now,
+        creation_date: Time.now
+      },
+      {
+        group_name: 'testteam2',
+        user_pool_id: 'one',
+        description: 'test team2',
+        role_arn: nil,
+        precedence: nil,
+        last_modified_date: Time.now,
+        creation_date: Time.now
+      },
+      {
+        group_name: 'testteam3',
+        user_pool_id: 'one',
+        description: 'test team3',
+        role_arn: nil,
+        precedence: nil,
+        last_modified_date: Time.now,
+        creation_date: Time.now
+      },
+    ]}
+  }
+
+  describe 'IntegrityChecker' do
+    it 'creates the teams so they match with cognito groups' do
+      stub_cognito_response(method: :list_groups, payload: groups)
+      stub_cognito_response(method: :create_group, payload: {})
+      groups[:groups].each do |group|
+        expect(Team.exists?(team_alias: group[:group_name])).to eq false
+      end
+      subject.check_groups_vs_teams
+      groups[:groups].each do |group|
+        expect(Team.exists?(team_alias: group[:group_name])).to eq true
+      end
+    end
+  end
+end

--- a/spec/lib/data/integrity_checker_spec.rb
+++ b/spec/lib/data/integrity_checker_spec.rb
@@ -36,9 +36,52 @@ RSpec.describe IntegrityChecker do
     ]}
   }
 
+  let(:groups_without_description) {
+    { groups: [
+      {
+        group_name: 'testteam1',
+        user_pool_id: 'one',
+        description: '',
+        role_arn: nil,
+        precedence: nil,
+        last_modified_date: Time.now,
+        creation_date: Time.now
+      },
+      {
+        group_name: 'testteam2',
+        user_pool_id: 'one',
+        role_arn: nil,
+        precedence: nil,
+        last_modified_date: Time.now,
+        creation_date: Time.now
+      },
+      {
+        group_name: 'testteam3',
+        user_pool_id: 'one',
+        description: nil,
+        role_arn: nil,
+        precedence: nil,
+        last_modified_date: Time.now,
+        creation_date: Time.now
+      },
+    ]}
+  }
+
   describe 'IntegrityChecker' do
     it 'creates the teams so they match with cognito groups' do
       stub_cognito_response(method: :list_groups, payload: groups)
+      stub_cognito_response(method: :create_group, payload: {})
+      groups[:groups].each do |group|
+        expect(Team.exists?(team_alias: group[:group_name])).to eq false
+      end
+      subject.check_groups_vs_teams
+      groups[:groups].each do |group|
+        expect(Team.exists?(team_alias: group[:group_name])).to eq true
+      end
+    end
+
+    it 'creates the teams so they match with cognito groups even if groups do not have description' do
+      stub_cognito_response(method: :list_groups, payload: groups_without_description)
       stub_cognito_response(method: :create_group, payload: {})
       groups[:groups].each do |group|
         expect(Team.exists?(team_alias: group[:group_name])).to eq false


### PR DESCRIPTION
A fail-safe mechanism to make sure groups in Cognito align with teams in the app.
It could happen that a Cognito group exists without a corresponding team, meaning we
are unable to manage or see it.
On the startup it will compare the cognito groups with teams and create any missing teams.
Also, I have set the puma workers number to one, since traffic is not expected to be high and also it
would cause the checker to run twice, potentially creating race conditions.