### PR TITLE
R4q1NXt5: Add page titles

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,9 +1,22 @@
 module ApplicationHelper
+  PAGE_TITLE_SUFFIX = ' - GOV.UK Verify Manage Certificates'.freeze
+
   def format_date_time(cert_date_time)
     cert_date_time.strftime("%e-%m-%Y %H:%M")
   end
 
   def date_to_readable_long_format(cert_date_time)
     cert_date_time.strftime("%d %B %Y, %H:%M%P")
+  end
+
+  def page_title(title)
+    content_for :page_title, title + PAGE_TITLE_SUFFIX
+  end
+
+  def display_page_title
+    title = content_for :page_title
+    raise NotImplementedError.new('Missing page title') if Rails.env.test? && (title == PAGE_TITLE_SUFFIX || title.nil?)
+
+    title
   end
 end

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -1,4 +1,6 @@
-<h1 class="govuk-heading-xl">Admin</h1>
+<%= page_title t('admin.title') %>
+
+<h1 class="govuk-heading-xl"><%= t('admin.title') %></h1>
 
 <div class="govuk-tabs" data-module="govuk-tabs">
   <h2 class="govuk-tabs__title">

--- a/app/views/certificates/new.html.erb
+++ b/app/views/certificates/new.html.erb
@@ -1,3 +1,5 @@
+<%= page_title t('certificates.title') %>
+
 <fieldset class="govuk-fieldset">
   <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
     <h1 class="govuk-fieldset__heading"><%= t 'certificates.upload' %></h1>

--- a/app/views/components/index.html.erb
+++ b/app/views/components/index.html.erb
@@ -1,3 +1,5 @@
+<%= page_title t('components.title') %>
+
 <h1 class="govuk-heading-xl"><%= t 'components.title' %></h1>
 
 <%= render "shared/component_certificates", components: @msa_components, name: COMPONENT_TYPE::MSA %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,3 +1,5 @@
+ <%= page_title t('login.title') %>
+
  <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-half">
         <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,3 +1,5 @@
+<%= page_title t('events.title') %>
+
 <h1 class="govuk-heading-l"><%= t 'events.title' %></h1>
 <table class="govuk-table">
   <thead class="govuk-table__head">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
-<html lang="en" class="govuk-template ">
+<html lang="en" class="govuk-template">
   <head>
     <meta name="robots" content="noindex,nofollow">
 
-    <title><%= t 'layout.application.title' %></title>
+    <title><%= display_page_title %></title>
+
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
@@ -19,7 +20,7 @@
 
 </head>
 
-  <body class="govuk-template__body ">
+  <body class="govuk-template__body">
 
     <%= javascript_tag nonce: true do %>
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');

--- a/app/views/msa_components/index.html.erb
+++ b/app/views/msa_components/index.html.erb
@@ -1,1 +1,3 @@
-<%= render "all_msa_components"%>
+<%= page_title t('components.component_heading', type: COMPONENT_TYPE::MSA_SHORT) %>
+
+<%= render 'all_msa_components' %>

--- a/app/views/msa_components/new.html.erb
+++ b/app/views/msa_components/new.html.erb
@@ -1,3 +1,5 @@
+<%= page_title t('components.new_msa_title') %>
+
 <fieldset class="govuk-fieldset">
   <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
     <h1 class="govuk-fieldset__heading"><%= t('components.upload_component', type: COMPONENT_TYPE::MSA_SHORT) %></h1>

--- a/app/views/msa_components/show.html.erb
+++ b/app/views/msa_components/show.html.erb
@@ -1,3 +1,5 @@
+<%= page_title @component.component_type + ' ' + @component.name %>
+
 <h1 class="govuk-heading-xl"><%= @component.name %></h1>
 
 <h2 class="govuk-heading-l"><%= @component.component_type %></h2>

--- a/app/views/password/forgot_form.html.erb
+++ b/app/views/password/forgot_form.html.erb
@@ -1,4 +1,6 @@
-<h1 class="govuk-heading-l"><%= t 'password.forgot_link' %></h1>
+<%= page_title t('password.title_forgotten') %>
+
+<h1 class="govuk-heading-l"><%= t('password.forgot_link') %></h1>
 
 <%= form_for @form, url: forgot_password_path do |f| %>
   <fieldset class="govuk-fieldset" aria-describedby="changed-password-hint">

--- a/app/views/password/password_form.html.erb
+++ b/app/views/password/password_form.html.erb
@@ -1,3 +1,5 @@
+<%= page_title t('password.title_change') %>
+
 <h1 class="govuk-heading-l"><%= t 'password.change_password_heading' %></h1>
 
 <%= form_for @password_form, url: profile_change_password_path do |f| %>

--- a/app/views/password/user_code.html.erb
+++ b/app/views/password/user_code.html.erb
@@ -1,1 +1,3 @@
+<%= page_title t('password.title_reset') %>
+
 <%= render 'password_recovery_form' %>

--- a/app/views/profile/show.html.erb
+++ b/app/views/profile/show.html.erb
@@ -1,3 +1,5 @@
+<%= page_title t('profile.title') %>
+
 <% if Rails.env.development? %>
   <div class="govuk-phase-banner">
     <p class="govuk-phase-banner__content">
@@ -9,14 +11,12 @@
       </span>
     </p>
   </div>
+<% end %>
 
-
-  <p>&nbsp;</p>
-<%end%>
-<h1  class="govuk-heading-l"><%= t 'profile.title' %></h1>
+<h1 class="govuk-heading-l"><%= t 'profile.title' %></h1>
 
 <div>
-  <h2  class="govuk-heading-m"><%= t 'profile.welcome' %> <%= @user.full_name %></h2>
+  <h2 class="govuk-heading-m"><%= t 'profile.welcome' %> <%= @user.full_name %></h2>
 
 <div class="govuk-accordion" data-module="govuk-accordion" id="profile-accordion">
   <div class="govuk-accordion__section ">

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -1,4 +1,6 @@
-<h1 class="govuk-heading-xl">Services</h1>
+<%= page_title t('services.title') %>
+
+<h1 class="govuk-heading-xl"><%= t('services.title') %></h1>
 
 <% if @services.present? %>
   <table class="govuk-table">

--- a/app/views/services/new.html.erb
+++ b/app/views/services/new.html.erb
@@ -1,3 +1,5 @@
+<%= page_title t('services.new.title') %>
+
 <fieldset class="govuk-fieldset">
   <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
     <h1 class="govuk-fieldset__heading"><%= t 'services.new.heading' %></h1>

--- a/app/views/sp_components/index.html.erb
+++ b/app/views/sp_components/index.html.erb
@@ -1,1 +1,3 @@
-<%= render "all_sp_components"%>
+<%= page_title t('components.component_heading', type: COMPONENT_TYPE::SP_SHORT) %>
+
+<%= render 'all_sp_components' %>

--- a/app/views/sp_components/new.html.erb
+++ b/app/views/sp_components/new.html.erb
@@ -1,3 +1,5 @@
+<%= page_title t('components.new_msa_title') %>
+
 <fieldset class="govuk-fieldset">
   <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
     <h1 class="govuk-fieldset__heading"><%= t('components.upload_component', type: COMPONENT_TYPE::SP_SHORT) %></h1>

--- a/app/views/sp_components/show.html.erb
+++ b/app/views/sp_components/show.html.erb
@@ -1,3 +1,5 @@
+<%= page_title @component.component_type + ' ' + @component.name %>
+
 <h1 class="govuk-heading-xl"><%= @component.name %></h1>
 
 <h2 class="govuk-heading-l"><%= @component.component_type %></h2>

--- a/app/views/static/cookies.html.erb
+++ b/app/views/static/cookies.html.erb
@@ -1,3 +1,5 @@
+<%= page_title 'Cookies' %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Cookies</h1>

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -1,3 +1,5 @@
+<%= page_title t('team.title') %>
+
 <h1 class="govuk-heading-xl"><%= t('team.heading') %></h1>
 
 <% if @teams.present? %>

--- a/app/views/teams/new.html.erb
+++ b/app/views/teams/new.html.erb
@@ -1,3 +1,5 @@
+<%= page_title t('team.new.title') %>
+
 <fieldset class="govuk-fieldset">
   <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
     <h1 class="govuk-fieldset__heading"><%=t('team.new.heading') %></h1>

--- a/app/views/user_journey/before_you_start.html.erb
+++ b/app/views/user_journey/before_you_start.html.erb
@@ -1,3 +1,5 @@
+<%= page_title t('user_journey.before_you_start.title') %>
+
 <%= render 'shared/certificate_details', certificate: @certificate %>
 
 <h1 class="govuk-heading-l"> <%= t 'user_journey.before_you_start.title' %></h1>

--- a/app/views/user_journey/check_your_certificate.html.erb
+++ b/app/views/user_journey/check_your_certificate.html.erb
@@ -1,3 +1,5 @@
+<%= page_title t('user_journey.certificate.title_check') %>
+
 <%= render 'shared/certificate_details', certificate: @certificate %>
 
 <h1 class="govuk-heading-l"><%= t 'user_journey.certificate.check_certificate_title' %></h1>

--- a/app/views/user_journey/confirmation.html.erb
+++ b/app/views/user_journey/confirmation.html.erb
@@ -1,3 +1,5 @@
+<%= page_title t('user_journey.confirmation.title') %>
+
 <%= render 'shared/certificate_details', certificate: @certificate %>
 
 <h1 class="govuk-heading-l"><%= t 'user_journey.adding_certificate_to_config' %></h1>

--- a/app/views/user_journey/index.html.erb
+++ b/app/views/user_journey/index.html.erb
@@ -1,3 +1,5 @@
+<%= page_title t('user_journey.title') %>
+
 <h1 class="govuk-heading-l"><%= t 'components.title' %></h1>
 
 <p><%= link_to t('user_journey.connection_broken_or_compromised'), t('user_journey.urls.connection_broken_or_compromised') %></p>

--- a/app/views/user_journey/upload_certificate.html.erb
+++ b/app/views/user_journey/upload_certificate.html.erb
@@ -1,3 +1,5 @@
+<%= page_title t('user_journey.certificate.title') %>
+
 <%= render 'shared/certificate_details', certificate: @certificate %>
 
 <div class="govuk-form-group">

--- a/app/views/user_journey/view_certificate.html.erb
+++ b/app/views/user_journey/view_certificate.html.erb
@@ -1,3 +1,5 @@
+<%= page_title t('user_journey.certificate.title_current') %>
+
 <% if @certificate.signing? && @certificate.component.enabled_signing_certificates.length == 2 %>
   <div class="govuk-error-summary <%= primary_signing_certificate?(@certificate) ? "govuk-error-summary--grey" : "govuk-error-summary--orange" %>" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
     <h2 class="govuk-error-summary__title" id="error-summary-title"><%= primary_signing_certificate?(@certificate) ? t('user_journey.adding_certificate_to_config') : t('user_journey.wait_for_an_email') %></h2>

--- a/app/views/users/index.erb
+++ b/app/views/users/index.erb
@@ -1,3 +1,5 @@
+<%= page_title t('users.title') %>
+
 <% if @gds && params['team_id'].nil? %>
   <h1 class="govuk-heading-xl"><%= t 'team.heading' %></h1>
   <ul class="govuk-list">

--- a/app/views/users/invite.erb
+++ b/app/views/users/invite.erb
@@ -1,3 +1,5 @@
+<%= page_title t('users.invite.title') %>
+
 <h1 class="govuk-heading-xl"><%= t 'users.invite.title' %></h1>
 
 <%= form_for @form, url: invite_to_team_post_path, class: 'govuk-form-group' do |f| %>

--- a/app/views/users/show.erb
+++ b/app/views/users/show.erb
@@ -1,3 +1,4 @@
+<%= page_title t('users.show.title', user: @team_member.full_name) %>
 
 <%= link_to t('common.back'), users_path, class: 'govuk-back-link' %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,6 +37,7 @@ en:
     gds_full: Government Digital Service
     gds: GDS
   login:
+    title: Log in
     heading: Log in
     login: Log in
     cancel: Cancel
@@ -52,7 +53,7 @@ en:
     errors:
       generic_error: "Something went wrong, try again"
   users:
-    title_no_team: Team members
+    title: Team members
     title_for_team: Team members for
     invite_button: Invite a new user
     change_link: Change details
@@ -74,6 +75,7 @@ en:
       cannot: Cannot
       legend: Permissions
     show:
+      title: "Manage user: %{name}"
       select_one: Select at least one
     update:
       button: Save
@@ -98,6 +100,7 @@ en:
     errors:
       invalid_user: User does not exist
   certificates:
+    title: Upload a new certificate
     caption: "%{heading}"
     header_id: ID
     header_name: Name
@@ -144,6 +147,9 @@ en:
     assume_roles_heading: "Switch Roles"
     assume_roles_legend: "Select which role(s) you wish to assume?"
   password:
+    title_change: Change your password
+    title_forgotten: Forgotten password
+    title_reset: Set up a new password
     forgot_link: Forgotten your password?
     forgot_password_legend: Enter your e-mail address below and we'll send you an e-mail with a code you can use to change your password.
     your_email_lbl: "Your e-mail address:"
@@ -195,10 +201,12 @@ en:
     main_layout:
       team_members: Team Members
   services:
+    title: Services
     heading: All services
     add_new: Add new service
     new:
-      heading: Add a Service
+      title: Create a new service
+      heading: Add a service
     service_name: Service name
     service_id: Service Entity ID
     create_service: Create service
@@ -209,11 +217,13 @@ en:
       problem: There is a problem
       authorisation: You are not authorised to perform this action
   team:
+    title: Teams
     heading: All teams
     name: Name
     add_team: Add new team
     associate_team: Associate team
     new:
+      title: New team
       heading: Add a team
       team_name_field: Team name
       create_team: Create team
@@ -226,6 +236,8 @@ en:
       name_not_unique: This team name is already being used, enter a unique one
   components:
     title: Manage certificates
+    new_sp_title: Create a new SP component
+    new_msa_title: Create a new MSA component
     name: Name
     team: Team
     entity_id: Entity ID
@@ -260,6 +272,7 @@ en:
     edit:
       heading: Associate team to
   user_journey:
+    title: Dashboard
     component_name:
       MSA: Matching Service Adapter
       VSP: Verify Service Provider
@@ -309,14 +322,15 @@ en:
       continue: Continue
       have_updated: I have updated my %{component} configuration
     certificate:
+      title: Upload or paste your new certificate
+      title_check: Check your new certificate
+      title_current: Current certificate
       component_name:
         MSA: "Matching Service Adapter: "
         VSP: "Verify Service Provider: "
         SP: "Service Provider: "
       check_certificate_title: Check you've uploaded the right certificate
       contains_the_following: "The certificate you uploaded contains the following information:"
-      date: Date
-      amount: Amount
       valid_from: Valid from
       valid_until: Valid until
       common_name: Common name
@@ -333,6 +347,7 @@ en:
       upload_certificate_file_body: Upload file
       paste_certificate: Paste certificate text into a text box
     confirmation:
+      title: Confirmation
       what_to_expect: This usually takes around 10 minutes. We'll email you when your new %{type} certificate is in use.
       next_steps: Next steps
       rotate_other_certificates: You can rotate other certificates straight away - you do not need to wait for the email.

--- a/spec/factories/components.rb
+++ b/spec/factories/components.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
 
   factory :msa_component do
     component_type { COMPONENT_TYPE::MSA }
+    name { 'Test MSA'}
     entity_id { 'https://test-entity-id' }
     team_id { create(:team).id }
     environment { 'staging' }


### PR DESCRIPTION
We had the page title static and fixed thorough the application.
This change makes the page title dynamic based on the view. I had to
retrospectively add the page titles to the views. This is particularly important
for any web analytics and for the users.

Also, I've added a check to raise an error if someone forgets to add a page title.