### PR TITLE
I2820FMF: Some follow-up fixes for the ChangeComponentEvent

### DIFF
--- a/app/controllers/sp_components_controller.rb
+++ b/app/controllers/sp_components_controller.rb
@@ -52,7 +52,7 @@ class SpComponentsController < ApplicationController
 private
 
   def component_params
-    params.require(:component).permit(:name, :component_type, :team_id, :environment)
+    params.require(:component).permit(:name, :component_type, :team_id, :environment, :vsp)
   end
 
   def find_teams

--- a/app/models/change_component_event.rb
+++ b/app/models/change_component_event.rb
@@ -1,7 +1,7 @@
 class ChangeComponentEvent < AggregatedEvent
   belongs_to_aggregate :component
 
-  data_attributes :name, :component_type, :team_id, :environment, :entity_id
+  data_attributes :attributes_changed
   validate :validate_changes
 
   def attributes_to_apply
@@ -10,18 +10,24 @@ class ChangeComponentEvent < AggregatedEvent
   end
 
   def attributes_changed
-    component.attributes.slice(component.changed.join(', '))
+    component.changes.transform_values { |changes| changes[1] }
   end
 
   def attribute_changes
     component.changes
   end
 
+private
+
   def validate_changes
+    return if attribute_changes.nil?
+
     attribute_changes.each do |attribute, value|
       case attribute
       when "name"
         errors.add(:name, I18n.t('events.errors.missing_name')) unless value[1].present?
+      when "vsp"
+        errors.add(:component_type, I18n.t('components.errors.invalid_type')) unless [true, false].include?(value[1])
       when "team_id"
         errors.add(:team_id, I18n.t('components.errors.invalid_team')) unless value[1].present?
       when "environment"
@@ -30,6 +36,8 @@ class ChangeComponentEvent < AggregatedEvent
         errors.add(:component_type, I18n.t('components.errors.invalid_type')) unless component_type_present_and_valid?(value[1])
       when "entity_id"
         errors.add(:entity_id, I18n.t('components.errors.missing_entity_id')) unless value[1].present?
+      else
+        raise NotImplementedError.new("Attribute #{attribute} is unexpected or missing validation")
       end
     end
   end

--- a/app/views/sp_components/edit.html.erb
+++ b/app/views/sp_components/edit.html.erb
@@ -18,12 +18,12 @@
       <%=error_message_on(f.object.errors, :component_type) %>
       <div class="govuk-radios govuk-radios--inline">
         <div class="govuk-radios__item ">
-          <%= f.radio_button :component_type, COMPONENT_TYPE::VSP, class: 'govuk-radios__input' %>
-          <%= f.label :component_type, COMPONENT_TYPE::VSP_SHORT, class: 'govuk-label govuk-radios__label' %>
+          <%= f.radio_button :vsp, true, class: 'govuk-radios__input', checked: @component.vsp %>
+          <%= f.label :vsp, COMPONENT_TYPE::VSP_SHORT, class: 'govuk-label govuk-radios__label' %>
         </div>
         <div class="govuk-radios__item">
-          <%= f.radio_button :component_type, COMPONENT_TYPE::SP, class: 'govuk-radios__input'  %>
-          <%= f.label :component_type, COMPONENT_TYPE::SP_SHORT, class: 'govuk-label govuk-radios__label' %>
+          <%= f.radio_button :vsp, false, class: 'govuk-radios__input', checked: !@component.vsp %>
+          <%= f.label :vsp, COMPONENT_TYPE::SP_SHORT, class: 'govuk-label govuk-radios__label' %>
         </div>
       </div>
     </div>

--- a/spec/models/shared_examples/change_component_event.rb
+++ b/spec/models/shared_examples/change_component_event.rb
@@ -9,15 +9,18 @@ RSpec.shared_examples "change component event" do |component_types|
         expect(event.aggregate_type).to eq "#{component_type}_component".camelcase
       end
 
-      it 'has team id assigned to event metadata' do
+      it 'has changed attributes and record them in the data attribute' do
         setup(component_type)
 
-        old_team_id = @component.team_id
+        component = create(:sp_component)
+        old_team_id = component.team_id
         new_team = create(:team)
-        @component.team_id = new_team.id
+        component.assign_attributes({team_id: new_team.id})
+        event = ChangeComponentEvent.create(component: component)
 
         expect(new_team.id).not_to eq old_team_id
-        expect(@event.component.team_id).to eq new_team.id
+        expect(event.data).to eq({team_id: new_team.id}.stringify_keys)
+        expect(event.component.team_id).to eq new_team.id
       end
 
       it 'errors when name is not present' do


### PR DESCRIPTION
- fixed data_attributes to use the actual changed hash (which is required if we want to replay events as part of event sourcing)
- changed the logic to find the changed attributes - it didn't work with multiple changes
- switched using VSP for ComponentType, as that's not a thing which changes - the model should always be SpComponent, only `vsp` attribute value should change
- added a validation for the vsp option
- added a default for validation, just in case we update the model and forget to update the validation
- moved some methods to be private
- updated tests to make sure the above is happening