### PR TITLE
Q2W1VFPI: Enable deleting teams

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -8,6 +8,13 @@ class TeamsController < ApplicationController
     @team = NewTeamEvent.new
   end
 
+  def destroy
+    team = Team.find_by_id(params[:id])
+    change_event = DeleteTeamEvent.create(team: team, data: { group: team.name })
+    flash[:error] = change_event.errors.full_messages.join(', ') unless change_event.errors.empty?
+    redirect_to teams_path
+  end
+
   def create
     team_event = NewTeamEvent.create(team_params)
     @team = team_event.team

--- a/app/models/delete_team_event.rb
+++ b/app/models/delete_team_event.rb
@@ -1,0 +1,35 @@
+require 'auth/authentication_backend'
+
+class DeleteTeamEvent < AggregatedEvent
+  include AuthenticationBackend
+
+  belongs_to_aggregate :team
+  after_save :destroy
+
+  validate :delete_cognito_group
+
+  def attributes_to_apply
+    {}
+  end
+
+  def delete_cognito_group
+    if cognito_group_empty?
+      delete_group(name: team.team_alias)
+    else
+      errors.add(:team, I18n.t('team.errors.not_empty'))
+    end
+  rescue AuthenticationBackend::AuthenticationBackendException => e
+    Rails.logger.error("#{I18n.t('team.errors.failed_to_delete')} -> #{e.message}")
+    errors.add(:team, I18n.t('team.errors.failed_to_delete'))
+  end
+
+private
+
+  def destroy
+    team.destroy!
+  end
+
+  def cognito_group_empty?
+    get_users_in_group(group_name: team.team_alias).empty?
+  end
+end

--- a/app/policies/teams_controller_policy.rb
+++ b/app/policies/teams_controller_policy.rb
@@ -17,4 +17,8 @@ class TeamsControllerPolicy < ApplicationPolicy
   def create?
     user.permissions.team_management
   end
+
+  def destroy?
+    user.permissions.team_management
+  end
 end

--- a/app/views/admin/_team.erb
+++ b/app/views/admin/_team.erb
@@ -21,7 +21,7 @@
         <td class="govuk-table__cell"><%= team.updated_at %></td>
       </tr>
       <tr class="govuk-table__row">
-        <td class="govuk-table__cell govuk-table__cell--numeric" colspan="2"><%= link_to 'Manage', '', class: 'govuk-button', data: { module: 'govuk-button' } %></td>
+        <td class="govuk-table__cell govuk-table__cell--numeric" colspan="2"><%= link_to 'Delete', team_path(id: team.id), method: :delete, data: { confirm: 'Are you sure?' }, class: 'govuk-button govuk-button--warning' %></td>
       </tr>
     </tbody>
   </table>

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -14,8 +14,8 @@
         <tr class="govuk-table__row">
           <td class="govuk-table__cell" scope="row"><%= team.name %></td>
           <td class="govuk-table__cell govuk-table__cell--numeric" scope="row">
-          <%= link_to t('users.invite.button'), invite_to_team_path(team.id), class: 'govuk-button govuk-button--secondary'%>
-
+            <%= link_to t('users.invite.button'), invite_to_team_path(team.id), class: 'govuk-button govuk-button--secondary'%>
+            <%= link_to 'Delete', team_path(team.id), method: :delete, data: { confirm: 'Are you sure?' }, class: 'govuk-button govuk-button--warning' %>
           </td>
         </tr>
       <% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -67,12 +67,16 @@ Rails.application.configure do
   config.cognito_client_id = ENV['AWS_COGNITO_CLIENT_ID']
   config.cognito_user_pool_id = ENV['AWS_COGNITO_USER_POOL_ID']
 
+  # Increase the timeout for devs
+  config.session_expiry = 120.minutes
+  config.session_inactivity = 120.minutes
+
   # To seed Cognito and check data integrity (uncomment, if needed to be run):
-  config.after_initialize do
+   config.after_initialize do
   #   require 'auth/initial_seeder'
   #   InitialSeeder.new
   #
      require 'data/integrity_checker'
      IntegrityChecker.new
-  end
+   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -223,6 +223,8 @@ en:
     errors:
       errored: errored
       failed: Failed to create team
+      failed_to_delete: Failed to delete group
+      not_empty: Cannot delete team with members
       blank_name: Enter a team name
       name_not_unique: This team name is already being used, enter a unique one
   components:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  resources :teams, path: 'admin/teams', only: %i[index new create]
+  resources :teams, path: 'admin/teams'
 
   devise_for :users, controllers: { sessions: 'sessions' }
 

--- a/lib/auth/authentication_backend.rb
+++ b/lib/auth/authentication_backend.rb
@@ -85,6 +85,18 @@ module AuthenticationBackend
     raise AuthenticationBackendException.new(e)
   end
 
+  def delete_group(name:)
+    client.delete_group(
+      group_name: name,
+      user_pool_id: user_pool_id,
+    )
+  rescue Aws::CognitoIdentityProvider::Errors::ResourceNotFoundException
+    Rails.logger.warn('The group does not exist/already been deleted')
+    {}
+  rescue Aws::CognitoIdentityProvider::Errors::ServiceError => e
+    raise AuthenticationBackendException.new(e)
+  end
+
   # Returns a secret shared code to associate a TOTP app/device with
   def associate_device(access_token:)
     associate = client.associate_software_token(session: access_token)

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -55,4 +55,34 @@ RSpec.describe TeamsController, type: :controller do
       expect(flash.now[:success]).to be_nil
     end
   end
+
+  describe 'DELETE #destroy' do
+    let(:team) { create(:team, name: 'super-awesome-team-soon-to-be-deleted') }
+
+    it 'successfully deletes the team and group in cognito' do
+      Rails.configuration.cognito_user_pool_id = 'dummy'
+      stub_cognito_response( method: :delete_group, payload: {})
+      expect_any_instance_of(AuthenticationBackend).to receive(:delete_group)
+
+      delete :destroy, params: { id: team.id }
+
+      expect(subject).to redirect_to(teams_path)
+      expect(flash[:error]).to be_nil
+      expect(Team.exists?(team.id)).to be false
+    end
+
+    it 'does not delete team if delete a group in cognito fails' do
+      Rails.configuration.cognito_user_pool_id = 'dummy'
+      stub_cognito_response(
+        method: :delete_group,
+        payload: 'ServiceError'
+      )
+
+      delete :destroy, params: { id: team.id }
+
+      expect(subject).to redirect_to(teams_path)
+      expect(flash[:error]).to include(t('team.errors.failed_to_delete'))
+      expect(Team.exists?(team.id)).to be true
+    end
+  end
 end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -17,6 +17,10 @@ FactoryBot.define do
     name { SecureRandom.alphanumeric }
   end
 
+  factory :delete_team_event do
+    team { create(:team) }
+  end
+
   factory :replace_encryption_certificate_event do
     component { create(:sp_component) }
     encryption_certificate_id { create(:sp_encryption_certificate).id }

--- a/spec/models/delete_team_event_spec.rb
+++ b/spec/models/delete_team_event_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe DeleteTeamEvent, type: :model do
+  include CognitoSupport
+
+  context 'on successful team deletion' do
+    it 'team is deleted and event persisted' do
+      stub_cognito_response(method: :delete_group)
+      stub_cognito_response(method: :list_users_in_group, payload: [])
+      delete_team_event = create(:delete_team_event)
+      expect(delete_team_event).to be_valid
+      expect(delete_team_event).to be_persisted
+      expect(Team.exists?(delete_team_event.team.id)).to be false
+    end
+
+    it 'has delete team event' do
+      stub_cognito_response(method: :delete_group)
+      stub_cognito_response(method: :list_users_in_group, payload: [])
+      delete_team_event = create(:delete_team_event)
+      expect(delete_team_event).to eq DeleteTeamEvent.last
+    end
+
+    it 'team is delete even if Cognito group does not exist or has already been deleted' do
+      stub_cognito_response(method: :delete_group, payload: 'ResourceNotFoundException')
+      stub_cognito_response(method: :list_users_in_group, payload: [])
+      delete_team_event = create(:delete_team_event)
+      expect(delete_team_event).to be_valid
+      expect(delete_team_event).to be_persisted
+      expect(Team.exists?(delete_team_event.team.id)).to be false
+    end
+  end
+
+  context 'deletion fails' do
+    it 'when the team has members' do
+      stub_cognito_response(method: :delete_group)
+      stub_cognito_response(method: :list_users_in_group, payload: { users: [ { username: 'user'} ] })
+      existing_team = create(:team)
+      expect{ create(:delete_team_event, team: existing_team)}.to raise_error(ActiveRecord::RecordInvalid)
+      expect(Team.exists?(existing_team.id)).to be true
+    end
+    it 'when cognito call fails' do
+      stub_cognito_response(method: :delete_group, payload: 'ServiceError')
+      stub_cognito_response(method: :list_users_in_group, payload: [])
+      existing_team = create(:team)
+      expect{ create(:delete_team_event, team: existing_team)}.to raise_error(ActiveRecord::RecordInvalid)
+      expect(Team.exists?(existing_team.id)).to be true
+    end
+  end
+end


### PR DESCRIPTION
- added a new event DeleteTeamEvent to delete existing teams
- prevent deletion when team still has members
- revert if Cognito group cannot be deleted
- deletes team even if the corresponding cognito group doesn't exist