### PR TITLE
Eq8a6mon: Enable adding services to multiple components (part 1: SP components)

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -13,8 +13,9 @@ class ServicesController < ApplicationController
   def create
     @service_event = NewServiceEvent.create(service_params)
 
-    if @service_event.valid?
-      redirect_to admin_path
+    if @service_event.valid? && @service_event.service.valid?
+      flash[:success] = t('common.action_successful', name: @service_event.name, action: :created)
+      redirect_to admin_path(anchor: :services)
     else
       @service_event.errors.merge!(@service_event.service.errors)
       Rails.logger.info(@service_event.errors.full_messages)

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -3,21 +3,18 @@ class ServicesController < ApplicationController
   include ComponentConcern
 
   def index
-    component = component_by_klass_name(params)
-    @services = component.services
+    @services = Service.all
   end
 
   def new
-    @component = component_by_klass_name(params)
     @service_event = NewServiceEvent.new
   end
 
   def create
-    @component = component_by_klass_name(params)
     @service_event = NewServiceEvent.create(service_params)
 
-    if @service_event.valid? && @service_event.service.valid?
-      redirect_to polymorphic_url(@component)
+    if @service_event.valid?
+      redirect_to admin_path
     else
       @service_event.errors.merge!(@service_event.service.errors)
       Rails.logger.info(@service_event.errors.full_messages)
@@ -36,16 +33,8 @@ class ServicesController < ApplicationController
 
 private
 
-  def component_by_klass_name(params)
-    component_id = params[component_key(params)]
-    component_name = component_name_from_params(params)
-    klass_component(component_name).find_by_id(component_id)
-  end
-
   def service_params
-    key = component_key(params)
     params.require(:service)
           .permit(:name, :entity_id)
-          .merge("#{key}": params[key])
   end
 end

--- a/app/controllers/sp_components_controller.rb
+++ b/app/controllers/sp_components_controller.rb
@@ -59,21 +59,21 @@ class SpComponentsController < ApplicationController
   end
 
   def associate_service
-    component_present = SpComponent.exists?(params[:sp_component_id])
+    is_component_present = SpComponent.exists?(params[:sp_component_id])
     service = Service.find_by_id(params[:service_id])
 
-    if component_present && service.present?
+    if is_component_present && service.present?
       @event = AssignSpComponentToServiceEvent.create(service: service, sp_component_id: params[:sp_component_id])
 
       if @event.valid?
-        redirect_to sp_components_path
+        redirect_to sp_component_path(params[:sp_component_id])
       else
         Rails.logger.info(@event.errors.full_messages)
 
         render :show
       end
     else
-      flash[:error] = I18n.t('service.errors.unknown_component') unless component_present
+      flash[:error] = I18n.t('service.errors.unknown_component') unless is_component_present
       flash[:error] = I18n.t('services.errors.unknown_service') unless service.present?
       redirect_to admin_path(anchor: 'SpComponent')
     end

--- a/app/controllers/sp_components_controller.rb
+++ b/app/controllers/sp_components_controller.rb
@@ -13,7 +13,7 @@ class SpComponentsController < ApplicationController
 
   def show
     @component = SpComponent.find(params[:id])
-    @available_services = Service.all.select { |s| s.sp_component_id.blank? }
+    @available_services = Service.where(sp_component_id: [nil, ''])
   end
 
   def edit
@@ -63,7 +63,7 @@ class SpComponentsController < ApplicationController
     service = Service.find_by_id(params[:service_id])
 
     if component_present && service.present?
-      @event = AssignSpComponentToServiceEvent.create(service: Service.find_by_id(params[:service_id]), sp_component_id: params[:sp_component_id])
+      @event = AssignSpComponentToServiceEvent.create(service: service, sp_component_id: params[:sp_component_id])
 
       if @event.valid?
         redirect_to sp_components_path

--- a/app/models/assign_sp_component_to_service_event.rb
+++ b/app/models/assign_sp_component_to_service_event.rb
@@ -1,0 +1,19 @@
+class AssignSpComponentToServiceEvent < AggregatedEvent
+  belongs_to_aggregate :service
+  data_attributes :sp_component_id
+  validate :component_is_correct_type?
+
+  def attributes_to_apply
+    {
+      sp_component_id: sp_component_id,
+    }
+  end
+
+private
+
+  def component_is_correct_type?
+    return if SpComponent.exists?(sp_component_id)
+
+    errors.add(:service, I18n.t('services.errors.wrong_component_type'))
+  end
+end

--- a/app/policies/component_policy.rb
+++ b/app/policies/component_policy.rb
@@ -35,4 +35,8 @@ class ComponentPolicy < ApplicationPolicy
   def destroy?
     user.permissions.component_management
   end
+
+  def associate_service?
+    user.permissions.component_management
+  end
 end

--- a/app/views/admin/_service.erb
+++ b/app/views/admin/_service.erb
@@ -1,3 +1,5 @@
+<%= link_to t('services.add_new'), new_service_path, class: "govuk-button" %>
+
 <% services.reverse.each do |service| %>
   <table class="govuk-table">
     <caption class="govuk-table__caption" id="services/<%= service.id %>">Connected Service ID: <%= service.id %></caption>

--- a/app/views/msa_components/show.html.erb
+++ b/app/views/msa_components/show.html.erb
@@ -73,6 +73,3 @@
   <%= render "services/list/services_table" %>
 <% end %>
 
-<%= link_to t('components.add_service'),
-    polymorphic_url([:new, @component, :service], component: @component),
-    class: 'govuk-button', data: { module: "govuk-button" } %>

--- a/app/views/services/new.html.erb
+++ b/app/views/services/new.html.erb
@@ -6,9 +6,7 @@
   </legend>
 
   <%= error_summary_for(@service_event&.errors, :service_event) %>
-  <%= form_for @service_event,
-      url: polymorphic_url([@component, :services], component: @component),
-      as: :service do |f| %>
+  <%= form_for @service_event, url: services_path, as: :service do |f| %>
     <div class="govuk-form-group <%= 'govuk-form-group--error' if @service_event.errors.key?(:name) %>">
       <h3 class="govuk-heading-m"><%= t 'services.service_name' %></h3>
       <%=error_message_on(f.object.errors, :name) %>

--- a/app/views/sp_components/show.html.erb
+++ b/app/views/sp_components/show.html.erb
@@ -73,6 +73,18 @@
   <%= render "services/list/services_table" %>
 <% end %>
 
-<%= link_to t('components.add_service'),
-    polymorphic_url([:new, @component, :service], component: @component),
-    class: 'govuk-button', data: { module: "govuk-button" } %>
+<%= form_tag(sp_component_associate_service_url(sp_component_id: @component.id), method: "patch") do %>
+  <div class="govuk-form-group">
+    <h3 class="govuk-heading-m"><%= t 'components.service' %></h3>
+    <div class="govuk-form-group">
+      <%= select_tag(
+        :service_id,
+        options_from_collection_for_select(@available_services, "id", "name"),
+        include_blank: 'Select',
+        class: 'govuk-select'
+      ) %>
+    </div>
+
+    <%=submit_tag t('components.add_service', type: COMPONENT_TYPE::SP_SHORT ), class: "govuk-button", data: { module: "govuk-button" } %>
+  </div>
+<% end %>

--- a/app/views/sp_components/show.html.erb
+++ b/app/views/sp_components/show.html.erb
@@ -85,6 +85,8 @@
       ) %>
     </div>
 
-    <%=submit_tag t('components.add_service', type: COMPONENT_TYPE::SP_SHORT ), class: "govuk-button", data: { module: "govuk-button" } %>
+    <div class="govuk-form-group">
+      <%=submit_tag t('components.add_service', type: COMPONENT_TYPE::SP_SHORT ), class: "govuk-button", data: { module: "govuk-button" } %>
+    </div>
   </div>
 <% end %>

--- a/app/views/sp_components/show.html.erb
+++ b/app/views/sp_components/show.html.erb
@@ -73,20 +73,23 @@
   <%= render "services/list/services_table" %>
 <% end %>
 
-<%= form_tag(sp_component_associate_service_url(sp_component_id: @component.id), method: "patch") do %>
-  <div class="govuk-form-group">
-    <h3 class="govuk-heading-m"><%= t 'components.service' %></h3>
+<% unless @available_services.empty? %>
+  <%= form_tag(sp_component_associate_service_url(sp_component_id: @component.id), method: "patch") do %>
     <div class="govuk-form-group">
-      <%= select_tag(
-        :service_id,
-        options_from_collection_for_select(@available_services, "id", "name"),
-        include_blank: 'Select',
-        class: 'govuk-select'
-      ) %>
-    </div>
+      <h3 class="govuk-heading-m"><%= t 'components.service' %></h3>
+      <div class="govuk-form-group">
+        <%= select_tag(
+          :service_id,
+          options_from_collection_for_select(@available_services, "id", "name"),
+          include_blank: 'Select',
+          class: 'govuk-select'
+        ) %>
+      </div>
 
-    <div class="govuk-form-group">
-      <%=submit_tag t('components.add_service', type: COMPONENT_TYPE::SP_SHORT ), class: "govuk-button", data: { module: "govuk-button" } %>
+      <div class="govuk-form-group">
+        <%=submit_tag t('components.add_service', type: COMPONENT_TYPE::SP_SHORT ), class: "govuk-button", data: { module: "govuk-button" } %>
+      </div>
     </div>
-  </div>
+  <% end %>
 <% end %>
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -237,6 +237,10 @@ en:
     service_name: Service name
     service_id: Service Entity ID
     create_service: Create service
+    errors:
+      wrong_component_type: Wrong component type
+      unknown_component: Invalid component
+      unknown_service: Invalid service
   shared:
     errors:
       error: Error
@@ -269,6 +273,7 @@ en:
     new_msa_title: Create a new MSA component
     edit_msa_title: Edit MSA Component
     name: Name
+    service: Service
     team: Team
     entity_id: Entity ID
     view_link: View component

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
   get '/admin', to: 'admin#index'
 
   resources :sp_components, path: 'admin/sp-components' do
+    patch 'associate_service'
     resources :services
     resources :certificates do
       member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   resources :teams, path: 'admin/teams'
-  resources :services, path: 'admin/services', only: %w(index destroy)
+  resources :services, path: 'admin/services', only: %i[index new create destroy]
 
   devise_for :users, controllers: { sessions: 'sessions' }
 

--- a/spec/controllers/sp_components_controller_spec.rb
+++ b/spec/controllers/sp_components_controller_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe SpComponentsController, type: :controller do
   include AuthSupport
 
   let(:sp_component) { create(:sp_component) }
+  let(:msa_component) { create(:msa_component) }
+  let(:service) { create(:service) }
 
   describe "GET #index" do
     it "returns http success" do
@@ -70,6 +72,25 @@ RSpec.describe SpComponentsController, type: :controller do
       expect(SpComponent.exists?(sp_component.id)).to be false
       delete :destroy, params: { id: sp_component.id }
       expect(subject).to redirect_to(admin_path)
+    end
+  end
+
+  describe "PATCH #associate_service" do
+    it "returns http redirect" do
+      compmgr_stub_auth
+
+      patch :associate_service, params: { sp_component_id: sp_component.id, service_id: service.id }
+
+      expect(subject).to redirect_to(sp_components_path)
+    end
+
+    it "returns to admin page and flashes error when invalid" do
+      compmgr_stub_auth
+
+      patch :associate_service, params: { sp_component_id: msa_component.id, service_id: service.id }
+
+      expect(flash[:error]).to eq(t('service.errors.unknown_component'))
+      expect(subject).to redirect_to(admin_path(anchor: 'SpComponent'))
     end
   end
 end

--- a/spec/controllers/sp_components_controller_spec.rb
+++ b/spec/controllers/sp_components_controller_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe SpComponentsController, type: :controller do
 
       patch :associate_service, params: { sp_component_id: sp_component.id, service_id: service.id }
 
-      expect(subject).to redirect_to(sp_components_path)
+      expect(subject).to redirect_to(sp_component_path(sp_component.id))
     end
 
     it "returns to admin page and flashes error when invalid" do

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -39,4 +39,9 @@ FactoryBot.define do
     value { PKI.new.generate_encoded_cert(expires_in: 9.months) }
     component { create(:sp_component) }
   end
+
+  factory :assign_sp_component_to_service_event do
+    service { create(:service) }
+    sp_component_id { create(:sp_component).id }
+  end
 end

--- a/spec/models/assign_sp_component_to_service_spec.rb
+++ b/spec/models/assign_sp_component_to_service_spec.rb
@@ -3,31 +3,31 @@ require 'rails_helper'
 RSpec.describe AssignSpComponentToServiceEvent, type: :model do
 
   let(:service) { create(:service) }
-  let(:component1) { create(:sp_component) }
-  let(:component2) { create(:sp_component) }
+  let(:component_1) { create(:sp_component) }
+  let(:component_2) { create(:sp_component) }
   let(:msa_component) { create(:msa_component) }
 
   it 'must be persisted' do
-    event = AssignSpComponentToServiceEvent.create(service: service, sp_component_id: component1.id)
+    event = AssignSpComponentToServiceEvent.create(service: service, sp_component_id: component_1.id)
     expect(event).to be_valid
     expect(event).to be_persisted
   end
 
   it "updates the service's SP component assignment" do
-    AssignSpComponentToServiceEvent.create(service: service, sp_component_id: component1.id)
-    expect(service.sp_component_id).to eq(component1.id)
-    AssignSpComponentToServiceEvent.create(service: service, sp_component_id: component2.id)
-    expect(service.sp_component_id).to eq(component2.id)
+    AssignSpComponentToServiceEvent.create(service: service, sp_component_id: component_1.id)
+    expect(service.sp_component_id).to eq(component_1.id)
+    AssignSpComponentToServiceEvent.create(service: service, sp_component_id: component_2.id)
+    expect(service.sp_component_id).to eq(component_2.id)
   end
 
   it 'does not error if same component is assigned twice' do
-    AssignSpComponentToServiceEvent.create(service: service, sp_component_id: component1.id)
-    expect(service.sp_component_id).to eq(component1.id)
+    AssignSpComponentToServiceEvent.create(service: service, sp_component_id: component_1.id)
+    expect(service.sp_component_id).to eq(component_1.id)
 
-    event = AssignSpComponentToServiceEvent.create(service: service, sp_component_id: component1.id)
+    event = AssignSpComponentToServiceEvent.create(service: service, sp_component_id: component_1.id)
     expect(event).to be_valid
     expect(event).to be_persisted
-    expect(service.sp_component_id).to eq(component1.id)
+    expect(service.sp_component_id).to eq(component_1.id)
   end
 
   it 'is not valid if component id is for an MSA component' do

--- a/spec/models/assign_sp_component_to_service_spec.rb
+++ b/spec/models/assign_sp_component_to_service_spec.rb
@@ -34,5 +34,6 @@ RSpec.describe AssignSpComponentToServiceEvent, type: :model do
     event = AssignSpComponentToServiceEvent.create(service: service, sp_component_id: msa_component.id)
     expect(event).not_to be_valid
     expect(event).not_to be_persisted
+    expect(event.errors.full_messages.first).to eq('Service Wrong component type')
   end
 end

--- a/spec/models/assign_sp_component_to_service_spec.rb
+++ b/spec/models/assign_sp_component_to_service_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe AssignSpComponentToServiceEvent, type: :model do
+
+  let(:service) { create(:service) }
+  let(:component1) { create(:sp_component) }
+  let(:component2) { create(:sp_component) }
+  let(:msa_component) { create(:msa_component) }
+
+  it 'must be persisted' do
+    event = AssignSpComponentToServiceEvent.create(service: service, sp_component_id: component1.id)
+    expect(event).to be_valid
+    expect(event).to be_persisted
+  end
+
+  it "updates the service's SP component assignment" do
+    AssignSpComponentToServiceEvent.create(service: service, sp_component_id: component1.id)
+    expect(service.sp_component_id).to eq(component1.id)
+    AssignSpComponentToServiceEvent.create(service: service, sp_component_id: component2.id)
+    expect(service.sp_component_id).to eq(component2.id)
+  end
+
+  it 'does not error if same component is assigned twice' do
+    AssignSpComponentToServiceEvent.create(service: service, sp_component_id: component1.id)
+    expect(service.sp_component_id).to eq(component1.id)
+
+    event = AssignSpComponentToServiceEvent.create(service: service, sp_component_id: component1.id)
+    expect(event).to be_valid
+    expect(event).to be_persisted
+    expect(service.sp_component_id).to eq(component1.id)
+  end
+
+  it 'is not valid if component id is for an MSA component' do
+    event = AssignSpComponentToServiceEvent.create(service: service, sp_component_id: msa_component.id)
+    expect(event).not_to be_valid
+    expect(event).not_to be_persisted
+  end
+end

--- a/spec/models/assign_sp_component_to_service_spec.rb
+++ b/spec/models/assign_sp_component_to_service_spec.rb
@@ -8,23 +8,23 @@ RSpec.describe AssignSpComponentToServiceEvent, type: :model do
   let(:msa_component) { create(:msa_component) }
 
   it 'must be persisted' do
-    event = AssignSpComponentToServiceEvent.create(service: service, sp_component_id: component_1.id)
+    event = create(:assign_sp_component_to_service_event, service: service, sp_component_id: component_1.id)
     expect(event).to be_valid
     expect(event).to be_persisted
   end
 
   it "updates the service's SP component assignment" do
-    AssignSpComponentToServiceEvent.create(service: service, sp_component_id: component_1.id)
+    create(:assign_sp_component_to_service_event, service: service, sp_component_id: component_1.id)
     expect(service.sp_component_id).to eq(component_1.id)
-    AssignSpComponentToServiceEvent.create(service: service, sp_component_id: component_2.id)
+    create(:assign_sp_component_to_service_event,service: service, sp_component_id: component_2.id)
     expect(service.sp_component_id).to eq(component_2.id)
   end
 
   it 'does not error if same component is assigned twice' do
-    AssignSpComponentToServiceEvent.create(service: service, sp_component_id: component_1.id)
+    create(:assign_sp_component_to_service_event, service: service, sp_component_id: component_1.id)
     expect(service.sp_component_id).to eq(component_1.id)
 
-    event = AssignSpComponentToServiceEvent.create(service: service, sp_component_id: component_1.id)
+    event = create(:assign_sp_component_to_service_event, service: service, sp_component_id: component_1.id)
     expect(event).to be_valid
     expect(event).to be_persisted
     expect(service.sp_component_id).to eq(component_1.id)

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -17,4 +17,13 @@ RSpec.describe Service, type: :model do
       expect(service).to be_persisted
     end
   end
+
+  context 'creating a spec without an initial component' do
+    let(:service) { create(:service) }
+
+    it 'should create a new service correctly' do
+      expect(service).to be_valid
+      expect(service).to be_persisted
+    end
+  end
 end

--- a/spec/system/visit_msa_service_new_spec.rb
+++ b/spec/system/visit_msa_service_new_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe 'New MSA Component Page', type: :system do
-  include_examples 'new component page', :msa_component
-end

--- a/spec/system/visit_service_new_spec.rb
+++ b/spec/system/visit_service_new_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe 'New Service Page', type: :system do
+  before(:each) do
+    login_gds_user
+  end
+
+  let(:entity_id) { 'http://test-entity-id' }
+
+  context 'creation is successful' do
+    it 'when required input is specified' do
+      service_name = 'test component'
+      entity_id = 'http://www.gov.uk'
+      visit new_service_path
+      fill_in 'service_name', with: service_name
+      fill_in 'service_entity_id', with: entity_id
+      click_button 'Create service'
+
+      expect(current_path).to eql admin_path
+    end
+  end
+
+  context 'creation fails without name' do
+    it 'when name is not specified' do
+      service_name = ''
+      entity_id = 'http://www.gov.uk'
+      visit new_service_path
+      fill_in 'service_name', with: service_name
+      fill_in 'service_entity_id', with: entity_id
+      click_button 'Create service'
+
+      expect(page).to have_content 'Enter a name'
+    end
+  end
+
+  context 'creation fails without entity id' do
+    it 'when entity id is not specified' do
+      service_name = 'test component'
+      entity_id = ''
+      visit new_service_path
+      fill_in 'service_name', with: service_name
+      fill_in 'service_entity_id', with: entity_id
+      click_button 'Create service'
+
+      expect(page).to have_content 'Entity ID is required'
+    end
+  end
+end

--- a/spec/system/visit_sp_service_new_spec.rb
+++ b/spec/system/visit_sp_service_new_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe 'New SP Component Page', type: :system do
-  include_examples 'new component page', :sp_component
-end


### PR DESCRIPTION
This PR adds the ability to create services independently of components, via the Services tab of the admin page.

It is also now possible to associate an SP component with a service.  Admin users can select a service from a drop-down when viewing the SP component, and click a button to associate that service with the component.  Only services which do not already have an SP component associated with them will be listed.

This functionality is needed for MSA components too; that will follow in a later PR.