### PR TITLE
BAU: Added expired? member to Certificate model

### DIFF
--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -28,6 +28,10 @@ class Certificate < Aggregate
     x509.not_after - Time.now < 30.day
   end
 
+  def expired?
+    x509.not_after < Time.now
+  end
+
   def deploying?
     updated_at >= 10.minutes.ago
   end

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -78,17 +78,15 @@ class Component < Aggregate
 private
 
   def unexpired_encryption_certificate
-    x509 = encryption_certificate&.x509
-    if x509.nil? || x509.not_after < Time.now
+    if encryption_certificate&.expired?
       Rails.logger.error "When publishing the meta data the service '#{name}' has been identified as having an expired encryption certificate."
-      nil
-    else
-      encryption_certificate
+      return nil
     end
+    encryption_certificate
   end
 
   def unexpired_enabled_signing_certificates
-    valid_certs = enabled_signing_certificates.reject { |cert| cert.x509.not_after < Time.now }
+    valid_certs = enabled_signing_certificates.reject(&:expired?)
     if valid_certs.size < enabled_signing_certificates.size
       Rails.logger.error "When publishing the meta data the service '#{name}' has been identified as having expired signing certificate(s)."
     end


### PR DESCRIPTION
It is nice to have an expired? member on the Certificate model
so it can be reusable. i.e see Component