### PR TITLE
A9cbkuHm: Remove the dependency on to ruby-sass gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ yarn-error.log
 
 .generators
 .vscode
+
+# cached rubocop rules pulled locally
+.rubocop-h*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 -   repo: local
     hooks:
     -   id: lint
-        name: govuk linter
-        entry: bundle exec govuk-lint-ruby
+        name: rubocop
+        entry: rubocop
         files: (^app|^lib)
         language: system

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,14 @@
+inherit_from:
+  - https://raw.githubusercontent.com/alphagov/govuk-lint/master/configs/rubocop/all.yml
+
 Style/ConditionalAssignment:
   Enabled: false
 Style/StringLiterals:
   Enabled: false
+
+AllCops:
+  Include: 
+    - 'app/**/*.rb'
+    - 'lib/**/*.rb'
+  Exclude:
+    - 'bin/**'

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'pg'
 # Use Puma as the app server
 gem 'puma', '~> 3.11'
 # Use SCSS for stylesheets
-gem 'sass-rails', '~> 5.0'
+gem 'sassc-rails'
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes
@@ -56,7 +56,8 @@ group :development, :test do
   gem 'capybara'
   gem 'factory_bot_rails'
   gem 'geckodriver-helper'
-  gem 'govuk-lint'
+  gem 'rubocop'
+  gem 'rubocop-rails'
   gem 'pry'
   gem 'rack_session_access'
   gem 'rails-controller-testing'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,11 +127,6 @@ GEM
       archive-zip (~> 0.7)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    govuk-lint (4.0.1)
-      rubocop (~> 0.72)
-      rubocop-rails (~> 2)
-      rubocop-rspec (~> 1.28)
-      scss_lint
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
     io-like (0.3.0)
@@ -263,25 +258,17 @@ GEM
     rubocop-rails (2.3.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
-    rubocop-rspec (1.36.0)
-      rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
     rubyzip (2.0.0)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.1.0)
-      railties (>= 5.2.0)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
-    scss_lint (0.58.0)
-      rake (>= 0.9, < 13)
-      sass (~> 3.5, >= 3.5.5)
+    sassc (2.2.1)
+      ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     selenium-webdriver (3.142.6)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -338,7 +325,6 @@ DEPENDENCIES
   email_validator
   factory_bot_rails
   geckodriver-helper
-  govuk-lint
   jbuilder (~> 2.5)
   jwt
   kaminari (~> 1.1)
@@ -353,7 +339,9 @@ DEPENDENCIES
   request_store
   rqrcode
   rspec-rails (>= 4.0.0.beta2)
-  sass-rails (~> 5.0)
+  rubocop
+  rubocop-rails
+  sassc-rails
   selenium-webdriver
   sentry-raven
   spring

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ You can use `bundle exec rspec $PATH_TO_SPEC` to run individual spec files.
 
 ### Linting
 
-This is done using the [govuk-lint](https://github.com/alphagov/govuk-lint) gem. It runs with the pre-commit but you can also run it manually:
+This is done using Rubocop and the [govuk-lint](https://github.com/alphagov/govuk-lint) rules. It runs with the pre-commit but you can also run it manually:
 
-`bundle exec govuk-lint-ruby app lib`
+`bundle exec rubocop`
 
 To automagically fix any issues use the `-a` flag:
 
-`bundle exec govuk-lint-ruby app lib -a`
+`bundle exec rubocop -a`
 
 ## Licence
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -56,4 +56,8 @@ Rails.application.configure do
   config.cognito_aws_secret_access_key = ENV['COGNITO_AWS_SECRET_ACCESS_KEY']
   config.cognito_client_id = ENV['AWS_COGNITO_CLIENT_ID']
   config.cognito_user_pool_id = ENV['AWS_COGNITO_USER_POOL_ID']
+
+  # Set a css_compressor so sassc-rails does not overwrite the compressor when running the tests
+  # workaround until https://github.com/sass/libsass/milestone/35 is shipped
+  config.assets.css_compressor = nil
 end

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -31,7 +31,7 @@ else
   fi
 fi
 
-bundle exec govuk-lint-ruby app lib
+bundle exec rubocop
 
 bundle check || bundle install
 


### PR DESCRIPTION
- replaced `sass-rails` with `sassc-rails`
- the govuk-lint gem has a transient dependency on the unsupported `sass` gem
so I've removed the linter completely and instead use the rubocop directly
while still importing the linter rules from govuk-lint repo