### PR TITLE
hNmxRDdx: Correct the DEPLOYING status on signing certs

### DIFF
--- a/app/helpers/user_journey_helper.rb
+++ b/app/helpers/user_journey_helper.rb
@@ -7,6 +7,10 @@ module UserJourneyHelper
     certificate == certificate.component.enabled_signing_certificates.second
   end
 
+  def deployment_in_progress?(certificate)
+    certificate.component.enabled_signing_certificates.first.deploying?
+  end
+
   def position(certificate)
     primary_signing_certificate?(certificate) ? 'primary' : 'secondary'
   end
@@ -16,7 +20,7 @@ module UserJourneyHelper
       "MISSING"
     elsif certificate.expires_soon?
       "EXPIRES IN #{(certificate.x509.not_after.to_date - Time.now.to_date).to_i} DAYS"
-    elsif certificate.component.enabled_signing_certificates.length == 2 && primary_signing_certificate?(certificate)
+    elsif certificate.deploying?
       "DEPLOYING"
     else
       "IN USE"

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -27,4 +27,8 @@ class Certificate < Aggregate
   def expires_soon?
     x509.not_after - Time.now < 30.day
   end
+
+  def deploying?
+    updated_at >= 10.minutes.ago
+  end
 end

--- a/app/views/shared/_user_component_certificates.html.erb
+++ b/app/views/shared/_user_component_certificates.html.erb
@@ -19,7 +19,7 @@
           <tr class="govuk-table__row" id="<%= component.encryption_certificate_id %>">
             <td class="govuk-table__cell"><%= link_to t('user_journey.encryption_certificate'), view_certificate_path(component.component_type, component.id, component.encryption_certificate_id) %></td>
             <td class="govuk-table__cell">
-              <div class="app-certificate-tag <%= 'app-certificate-tag-expiring' if component.encryption_certificate.expires_soon? %>">
+              <div class="app-certificate-tag <%= 'app-certificate-tag-expiring' if component.encryption_certificate.expires_soon? %> <%= 'app-certificate-tag-deploying' if component.encryption_certificate.deploying? %>">
                 <strong class="govuk-tag"><%= certificate_status(component.encryption_certificate) %></strong>
               </div>
             </td>
@@ -42,7 +42,7 @@
               <% end %>
             </td>
             <td class="govuk-table__cell">
-              <div class="app-certificate-tag <%= 'app-certificate-tag-deploying' if position(signing) == 'primary' && component.enabled_signing_certificates.length == 2 %><%= 'app-certificate-tag-expiring' if signing.expires_soon? %>">
+              <div class="app-certificate-tag <%= 'app-certificate-tag-deploying' if signing.deploying? %><%= 'app-certificate-tag-expiring' if signing.expires_soon? %>">
                 <strong class="govuk-tag"><%= certificate_status(signing) %></strong>
               </div>
             </td>

--- a/app/views/user_journey/view_certificate.html.erb
+++ b/app/views/user_journey/view_certificate.html.erb
@@ -1,19 +1,25 @@
 <%= page_title t('user_journey.certificate.title_current') %>
 
 <% if @certificate.signing? && @certificate.component.enabled_signing_certificates.length == 2 %>
-  <div class="govuk-error-summary <%= primary_signing_certificate?(@certificate) ? "govuk-error-summary--grey" : "govuk-error-summary--orange" %>" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
-    <h2 class="govuk-error-summary__title" id="error-summary-title"><%= primary_signing_certificate?(@certificate) ? t('user_journey.adding_certificate_to_config') : t('user_journey.wait_for_an_email') %></h2>
-    <div class="govuk-error-summary__body">
-      <% if primary_signing_certificate?(@certificate) %>
-        <p><%= t 'user_journey.we_will_email_you' %></p>
-        <p><%= t('user_journey.add_new_signing_key_warning', component: @certificate.component.display, date: date_to_readable_long_format(@certificate.x509.not_after)) %></p>
-      <% elsif secondary_signing_certificate?(@certificate) %>
+  <% if primary_signing_certificate?(@certificate) && @certificate.deploying? %>
+    <div class="govuk-error-summary govuk-error-summary--grey" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
+      <h2 class="govuk-error-summary__title" id="error-summary-title"><%= t('user_journey.adding_certificate_to_config') %></h2>
+      <div class="govuk-error-summary__body">
+        <p><%= t('user_journey.we_will_email_you') %></p>
+        <p><%= t('user_journey.add_new_signing_key_warning', component: @certificate.component.display, date: date_to_readable_long_format(@certificate.x509.not_after)) %></p>      
+        <p><%= render 'shared/component_certificate_doc_links', certificate: @certificate %></p>
+      </div>
+    </div>
+  <% elsif secondary_signing_certificate?(@certificate) && deployment_in_progress?(@certificate) %>
+    <div class="govuk-error-summary govuk-error-summary--orange" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
+      <h2 class="govuk-error-summary__title" id="error-summary-title"><%= t('user_journey.wait_for_an_email') %></h2>
+      <div class="govuk-error-summary__body">      
         <p><%= t 'user_journey.how_long_it_takes' %></p>
         <p><%= t('user_journey.delete_old_signing_key_and_cert', component: @certificate.component.display) %></p>
-      <% end %>
-      <p><%= render 'shared/component_certificate_doc_links', certificate: @certificate %></p>
+        <p><%= render 'shared/component_certificate_doc_links', certificate: @certificate %></p>
+      </div>
     </div>
-  </div>
+  <% end %>  
 <% end %>
 
 <h1 class="govuk-heading-l">
@@ -25,13 +31,18 @@
 </h1>
 
 <%= render 'shared/user_certificate_view', certificate: @certificate, full_details: true %>
-<% if @certificate.signing? %>
+
+<% if @certificate.encryption? %>
+  <% if @certificate.component.type == COMPONENT_TYPE::SP_SHORT %>
+    <%= link_to t('user_journey.certificate.replace'), dual_running_path, class: "govuk-button", data: { module: "govuk-button" }, role:"button" %>
+  <% else %>
+    <%= link_to t('user_journey.certificate.replace'), before_you_start_path, class: "govuk-button", data: { module: "govuk-button" }, role:"button" %>
+  <% end %>
+
+<% else %>
   <% if @certificate.component.enabled_signing_certificates.length < 2 %>
     <%= link_to t('user_journey.certificate.add_new'), before_you_start_path, class: "govuk-button", data: { module: "govuk-button" }, role:"button" %> 
+  <% elsif secondary_signing_certificate?(@certificate) && !deployment_in_progress?(@certificate) %>
+    TODO: OPTION TO REMOVE/DISABLE OLD CERT
   <% end %>
-<% elsif @certificate.component.display == COMPONENT_TYPE::SP_LONG && @certificate.encryption? %>
-  <%= link_to t('user_journey.certificate.replace'), dual_running_path, class: "govuk-button", data: { module: "govuk-button" }, role:"button" %>
-<% else %>
-  <%= link_to t('user_journey.certificate.replace'), before_you_start_path, class: "govuk-button", data: { module: "govuk-button" }, role:"button" %>
 <% end %>
-


### PR DESCRIPTION
Until now the status was driven by the number of enabled signing certs on the component.
This PR adds the real logic with a 10 minute period for which it will
display the deploying status and all the corresponding messages on
primary/secondary certs. I also reshuffled the logic slightly to be more readable.

In the follow-up PR I'll do the encryption cert logic and the TODO bit.