### PR TITLE
BAU: flash message when deleting service not found

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -30,6 +30,8 @@ class ServicesController < ApplicationController
     if service.present?
       DeleteServiceEvent.create(service: service, data: { name: service.name, entity_id: service.entity_id })
       flash[:success] = t('common.action_successful', name: service.name, action: :deleted)
+    else
+      flash[:error] = t('common.error_not_found', name: Service.model_name.human)
     end
     redirect_to admin_path(anchor: :services)
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,6 +35,7 @@ en:
     action_successful: "%{name} has been %{action} sucessfully."
     error_blank_name: Name can't be blank
     error_name_not_unique: Name has already been taken
+    error_not_found: "{name} not found."
     gds_full: Government Digital Service
     gds: GDS
   login:
@@ -159,7 +160,7 @@ en:
       title: Reset your multi-factor authentication
       heading: You are about to reset your multi-factor authentication
       body: You will need to use an authentication app to set up a new multi-factor authentication account.
-      warning: Once you select ‘continue’, your existing authentication account will no longer be valid. 
+      warning: Once you select ‘continue’, your existing authentication account will no longer be valid.
     software_token: Multi-factor authentication present
     update_token_heading: Update your multi-factor software token
     mfa_success: Your multi-factor authentication configuration have been updated.

--- a/spec/controllers/services_controller_spec.rb
+++ b/spec/controllers/services_controller_spec.rb
@@ -17,14 +17,22 @@ RSpec.describe ServicesController, type: :controller do
   end
 
   describe 'DELETED #destroy' do
-    it 'expects DeleteServiceEvent to be called when deleting service' do
-      expect(DeleteServiceEvent).to receive(:create).and_call_original
-      delete :destroy, params: { id: service.id }
-      expect(Service.exists?(service.id)).to be false
+    context 'when service is present' do
+      it 'expects DeleteServiceEvent to be called when deleting service' do
+        expect(DeleteServiceEvent).to receive(:create).and_call_original
+        delete :destroy, params: { id: service.id }
+        expect(Service.exists?(service.id)).to be false
+      end
+      it 'expects flash to display service was deleted successfully' do
+        delete :destroy, params: { id: service.id }
+        expect(flash[:success]).to eq t('common.action_successful', name: service.name, action: :deleted)
+      end
     end
-    it 'displays service that was removed' do
-      delete :destroy, params: { id: service.id }
-      expect(flash[:success]).to eq t('common.action_successful', name: service.name, action: :deleted)
+    context 'when service is not present' do
+      it 'expects flash to display service was not found' do
+        delete :destroy, params: { id: 'non-existant' }
+        expect(flash[:error]).to eq t('common.error_not_found', name: Service.model_name.human)
+      end
     end
   end
 end


### PR DESCRIPTION
When deleting a service we are checking for the existence a service
no feedback is when the service is not found.