### PR TITLE
BAU: Fix S3 AccessDenied when cross-account

### DIFF
--- a/app/models/healthcheck/storage_check.rb
+++ b/app/models/healthcheck/storage_check.rb
@@ -13,6 +13,7 @@ module Healthcheck
               key: FILES::HEALTHCHECK,
               body: '',
               server_side_encryption: 'AES256',
+              acl: 'bucket-owner-full-control',
             )
           end
         rescue Aws::S3::Errors::ServiceError

--- a/app/models/publish_services_metadata_event.rb
+++ b/app/models/publish_services_metadata_event.rb
@@ -19,6 +19,7 @@ class PublishServicesMetadataEvent < Event
       key: FILES::CONFIG_METADATA,
       body: StringIO.new(metadata.to_json),
       server_side_encryption: 'AES256',
+      acl: 'bucket-owner-full-control',
     )
   rescue Aws::S3::Errors::ServiceError
     Rails.logger.error("Failed to publish config metadata for event #{event_id}")


### PR DESCRIPTION
By default, when a file is written to a S3 bucket from a different account, the
destination account does not have access to the file/object.
This makes sure the bucket owner has access to the object itself.

https://aws.amazon.com/premiumsupport/knowledge-center/s3-bucket-owner-access/