### PR TITLE
Removes expired certs before producing meta-data

### DIFF
--- a/lib/auth/cognito_stub_client.rb
+++ b/lib/auth/cognito_stub_client.rb
@@ -37,7 +37,7 @@ class CognitoStubClient
       ],
       mfa_options: nil,
       preferred_mfa_setting: "SOFTWARE_TOKEN_MFA",
-      user_mfa_setting_list: %W[SOFTWARE_TOKEN_MFA] }
+      user_mfa_setting_list: %w[SOFTWARE_TOKEN_MFA] }
   end
 
   def self.stub_gds_user_hash


### PR DESCRIPTION
The change to cognito_stub_client was to satisfy rubocop

See Trello: https://trello.com/c/jhmC5xc1