### PR TITLE
BAU: Remove the successful sign-in message

### DIFF
--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -52,7 +52,7 @@ en:
       updated: "Your account has been updated successfully."
       updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again"
     sessions:
-      signed_in: "Signed in successfully."
+      signed_in: ''
       signed_out: "Signed out successfully."
       already_signed_out: "Signed out successfully."
       InvalidPasswordException: "Your password must be at least 8 characters"

--- a/spec/system/sign_out_spec.rb
+++ b/spec/system/sign_out_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe 'Sign out', type: :system do
 
     user = FactoryBot.create(:user_manager_user)
     sign_in(user.email, user.password)
-    expect(page).to have_content t('devise.sessions.signed_in')
     click_link t('layout.application.sign_out_link')
 
     expect(current_path).to eql new_user_session_path

--- a/spec/system/visit_sign_in_spec.rb
+++ b/spec/system/visit_sign_in_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe 'Sign in', type: :system do
     sign_in(user.email, user.password)
 
     expect(current_path).to eql root_path
-    expect(page).to have_content t('devise.sessions.signed_in')
   end
 
   scenario 'user cant sign in with unsigned jwt' do
@@ -45,7 +44,6 @@ RSpec.describe 'Sign in', type: :system do
     fill_in "user[totp_code]", with: "000000"
     click_button(t('login.login'))
     expect(current_path).to eql root_path
-    expect(page).to have_content t('devise.sessions.signed_in')
     # Ensure session is cleaned up from flow
     expect(page.get_rack_session.has_key?(:cognito_session_id)).to eql false
     expect(page.get_rack_session.has_key?(:challenge_name)).to eql false
@@ -130,7 +128,6 @@ RSpec.describe 'Sign in', type: :system do
     fill_in "user[new_password]", with: "000000"
     click_button(t('login.login'))
     expect(current_path).to eql root_path
-    expect(page).to have_content t('devise.sessions.signed_in')
     # Ensure session is cleaned up from flow
     expect(page.get_rack_session.has_key?(:cognito_session_id)).to eql false
     expect(page.get_rack_session.has_key?(:challenge_name)).to eql false
@@ -152,7 +149,6 @@ RSpec.describe 'Sign in', type: :system do
     click_button(t('login.login'))
 
     expect(current_path).to eql root_path
-    expect(page).to have_content t('devise.sessions.signed_in')
     # Ensure session is cleaned up from flow
     expect(page.get_rack_session.has_key?(:cognito_session_id)).to eql false
     expect(page.get_rack_session.has_key?(:challenge_name)).to eql false


### PR DESCRIPTION
We don't need to display the "Signed in successfully." message to users if
they just logged in.