### PR TITLE
BAU: Prevent deleting GDS team

### DIFF
--- a/app/models/delete_team_event.rb
+++ b/app/models/delete_team_event.rb
@@ -6,7 +6,7 @@ class DeleteTeamEvent < AggregatedEvent
   belongs_to_aggregate :team
   after_save :destroy
 
-  validate :delete_cognito_group
+  validate :delete_cognito_group, :not_gds_team
 
   def attributes_to_apply
     {}
@@ -31,5 +31,9 @@ private
 
   def cognito_group_empty?
     get_users_in_group(group_name: team.team_alias).empty?
+  end
+
+  def not_gds_team
+    errors.add(:team, I18n.t('team.errors.failed_to_delete_gds')) if team.team_alias == TEAMS::GDS
   end
 end

--- a/app/views/admin/_team.erb
+++ b/app/views/admin/_team.erb
@@ -21,7 +21,11 @@
         <td class="govuk-table__cell"><%= team.updated_at %></td>
       </tr>
       <tr class="govuk-table__row">
-        <td class="govuk-table__cell govuk-table__cell--numeric" colspan="2"><%= link_to 'Delete', team_path(id: team.id), method: :delete, data: { confirm: 'Are you sure?' }, class: 'govuk-button govuk-button--warning' %></td>
+        <td class="govuk-table__cell govuk-table__cell--numeric" colspan="2">
+          <% unless team.team_alias == TEAMS::GDS %>
+            <%= link_to 'Delete', team_path(id: team.id), method: :delete, data: { confirm: 'Are you sure?' }, class: 'govuk-button govuk-button--warning' %>
+          <% end %>
+        </td>
       </tr>
     </tbody>
   </table>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -245,6 +245,7 @@ en:
       errored: errored
       failed: Failed to create team
       failed_to_delete: Failed to delete group
+      failed_to_delete_gds: GDS team cannot be deleted
       not_empty: Cannot delete team with members
       blank_name: Enter a team name
       name_not_unique: This team name is already being used, enter a unique one

--- a/spec/models/delete_team_event_spec.rb
+++ b/spec/models/delete_team_event_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe DeleteTeamEvent, type: :model do
       expect(delete_team_event).to eq DeleteTeamEvent.last
     end
 
-    it 'team is delete even if Cognito group does not exist or has already been deleted' do
+    it 'team is deleted even if Cognito group does not exist or has already been deleted' do
       stub_cognito_response(method: :delete_group, payload: 'ResourceNotFoundException')
       stub_cognito_response(method: :list_users_in_group, payload: [])
       delete_team_event = create(:delete_team_event)
@@ -38,6 +38,15 @@ RSpec.describe DeleteTeamEvent, type: :model do
       expect{ create(:delete_team_event, team: existing_team)}.to raise_error(ActiveRecord::RecordInvalid)
       expect(Team.exists?(existing_team.id)).to be true
     end
+
+    it 'when the team is GDS' do
+      stub_cognito_response(method: :delete_group)
+      stub_cognito_response(method: :list_users_in_group, payload: [])
+      gds_team = create(:team, team_alias: TEAMS::GDS)
+      expect{create(:delete_team_event, team: gds_team)}.to raise_error(ActiveRecord::RecordInvalid)
+      expect(Team.exists?(gds_team.id)).to be true
+    end
+
     it 'when cognito call fails' do
       stub_cognito_response(method: :delete_group, payload: 'ServiceError')
       stub_cognito_response(method: :list_users_in_group, payload: [])


### PR DESCRIPTION
GDS team/group is an admin team and should never be deleted.