### PR TITLE
3t1kxCb9 Reject certificates with the wrong algorithm

### DIFF
--- a/app/models/x509_validator.rb
+++ b/app/models/x509_validator.rb
@@ -54,7 +54,7 @@ module X509Validator
   end
 
   def valid_algorithms
-    %w[sha256WithRSAEncryption sha384WithRSAEncryption sha512WithRSAEncryption]
+    %w[sha256WithRSAEncryption sha384WithRSAEncryption]
   end
 
   def certificate_digest_right(record, x509)

--- a/app/models/x509_validator.rb
+++ b/app/models/x509_validator.rb
@@ -46,8 +46,20 @@ module X509Validator
   end
 
   def certificate_is_strong(record, x509)
-    return if x509.public_key.params['n'].num_bits >= 2048
+    if x509.public_key.params['n'].num_bits >= 2048
+      certificate_digest_right(record, x509)
+    else
+      record.errors.add(:certificate, I18n.t('certificates.errors.small_key'))
+    end
+  end
 
-    record.errors.add(:certificate, I18n.t('certificates.errors.small_key'))
+  def valid_algorithms
+    %w[sha256WithRSAEncryption sha384WithRSAEncryption sha512WithRSAEncryption]
+  end
+
+  def certificate_digest_right(record, x509)
+    return if valid_algorithms.include?(x509.signature_algorithm)
+
+    record.errors.add(:certificate, I18n.t('certificates.errors.bad_algorithm'))
   end
 end

--- a/app/models/x509_validator.rb
+++ b/app/models/x509_validator.rb
@@ -47,17 +47,17 @@ module X509Validator
 
   def certificate_is_strong(record, x509)
     if x509.public_key.params['n'].num_bits >= 2048
-      certificate_digest_right(record, x509)
+      hash_algorithm_is_strong(record, x509)
     else
       record.errors.add(:certificate, I18n.t('certificates.errors.small_key'))
     end
   end
 
   def valid_algorithms
-    %w[sha256WithRSAEncryption sha384WithRSAEncryption]
+    %w[sha256WithRSAEncryption sha512WithRSAEncryption]
   end
 
-  def certificate_digest_right(record, x509)
+  def hash_algorithm_is_strong(record, x509)
     return if valid_algorithms.include?(x509.signature_algorithm)
 
     record.errors.add(:certificate, I18n.t('certificates.errors.bad_algorithm'))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -130,6 +130,7 @@ en:
       valid_too_long: expires too far in the future
       not_rsa: is not RSA
       small_key: key size is less than 2048 bits
+      bad_algorithm: is using an upsupported algorithm
       not_signing: signing certificate is needed
       invalid_file_type: is an invalid file type
       cannot_disable: Cannot disable the only signing certificate on a component

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -130,7 +130,7 @@ en:
       valid_too_long: expires too far in the future
       not_rsa: is not RSA
       small_key: key size is less than 2048 bits
-      bad_algorithm: is using an upsupported algorithm
+      bad_algorithm: is using an unsupported algorithm
       not_signing: signing certificate is needed
       invalid_file_type: is an invalid file type
       cannot_disable: Cannot disable the only signing certificate on a component

--- a/spec/models/upload_certificate_event_spec.rb
+++ b/spec/models/upload_certificate_event_spec.rb
@@ -84,6 +84,38 @@ RSpec.describe UploadCertificateEvent, type: :model do
       expect(event.errors[:certificate]).to eql [t('certificates.errors.not_rsa')]
     end
 
+    it 'must accept sha-256' do
+      cert = root.generate_signed_cert(expires_in: 6.months, digest: "SHA256")
+
+      event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert.to_pem, component: msa_component)
+      expect(event).to be_valid
+      expect(event.errors[:certificate]).to be_empty
+    end
+
+    it 'must accept sha-512' do
+      cert = root.generate_signed_cert(expires_in: 6.months, digest: "SHA512")
+
+      event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert.to_pem, component: msa_component)
+      expect(event).to be_valid
+      expect(event.errors[:certificate]).to be_empty
+    end
+
+    it 'must not be sha-1' do
+      cert = root.generate_signed_cert(expires_in: 6.months, digest: "SHA1")
+
+      event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert.to_pem, component: msa_component)
+      expect(event).to_not be_valid
+      expect(event.errors[:certificate]).to eql [t('certificates.errors.bad_algorithm')]
+    end
+
+    it 'must not be sha-384' do
+      cert = root.generate_signed_cert(expires_in: 6.months, digest: "SHA384")
+
+      event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert.to_pem, component: msa_component)
+      expect(event).to_not be_valid
+      expect(event.errors[:certificate]).to eql [t('certificates.errors.bad_algorithm')]
+    end
+
     it 'must be at least 2048 bits' do
       cert = root.generate_signed_rsa_cert_and_key(size: 1024)[0]
 

--- a/spec/support/certificate_support.rb
+++ b/spec/support/certificate_support.rb
@@ -3,7 +3,7 @@ module CertificateSupport
     generate_rsa_cert_and_key(args)[0]
   end
 
-  def generate_rsa_cert_and_key(expires_in: 1.year, size: 2048, cn: "GENERATED TEST CERTIFICATE")
+  def generate_rsa_cert_and_key(expires_in: 1.year, size: 2048, cn: "GENERATED TEST CERTIFICATE", digest: nil)
     key = OpenSSL::PKey::RSA.new size
     generate_cert_using_key(key.public_key, expires_in, cn)
   end


### PR DESCRIPTION
### What it is?
Enforcing higher security standards by only accepting certificates with 'SHA256withRSA' algorithm. When we do checks/validation on a new certificate, we should also validate the algorithm used to sign the cert.

### Why do we need it?
The 'SHA256withRSA' signature algorithm is currently deemed as sufficiently secure and we therefore we should not accept other (less secure) algorithms to maintain Verify integrity and security.

Trello Ticket: https://trello.com/c/3t1kxCb9