### PR TITLE
1NDRKTxw: Support for disabling certs

### DIFF
--- a/app/controllers/user_journey_controller.rb
+++ b/app/controllers/user_journey_controller.rb
@@ -41,6 +41,16 @@ class UserJourneyController < ApplicationController
     )
   end
 
+  def disable_certificate
+    event = DisableSigningCertificateEvent.create(certificate: @certificate)
+    if event.errors.empty?
+      redirect_to root_path
+    else
+      flash[:error] = event.errors.full_messages
+      render :view_certificate
+    end
+  end
+
   def submit
     extractor = CertificateExtractor.new(params)
 

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -26,6 +26,7 @@ class GroupPolicy < ApplicationPolicy
   alias_method :submit?, :team_authorized?
   alias_method :confirmation?, :team_authorized?
   alias_method :confirm?, :team_authorized?
+  alias_method :disable_certificate?, :team_authorized?
 
 private
 

--- a/app/policies/user_journey_controller_policy.rb
+++ b/app/policies/user_journey_controller_policy.rb
@@ -18,6 +18,10 @@ class UserJourneyControllerPolicy < ApplicationPolicy
     user.permissions.certificate_management
   end
 
+  def disable_certificate?
+    user.permissions.certificate_management
+  end
+
   def dual_running?
     user.permissions.certificate_management
   end

--- a/app/views/user_journey/view_certificate.html.erb
+++ b/app/views/user_journey/view_certificate.html.erb
@@ -51,6 +51,22 @@
   <% if @certificate.component.enabled_signing_certificates.length < 2 %>
     <%= link_to t('user_journey.certificate.add_new'), before_you_start_path, class: "govuk-button", data: { module: "govuk-button" }, role:"button" %> 
   <% elsif secondary_signing_certificate?(@certificate) && !deployment_in_progress?(@certificate) %>
-    TODO: OPTION TO REMOVE/DISABLE OLD CERT
+    <div class="govuk-error-summary govuk-error-summary--grey" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
+      <h2 class="govuk-error-summary__title" id="error-summary-title"><%= t('user_journey.certificate.stop_using_secondary_heading')%></h2>
+      <div class="govuk-error-summary__body">
+        <p><%= t('user_journey.certificate.stop_using_secondary_warning')%></p>
+        <p><%= render 'shared/component_certificate_doc_links', certificate: @certificate %></p>
+        <%= link_to t('user_journey.certificate.stop_using'), disable_certificate_path, method: :patch, class: "govuk-button", data: { module: "govuk-button" }, role:"button" %> 
+      </div>
+    </div>
+  <% else %>
+    <div class="govuk-error-summary govuk-error-summary--orange" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
+      <h2 class="govuk-error-summary__title" id="error-summary-title"><%= t('user_journey.certificate.stop_using_primary_heading')%></h2>
+      <div class="govuk-error-summary__body">
+        <p><%= t('user_journey.certificate.stop_using_primary_warning_html', href: link_to(t('user_journey.certificate.stop_using_secondary_link'), view_certificate_path(@certificate.component.component_type, @certificate.component.id, @certificate.component.enabled_signing_certificates.second)))%></p>
+        <p><%= render 'shared/component_certificate_doc_links', certificate: @certificate %></p>
+        <%= link_to t('user_journey.certificate.stop_using'), disable_certificate_path, method: :patch, class: "govuk-button govuk-button--warning", data: { module: "govuk-button" }, role:"button" %> 
+      </div>
+    </div>
   <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -129,6 +129,7 @@ en:
       small_key: key size is less than 2048 bits
       not_signing: signing certificate is needed
       invalid_file_type: is an invalid file type
+      cannot_disable: Cannot disable the only signing certificate on a component
   profile:
     title: Your profile
     item: Item
@@ -380,6 +381,12 @@ en:
       sp_doesnt_support_dual_running: Because your service provider does not support dual running, your connection will break when the GOV.UK Verify Hub starts using your new certificate.
       restore_connection: At this point, you will need to restore your connection.
       choose_one: 'Choose one of the following:'
+      stop_using_primary_heading: Stop using this primary certificate
+      stop_using_primary_warning_html: "This is your primary (most recent) certificate. During a normal certificate rotation you should be disabling your %{href} instead."
+      stop_using_secondary_link: secondary certificate
+      stop_using_secondary_heading: Stop using this secondary certificate
+      stop_using_secondary_warning: By clicking the button below, GOV.UK Verify will stop using this certificate within 10 minutes. Make sure you're no longer using the corresponding private key.
+      stop_using: Stop using this certificate
     confirmation:
       title: Confirmation
       what_to_expect: This usually takes around 10 minutes. We'll email you when your new %{type} certificate is in use.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,7 @@ Rails.application.routes.draw do
   post 'profile/update-role', to: 'profile#update_role'
 
   get '/component/:component_type/:component_id/certificate/:certificate_id', to: 'user_journey#view_certificate', as: 'view_certificate'
+  patch '/component/:component_type/:component_id/certificate/:certificate_id/disable', to: 'user_journey#disable_certificate', as: 'disable_certificate'
   get '/component/:component_type/:component_id/certificate/:certificate_id/dual-running', to: 'user_journey#dual_running', as: 'dual_running'
   get '/component/:component_type/:component_id/certificate/:certificate_id/is-dual-running', to: 'user_journey#is_dual_running', as: 'is_dual_running'
   get '/component/:component_type/:component_id/certificate/:certificate_id/before-you-start(/:dual_running)', to: 'user_journey#before_you_start', as: 'before_you_start'

--- a/spec/models/enable_signing_certificate_event_spec.rb
+++ b/spec/models/enable_signing_certificate_event_spec.rb
@@ -14,6 +14,12 @@ RSpec.describe EnableSigningCertificateEvent, type: :model do
     ).certificate
   end
 
+  let(:signing_certificate_secondary) do
+    UploadCertificateEvent.create(
+      usage: CERTIFICATE_USAGE::SIGNING, value: good_cert_value, component: component
+    ).certificate
+  end
+
   let(:expired_signing_certificate) do
     UploadCertificateEvent.create(
       usage: CERTIFICATE_USAGE::SIGNING, value: expired_cert_value, component: component
@@ -46,6 +52,7 @@ RSpec.describe EnableSigningCertificateEvent, type: :model do
   end
 
   it 'can enable a disabled certificate' do
+    signing_certificate_secondary
     disabled_cert = disable_signing_certificate_event.certificate
     expect(disabled_cert.enabled).to eq(false)
     enabled_cert = enable_signing_certificate_event.certificate

--- a/spec/system/shared_examples/show_component_page.rb
+++ b/spec/system/shared_examples/show_component_page.rb
@@ -68,15 +68,13 @@ RSpec.shared_examples "show component page" do |component_type|
       certs = component.enabled_signing_certificates
       visit polymorphic_url(component)
 
-      certs.each do |certificate|
-        show_page.disable_signing_certificate(certificate)
-      end
+      show_page.disable_signing_certificate(certs[0])
 
       disabled_certs = component.disabled_signing_certificates
 
       expect(show_page).to have_selector('h1', text: component.name)
       expect(show_page).to have_disabled_signing_certificate(disabled_certs[0])
-      expect(show_page).to have_disabled_signing_certificate(disabled_certs[1])
+      expect(show_page).not_to have_disabled_signing_certificate(disabled_certs[1])
     end
 
     it 'displays encryption certificate for component' do


### PR DESCRIPTION
Currently users are not able to disable ("Stop using") the secondary/old certs.

This is to implement the logic to allow them to disable the old one when dual running.

I've also updated the validation on the change event to prevent disable a cert
if it's the only one and the component would end up without certs.

Secondary certificate:
<img width="586" alt="image" src="https://user-images.githubusercontent.com/30629434/67102974-437e3100-f1bc-11e9-94c3-d0462991ca9f.png">

Primary certificate:
<img width="578" alt="image" src="https://user-images.githubusercontent.com/30629434/67102998-4a0ca880-f1bc-11e9-8e06-5984f9ae016f.png">
