### PR TITLE
CbTC5TPe: Fixed menu not opening on mobile display

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,7 +29,7 @@
 
     <a href="#main-content" class="govuk-skip-link"><%= t 'layout.application.skip_link' %></a>
 
-    <header class="govuk-header " role="banner" data-module="header">
+    <header class="govuk-header " role="banner" data-module="govuk-header">
       <div class="govuk-header__container govuk-width-container">
         <div class="govuk-header__logo">
           <a href="/" class="govuk-header__link govuk-header__link--homepage">
@@ -48,7 +48,7 @@
 
           <%= link_to t('layout.application.service_name'), root_path, class: "govuk-header__link govuk-header__link--service-name" %>
 
-          <button type="button" role="button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation" data-module="govuk-button"><%= t 'layout.application.menu' %></button>
+          <button type="button" role="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation" data-module="govuk-button"><%= t 'layout.application.menu' %></button>
           <% if user_signed_in? %>
             <nav>
               <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">


### PR DESCRIPTION
Previously, when the window width was small(such as when using a mobile) the menu icon was not clickable and the menu did not expand. 

It now does. 

<img width="497" alt="Screen Shot 2019-10-28 at 14 33 37" src="https://user-images.githubusercontent.com/41922771/67687746-adeb5a00-f990-11e9-801b-206d6df581bc.png">

This issue arose because the CSS class names were not updated when we upgraded the design system. 