### PR TITLE
BAU: Use specific rails version for Migration class

### DIFF
--- a/db/migrate/20190831100615_init_schema.rb
+++ b/db/migrate/20190831100615_init_schema.rb
@@ -1,4 +1,4 @@
-class InitSchema < ActiveRecord::Migration
+class InitSchema < ActiveRecord::Migration[6.0]
   def up
     # These are extensions that must be enabled in order to support this database
     enable_extension "pgcrypto"


### PR DESCRIPTION
This fixes an error that was occurring when running migrations.