### PR TITLE
Add a feature flag to the integrity checker

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -140,6 +140,6 @@ Rails.application.configure do
     InitialSeeder.new unless ENV['DISABLE_COGNITO_SEEDING'].present?
 
     require 'data/integrity_checker'
-    IntegrityChecker.new
+    IntegrityChecker.new unless ENV['DISABLE_INTEGRITY_CHECKER'].present?
   end
 end


### PR DESCRIPTION
Since we might not always want to run it, especially during DB migrations.