### PR TITLE
ttb2P0KA: Enable admins to resent invitation for users

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -28,7 +28,7 @@ class UsersController < ApplicationController
     @team_member = as_team_member(cognito_user: cognito_user)
     @form = UpdateUserRolesForm.new(roles: @team_member.roles)
   rescue AuthenticationBackendException
-    flash[:error] = "User does not exist."
+    flash[:error] = t('users.errors.invalid_user')
     redirect_to users_path
   end
 
@@ -69,6 +69,18 @@ class UsersController < ApplicationController
       @gds_team = Team.find_by_id(params[:team_id])&.name == TEAMS::GDS
       render :invite, status: :bad_request
     end
+  end
+
+  def resend_invitation
+    begin
+      user = as_team_member(cognito_user: get_user(user_id: params[:user_id]))
+      resend_invite(username: user.email)
+      flash[:success] = t('users.update.resend_invitation.success')
+    rescue AuthenticationBackendException => e
+      flash[:error] = t('users.update.resend_invitation.error')
+      Rails.logger.error e
+    end
+    redirect_to update_user_path(user_id: params[:user_id])
   end
 
 private

--- a/app/policies/member_policy.rb
+++ b/app/policies/member_policy.rb
@@ -16,6 +16,7 @@ class MemberPolicy < ApplicationPolicy
 
   alias_method :show?, :member_authorized?
   alias_method :update?, :member_authorized?
+  alias_method :resend_invitation?, :member_authorized?
 
 private
 

--- a/app/policies/users_controller_policy.rb
+++ b/app/policies/users_controller_policy.rb
@@ -25,4 +25,8 @@ class UsersControllerPolicy < ApplicationPolicy
   def new?
     user.permissions.user_management
   end
+
+  def resend_invitation?
+    user.permissions.user_management
+  end
 end

--- a/app/views/users/show.erb
+++ b/app/views/users/show.erb
@@ -7,7 +7,9 @@
 
   <% if @gds || (@team_member.user_status?('FORCE_CHANGE_PASSWORD') || @team_member.user_status?('RESET_REQUIRED')) %>
     <p class="govuk-body">
-      <%= t('users.status_label') %> <%= t("users.status.#{@team_member.status}") %>
+      <%= t('users.status_label') %> <%= t("users.status.#{@team_member.status}") %> - <% if @team_member.user_status?('FORCE_CHANGE_PASSWORD') %>
+        <%= link_to t('users.update.resend_invitation.link'), resend_invitation_path, class: 'govuk-link'%>
+      <% end %>
     </p>
   <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -77,6 +77,10 @@ en:
       select_one: Select at least one
     update:
       button: Save
+      resend_invitation:
+        link: Resend
+        success: The invitation has been successfully resent
+        error: There was an error resending the invitation
     roles:
       certmgr: Manage certificates
       usermgr: Add, edit and remove team members
@@ -91,6 +95,8 @@ en:
       UNKNOWN: Unknown
       RESET_REQUIRED: (password reset required)
     admin_team: admin team
+    errors:
+      invalid_user: User does not exist
   certificates:
     caption: "%{heading}"
     header_id: ID

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
   post '/users/team/:team_id/invite', to: 'users#new', as: :invite_to_team_post
   get '/users/:user_id/update', to: 'users#show', as: :update_user
   post '/users/:user_id/update', to: 'users#update', as: :update_user_post
+  get '/users/:user_id/resend-invitation', to: 'users#resend_invitation', as: :resend_invitation
 
   get '/mfa-enrolment', to: 'mfa#index', as: :mfa_enrolment
   post '/mfa-enrolment', to: 'mfa#enrol', as: :enrol_to_mfa


### PR DESCRIPTION
Currently, the temporary password expires after 1 day when an user is created/invited.
This adds the functionality to resend a new password/invite for the user if they did not manage
to login and set their own password before the temporary one expired.