### PR TITLE
Fix: Multiple teams can be linked to a single cognito group 

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -18,7 +18,7 @@ class TeamsController < ApplicationController
   def create
     team_event = NewTeamEvent.create(team_params)
     @team = team_event.team
-    if @team.valid? && team_event.valid?
+    if @team.valid? && team_event.errors.empty?
       flash.now[:success] = "#{@team.name} #{t('team.new.success')}."
 
       redirect_to teams_path

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,4 +1,5 @@
 class Team < Aggregate
   has_many :components
   validates_uniqueness_of :name, message: I18n.t('team.errors.name_not_unique')
+  validates_uniqueness_of :team_alias, message: I18n.t('team.errors.name_not_unique')
 end

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :team do
     name { 'Team ' + SecureRandom.alphanumeric }
-    team_alias { 'testteam' }
+    team_alias { 'team' + SecureRandom.alphanumeric }
   end
 end

--- a/spec/models/new_team_event_spec.rb
+++ b/spec/models/new_team_event_spec.rb
@@ -24,5 +24,12 @@ RSpec.describe NewTeamEvent, type: :model do
       error_message_on_name = event.errors[:name].first
       expect(error_message_on_name).to eq t('team.errors.blank_name')
     end
+
+    it 'when team already exists with a different name but same resulting alias' do
+      existing_team = create(:team, name: 'test team name', team_alias: 'testteamname')
+      new_team_event = NewTeamEvent.create(name: 'testteamname')
+      expect(new_team_event.team.valid?).to be false
+      expect(new_team_event).not_to be_persisted
+    end
   end
 end

--- a/spec/models/upload_certificate_event_spec.rb
+++ b/spec/models/upload_certificate_event_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
   root = PKI.new
   entity_id = 'http://test-entity-id'
   good_cert_value = root.generate_encoded_cert(expires_in: 2.months)
-  team = Team.create(name: SecureRandom.alphanumeric, id: SecureRandom.uuid)
+  team = Team.create(name: SecureRandom.alphanumeric, id: SecureRandom.uuid, team_alias: SecureRandom.alphanumeric)
   component = NewMsaComponentEvent.create(
     name: 'fake_name', entity_id: entity_id, team_id: team.id, environment: 'staging'
   ).msa_component


### PR DESCRIPTION
and that's bad!

- `team_alias` is the team name without spaces (as cognito does not support group names with spaces)
- we were only validating on team name, so `team one` would create a group in with name of `teamone`
and `teamone` name would link to it too since the alias would ended up the same
- made sure we validate the `team_alias` in addition to the team name

Also fixed our code calling cognito twice
- When create the NewTeamEvent it creates a team and a group in cognito (as part of validation).
However, we call `NewTeamEvent.valid?` later in the code which runs the
validators again, (which means calling cognito again).