### PR TITLE
BAU: Fix the assets issues

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -46,5 +46,9 @@ module VerifySelfService
 
     # The cache reload time for the JWKS file from amazon
     config.jwks_cache_expiry = 1.hour
+
+    # Set a css_compressor so sassc-rails does not overwrite the compressor when running 
+    # workaround until https://github.com/sass/libsass/milestone/35 is shipped
+    config.assets.css_compressor = nil
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -56,8 +56,4 @@ Rails.application.configure do
   config.cognito_aws_secret_access_key = ENV['COGNITO_AWS_SECRET_ACCESS_KEY']
   config.cognito_client_id = ENV['AWS_COGNITO_CLIENT_ID']
   config.cognito_user_pool_id = ENV['AWS_COGNITO_USER_POOL_ID']
-
-  # Set a css_compressor so sassc-rails does not overwrite the compressor when running the tests
-  # workaround until https://github.com/sass/libsass/milestone/35 is shipped
-  config.assets.css_compressor = nil
 end


### PR DESCRIPTION
The CSS compressor needs to be switched off in all the environments. This means
the deployed assets are not compressed/minifed.
This hopefully is a short-term solution until libsass gets an update - tracked https://github.com/sass/libsass/issues/2701 because govuk-frontend is not compatible with libsass (https://github.com/alphagov/govuk-frontend/issues/1350)