### PR TITLE
I7IBiAot Allow users to change their own MFA settings

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,9 +1,4 @@
-require 'rqrcode'
-require 'erb'
-
 class SessionsController < Devise::SessionsController
-  include ERB::Util
-  include AuthenticationBackend
   include MfaQrHelper
 
   layout 'full_width_layout'

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,6 +4,8 @@ require 'erb'
 class SessionsController < Devise::SessionsController
   include ERB::Util
   include AuthenticationBackend
+  include MfaQrHelper
+
   layout 'full_width_layout'
 
   before_action :load_secret_code, only: %i(create new)
@@ -44,17 +46,7 @@ class SessionsController < Devise::SessionsController
   end
 
   def load_secret_code
-    generate_new_qr unless session[:secret_code].nil?
-  end
-
-private
-
-  def generate_new_qr
     @secret_code = session[:secret_code]
-    issuer = "GOV.UK Verify Admin Tool"
-    issuer += " (#{Rails.env})" unless Rails.env.production?
-    encoded_issuer = url_encode(issuer)
-    qrcode = RQRCode::QRCode.new("otpauth://totp/#{encoded_issuer}:#{url_encode(session[:email])}?secret=#{@secret_code}&issuer=#{encoded_issuer}")
-    @secret_code_svg = qrcode.as_svg(module_size: 3)
+    @secret_code_svg = generate_new_qr(secret_code: session[:secret_code], email: session[:email]) unless session[:secret_code].nil?
   end
 end

--- a/app/helpers/mfa_qr_helper.rb
+++ b/app/helpers/mfa_qr_helper.rb
@@ -1,0 +1,15 @@
+require 'rqrcode'
+require 'erb'
+
+module MfaQrHelper
+  include ERB::Util
+  include AuthenticationBackend
+
+  def generate_new_qr(secret_code:, email:)
+    issuer = "GOV.UK Verify Admin Tool"
+    issuer += " (#{Rails.env})" unless Rails.env.production?
+    encoded_issuer = url_encode(issuer)
+    qrcode = RQRCode::QRCode.new("otpauth://totp/#{encoded_issuer}:#{url_encode(email)}?secret=#{secret_code}&issuer=#{encoded_issuer}")
+    qrcode.as_svg(module_size: 3)
+  end
+end

--- a/app/models/mfa_enrolment_form.rb
+++ b/app/models/mfa_enrolment_form.rb
@@ -1,11 +1,11 @@
 class MfaEnrolmentForm
   include ActiveModel::Model
 
-  attr_reader :code
+  attr_reader :totp_code
 
-  validates_presence_of :code
+  validates_presence_of :totp_code
 
   def initialize(hash)
-    @code = hash[:code]
+    @totp_code = hash[:totp_code]
   end
 end

--- a/app/models/mfa_enrolment_form.rb
+++ b/app/models/mfa_enrolment_form.rb
@@ -5,7 +5,7 @@ class MfaEnrolmentForm
 
   validates_presence_of :totp_code
 
-  def initialize(hash)
+  def initialize(hash = {})
     @totp_code = hash[:totp_code]
   end
 end

--- a/app/policies/profile_controller_policy.rb
+++ b/app/policies/profile_controller_policy.rb
@@ -22,4 +22,24 @@ class ProfileControllerPolicy < ApplicationPolicy
 
     true
   end
+
+  def setup_mfa?
+    true
+  end
+
+  def show_change_mfa?
+    true
+  end
+
+  def change_mfa?
+    true
+  end
+
+  def request_new_code?
+    true
+  end
+
+  def warn_mfa?
+    true
+  end
 end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -6,7 +6,7 @@
         <% if %w[SOFTWARE_TOKEN_MFA SMS_MFA].include? session[:challenge_name] %>
             <%= render "mfa_form", f:f %>
         <% elsif session[:challenge_name] == 'MFA_SETUP'%>
-            <%= render "mfa_enrolment", f:f %>
+            <%= render "shared/mfa_enrolment", f:f %>
         <% elsif session[:challenge_name] == "NEW_PASSWORD_REQUIRED" %>
             <%= render "new_password_required_form", f:f %>
         <% else %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -72,14 +72,14 @@
 
     <div class="govuk-width-container">
       <main class="govuk-main-wrapper " id="main-content" role="main">
-        <% if flash.present? %>
+        <% if flash.present? && (flash.keys & %w[error errors notice success warn alert]).size > 0 %>
           <div class="govuk-warning-text">
             <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
             <strong class="govuk-warning-text__text">
               <span class="govuk-warning-text__assistive"><%= t 'layout.application.warning' %></span>
               <% flash.each do |name, msg| -%>
-                <%= t('layout.application.message', message: msg) %>
-                <% end -%>
+                <% if %w(error errors warn notice success alert).include?(name) %><%= t('layout.application.message', message: msg) %><% end %>
+              <% end -%>
             </strong>
           </div>
         <% end %>

--- a/app/views/profile/show.html.erb
+++ b/app/views/profile/show.html.erb
@@ -30,8 +30,18 @@
     </tr>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell"><%= t 'profile.mfa' %></td>
-      <td class="govuk-table__cell"><%= t 'profile.set_up' %></td>
-      <td class="govuk-table__cell"></td>
+      <td class="govuk-table__cell">
+        <% unless @mfa_status ==  'SOFTWARE_TOKEN_MFA'%>
+          <%= link_to t('profile.set_up'), setup_mfa_path, class: 'govuk-link' %>
+        <% else %>
+          <%= t 'profile.software_token' %>
+        <% end %>
+      </td>
+      <td class="govuk-table__cell">
+        <% if @mfa_status ==  'SOFTWARE_TOKEN_MFA' %>
+          <%= link_to t('profile.change'), profile_update_mfa_path, class: 'govuk-link' %>
+        <% end %>
+      </td>
     </tr>
   </tbody>
 </table>

--- a/app/views/profile/show.html.erb
+++ b/app/views/profile/show.html.erb
@@ -31,15 +31,15 @@
     <tr class="govuk-table__row">
       <td class="govuk-table__cell"><%= t 'profile.mfa' %></td>
       <td class="govuk-table__cell">
-        <% unless @mfa_status ==  'SOFTWARE_TOKEN_MFA'%>
-          <%= link_to t('profile.set_up'), setup_mfa_path, class: 'govuk-link' %>
-        <% else %>
+        <% if @mfa_status ==  'SOFTWARE_TOKEN_MFA'%>
           <%= t 'profile.software_token' %>
         <% end %>
       </td>
       <td class="govuk-table__cell">
         <% if @mfa_status ==  'SOFTWARE_TOKEN_MFA' %>
           <%= link_to t('profile.change'), profile_update_mfa_path, class: 'govuk-link' %>
+        <% else %>
+          <%= link_to t('profile.set_up'), setup_mfa_path, class: 'govuk-link' %>
         <% end %>
       </td>
     </tr>

--- a/app/views/profile/show_change_mfa.html.erb
+++ b/app/views/profile/show_change_mfa.html.erb
@@ -1,6 +1,8 @@
+<%= page_title t('profile.mfa_prefs_title') %>
+
 <%= form_for @form, url: update_mfa_post_path do |f| %>
   <%= render "shared/mfa_enrolment", f:f %>
-  <%= f.submit 'Confirm Code', class: "govuk-button govuk-!-margin-right-1", data: { module: "govuk-button" } %>
-  <% unless flash[:retry].nil? %><%= link_to 'Request new code', request_new_code_path, class: "govuk-button govuk-button--secondary" %><% end %>
+  <%= f.submit t('profile.confirm'), class: "govuk-button govuk-!-margin-right-1", data: { module: "govuk-button" } %>
+  <% unless flash[:retry].nil? %><%= link_to t('profile.new_code'), request_new_code_path, class: "govuk-button govuk-button--secondary" %><% end %>
   <%= link_to t('login.cancel'), profile_path , class: "govuk-button govuk-button--secondary", data: { module: "govuk-button" } %>
 <% end %>

--- a/app/views/profile/show_change_mfa.html.erb
+++ b/app/views/profile/show_change_mfa.html.erb
@@ -1,6 +1,6 @@
 <%= form_for @form, url: update_mfa_post_path do |f| %>
   <%= render "shared/mfa_enrolment", f:f %>
   <%= f.submit 'Confirm Code', class: "govuk-button govuk-!-margin-right-1", data: { module: "govuk-button" } %>
-  <% if session[:retry] == true %><%= link_to 'Request new code', request_new_code_path, class: "govuk-button govuk-button--secondary" %><% end %>
+  <% unless flash[:retry].nil? %><%= link_to 'Request new code', request_new_code_path, class: "govuk-button govuk-button--secondary" %><% end %>
   <%= link_to t('login.cancel'), profile_path , class: "govuk-button govuk-button--secondary", data: { module: "govuk-button" } %>
 <% end %>

--- a/app/views/profile/show_change_mfa.html.erb
+++ b/app/views/profile/show_change_mfa.html.erb
@@ -1,0 +1,6 @@
+<%= form_for @form, url: update_mfa_post_path do |f| %>
+  <%= render "shared/mfa_enrolment", f:f %>
+  <%= f.submit 'Confirm Code', class: "govuk-button govuk-!-margin-right-1", data: { module: "govuk-button" } %>
+  <% if session[:retry] == true %><%= link_to 'Request new code', request_new_code_path, class: "govuk-button govuk-button--secondary" %><% end %>
+  <%= link_to t('login.cancel'), profile_path , class: "govuk-button govuk-button--secondary", data: { module: "govuk-button" } %>
+<% end %>

--- a/app/views/profile/warn_mfa.html.erb
+++ b/app/views/profile/warn_mfa.html.erb
@@ -1,0 +1,14 @@
+<%= page_title t('password.title_change') %>
+
+<h1 class="govuk-heading-l"><%= t 'profile.update_token_heading' %></h1>
+
+<div class="govuk-warning-text">
+  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+  <strong class="govuk-warning-text__text">
+    <span class="govuk-warning-text__assistive">Warning</span>
+    Once you click continue your existing software token will no longer be valid.
+  </strong>
+</div>
+
+<%= link_to t('user_journey.continue'), profile_update_mfa_get_code_path, class: "govuk-button govuk-!-margin-right-1", data: { module: "govuk-button" } %>
+<%= link_to t('login.cancel'), profile_path , class: "govuk-button govuk-button--secondary", data: { module: "govuk-button" } %>

--- a/app/views/profile/warn_mfa.html.erb
+++ b/app/views/profile/warn_mfa.html.erb
@@ -1,14 +1,16 @@
-<%= page_title t('password.title_change') %>
+<%= page_title t('profile.mfa_prefs_title') %>
 
 <h1 class="govuk-heading-l"><%= t 'profile.update_token_heading' %></h1>
 
 <div class="govuk-warning-text">
   <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
   <strong class="govuk-warning-text__text">
-    <span class="govuk-warning-text__assistive">Warning</span>
-    Once you click continue your existing software token will no longer be valid.
+    <span class="govuk-warning-text__assistive"><%= t 'layout.application.warning'%></span>
+    <%= t 'profile.mfa_warning'%>
   </strong>
 </div>
 
-<%= link_to t('user_journey.continue'), profile_update_mfa_get_code_path, class: "govuk-button govuk-!-margin-right-1", data: { module: "govuk-button" } %>
-<%= link_to t('login.cancel'), profile_path , class: "govuk-button govuk-button--secondary", data: { module: "govuk-button" } %>
+<%= link_to t('user_journey.continue'), profile_update_mfa_get_code_path, 
+  class: "govuk-button govuk-!-margin-right-1", data: { module: "govuk-button" } %>
+<%= link_to t('login.cancel'), profile_path , 
+  class: "govuk-button govuk-button--secondary", data: { module: "govuk-button" } %>

--- a/app/views/shared/_mfa_enrolment.erb
+++ b/app/views/shared/_mfa_enrolment.erb
@@ -1,29 +1,28 @@
-<h1 class="govuk-heading-xl"><%= t('mfa_enrolment.heading') %></h1>
-
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-half">
-
-      <%= f.label :totp_code, class: "govuk-label" %>
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl"><%= t('mfa_enrolment.heading') %></h1>
+    <p class="govuk-body"><%= t('mfa_enrolment.description') %></p>
+      <div id="qr-code">  
+          <%= raw(@secret_code_svg) %>
+      </div>
+    <p class="govuk-body"> 
+      <details class="govuk-details" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+          <span class="govuk-details__summary-text">
+            <%= t('mfa_enrolment.no_qr') %>
+          </span>
+        </summary>
+        <div class="govuk-details__text">
+          <%= t('mfa_enrolment.no_qr_instructions') %>
+          <pre><%= @secret_code %></pre>
+        </div>
+      </details>
+    </p>
+    <div class="govuk-form-group">
+      <h4 class="govuk-heading-s"><%= t('mfa_enrolment.heading_code_entry') %></h4>
+      <%= f.label :totp_code, t('mfa_enrolment.code_entry'), class: "govuk-label" %>
       <%= f.text_field :totp_code, autofocus: true, autocomplete: 'off', class: "govuk-input govuk-input--width-10" %>
       <%= f.hidden_field :email, value: { email: false } %>
-
-  </div>
-
-  <div class="govuk-grid-column-one-half">
-    <div class="mfa-qr-code">
-      <%= raw(@secret_code_svg) %>
     </div>
   </div>
 </div>
-<details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">
-      <%= t('mfa_enrolment.no_qr') %>
-    </span>
-  </summary>
-  <div class="govuk-details__text">
-    <%= t('mfa_enrolment.no_qr_instructions') %>
-    <pre><%= @secret_code %></pre>
-  </div>
-</details>
-

--- a/app/views/shared/_mfa_enrolment.erb
+++ b/app/views/shared/_mfa_enrolment.erb
@@ -1,0 +1,29 @@
+<h1 class="govuk-heading-xl"><%= t('mfa_enrolment.heading') %></h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-half">
+
+      <%= f.label :totp_code, class: "govuk-label" %>
+      <%= f.text_field :totp_code, autofocus: true, autocomplete: 'off', class: "govuk-input govuk-input--width-10" %>
+      <%= f.hidden_field :email, value: { email: false } %>
+
+  </div>
+
+  <div class="govuk-grid-column-one-half">
+    <div class="mfa-qr-code">
+      <%= raw(@secret_code_svg) %>
+    </div>
+  </div>
+</div>
+<details class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      <%= t('mfa_enrolment.no_qr') %>
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    <%= t('mfa_enrolment.no_qr_instructions') %>
+    <pre><%= @secret_code %></pre>
+  </div>
+</details>
+

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,8 +38,8 @@ module VerifySelfService
 
     config.i18n.default_locale = :en
 
-    # User will be timed out after 90 minutes regardless of activity
-    config.session_expiry = 90.minutes
+    # User will be timed out after 60 minutes regardless of activity
+    config.session_expiry = 60.minutes
 
     # User will be timed out after 15 minutes of inactivity
     config.session_inactivity = 15.minutes

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -33,8 +33,8 @@ Rails.application.configure do
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
 
-  # User will be timed out after 90 minutes regardless of activity
-  # config.session_expiry = 90.minutes
+  # User will be timed out after 60 minutes regardless of activity
+  # config.session_expiry = 60.minutes
 
   # User will be timed out after 15 minutes of inactivity
   # config.session_inactivity = 15.minutes

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -143,6 +143,9 @@ en:
     password: Password
     change: Change
     mfa: Multi-factor authentication
+    software_token: 2nd Factor Authentication Present
+    update_token_heading: Update your 2nd factor software token
+    mfa_success: Your 2nd factor authentication preferences have been updated.
     set_up: Set up
     permissions: Your permissions
     dev: DEV

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -143,7 +143,11 @@ en:
     password: Password
     change: Change
     mfa: Multi-factor authentication
-    software_token: Multi-Factor Authentication Present
+    new_code: Request new code
+    confirm: Confirm Code
+    mfa_prefs_title: Multi-Factor Authentication Preferences
+    mfa_warning: Once you click continue your existing software token will no longer be valid.
+    software_token: Multi-factor authentication present
     update_token_heading: Update your multi-factor software token
     mfa_success: Your multi-factor authentication configuration have been updated.
     mfa_setup_correctly: Multi-factor authentication setup correctly

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -143,9 +143,10 @@ en:
     password: Password
     change: Change
     mfa: Multi-factor authentication
-    software_token: 2nd Factor Authentication Present
-    update_token_heading: Update your 2nd factor software token
-    mfa_success: Your 2nd factor authentication preferences have been updated.
+    software_token: Multi-Factor Authentication Present
+    update_token_heading: Update your multi-factor software token
+    mfa_success: Your multi-factor authentication configuration have been updated.
+    mfa_setup_correctly: Multi-factor authentication setup correctly
     set_up: Set up
     permissions: Your permissions
     dev: DEV

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,11 @@ Rails.application.routes.draw do
 
   get '/profile/change-password', to: 'password#password_form'
   post '/profile/change-password', to: 'password#update_password'
+  get '/profile/setup-mfa', to: 'profile#setup_mfa', as: :setup_mfa
+  get '/profile/update-mfa/new-code', to: 'profile#request_new_code', as: :request_new_code
+  get '/profile/update-mfa', to: 'profile#warn_mfa'
+  get '/profile/update-mfa/get-code', to: 'profile#show_change_mfa'
+  post '/profile/update-mfa', to: 'profile#change_mfa', as: :update_mfa_post
   get 'forgot-password', to: 'password#forgot_form'
   post 'forgot-password', to: 'password#send_code'
   get 'reset-password', to: 'password#user_code'

--- a/spec/controllers/profile_controller_spec.rb
+++ b/spec/controllers/profile_controller_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe ProfileController, type: :controller do
       expect(subject).to redirect_to(profile_path)
     end
 
-    it 'redirects to change mfa' do
+    it 'redirects to change mfa when cognito returns an error' do
       usermgr_stub_auth
       stub_cognito_response(
         method: :set_user_mfa_preference,
@@ -77,6 +77,13 @@ RSpec.describe ProfileController, type: :controller do
     it 'renders the page again if form is not valid' do
       usermgr_stub_auth
       post :change_mfa, params: { mfa_enrolment_form: { 'totp_code': nil } }
+      expect(response).to have_http_status(:bad_request)
+      expect(subject).to render_template(:show_change_mfa)
+    end
+
+    it 'renders the page again if params is missing' do
+      usermgr_stub_auth
+      post :change_mfa
       expect(response).to have_http_status(:bad_request)
       expect(subject).to render_template(:show_change_mfa)
     end

--- a/spec/models/mfa_enrolment_form_spec.rb
+++ b/spec/models/mfa_enrolment_form_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe MfaEnrolmentForm, type: :model do
 
   it 'is valid with valid attributes' do
-    expect(MfaEnrolmentForm.new({ code: 'abcdefg' })).to be_valid
+    expect(MfaEnrolmentForm.new({ totp_code: 'abcdefg' })).to be_valid
   end
 
   it 'is not valid with no params' do

--- a/spec/system/sign_out_spec.rb
+++ b/spec/system/sign_out_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Sign out', type: :system do
   end
 
   scenario 'user signed out after inactiviy' do
-    Rails.configuration.session_expiry_in_minutes = 90.minutes
+    Rails.configuration.session_expiry_in_minutes = 60.minutes
     Rails.configuration.session_inactivity_in_minutes = 15.minutes
     cognito_stubs
 

--- a/spec/system/visit_mfa_preferences_spec.rb
+++ b/spec/system/visit_mfa_preferences_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'MFA Preferences page', type: :system do
       visit profile_update_mfa_get_code_path
       expect(current_path).to eql profile_update_mfa_get_code_path
       expect(page).to have_content secret_code
-      expect(page).to have_selector(".mfa-qr-code svg")
+      expect(page).to have_selector("#qr-code")
 
       fill_in "mfa_enrolment_form[totp_code]", with: "000000"
       click_button(t('profile.confirm'))

--- a/spec/system/visit_mfa_preferences_spec.rb
+++ b/spec/system/visit_mfa_preferences_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe 'MFA Preferences page', type: :system do
+  before(:each) do
+    login_user
+  end
+
+  context 'warning page' do
+    it 'shows content' do
+      visit profile_update_mfa_path
+
+      expect(page).to have_content t('profile.mfa_warning')
+      expect(current_path).to eql profile_update_mfa_path
+    end
+  end
+
+  context 'mfa preferences page' do
+    it 'visitng, gives a code, clicking change returns to profile' do
+      secret_code = 'OC7YQ4VYEVRWQGIKSXV25B3MZUV355I5XUKKM4P7KGTO72OTXXUQ'
+      stub_cognito_response(method: :associate_software_token, payload: { secret_code: secret_code })
+      stub_cognito_response(method: :verify_software_token, payload: { status: "SUCCESS" })
+      visit profile_update_mfa_get_code_path
+      expect(current_path).to eql profile_update_mfa_get_code_path
+      expect(page).to have_content secret_code
+      expect(page).to have_selector(".mfa-qr-code svg")
+
+      fill_in "mfa_enrolment_form[totp_code]", with: "000000"
+      click_button(t('profile.confirm'))
+
+      expect(current_path).to eql profile_path
+    end
+  end
+
+  context 'mfa preferences journey' do
+  end
+end

--- a/spec/system/visit_profile_page_spec.rb
+++ b/spec/system/visit_profile_page_spec.rb
@@ -11,5 +11,34 @@ RSpec.describe 'Profile page', type: :system do
       expect(page).to have_content t('profile.title')
       expect(current_path).to eql profile_path
     end
+
+    it 'should show profile page with mfa setup' do
+      user_info = { username: "00000000-0000-0000-0000-000000000000",
+                    user_attributes: [],
+                    mfa_options: nil,
+                    preferred_mfa_setting: nil,
+                    user_mfa_setting_list: nil,
+                  }
+      stub_cognito_response(method: :get_user, payload: user_info)
+      visit profile_path
+
+      expect(page).to have_content "#{t('profile.mfa')} #{t('profile.set_up')}"
+      expect(current_path).to eql profile_path
+    end
+
+    it 'should show profile page with change mfa' do
+      user_info = { username: "00000000-0000-0000-0000-000000000000",
+                    user_attributes: [],
+                    mfa_options: nil,
+                    preferred_mfa_setting: "SOFTWARE_TOKEN_MFA",
+                    user_mfa_setting_list: [ "SOFTWARE_TOKEN_MFA" ],
+                  }
+      stub_cognito_response(method: :get_user, payload: user_info)
+      visit profile_path
+
+      expect(page).to have_content "#{t('profile.mfa')} #{t('profile.software_token')} #{t('profile.change')}"
+      expect(current_path).to eql profile_path
+    end
   end
 end
+


### PR DESCRIPTION
Users probably need a way to reset their own TOTP device if they for example upgrade their phone or move to a new TOTP app. This is important as if a user losses their TOTP device then there is no way for an admin to reset this on their behalf. 