### PR TITLE
1YBAF1GT: remove unused password and mfa reset links

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -18,15 +18,6 @@
     <%= @team_member.email %><%= link_to t('users.show.change_email'), update_user_email_address_path, class: 'govuk-!-padding-left-1 govuk-link--no-visited-state' %>
   </p>
 
-  <ul class="govuk-list">
-    <li>
-      <a href="#" class="govuk-link--no-visited-state">Reset password</a>
-    </li>
-    <li>
-      <a href="#" class="govuk-link--no-visited-state">Reset multi-factor authentication</a>
-    </li>
-  </ul>
-
   <% unless @team_member.gds? %>
     <div class="govuk-form-group">
       <fieldset class="govuk-fieldset">


### PR DESCRIPTION
On the user details screen, we display links to password reset and MFA reset. They're not used and will not be at this stage.