### PR TITLE
Services used by component now show & associated test

### DIFF
--- a/app/views/shared/_user_certificate_view.html.erb
+++ b/app/views/shared/_user_certificate_view.html.erb
@@ -2,7 +2,7 @@
   <% if full_details %>
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key"><%= t 'user_journey.certificate.used_by' %></dt>
-      <dd class="govuk-summary-list__value"><%= certificate.component.services.map(&:name).join(', ') %></dd>
+      <dd class="govuk-summary-list__value" id="<%= certificate.component.id %>"><%= certificate.component.services.map(&:name).join(', ') %></dd>
     </div>
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key"><%= t 'components.environment' %></dt>

--- a/app/views/shared/_user_certificate_view.html.erb
+++ b/app/views/shared/_user_certificate_view.html.erb
@@ -2,7 +2,7 @@
   <% if full_details %>
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key"><%= t 'user_journey.certificate.used_by' %></dt>
-      <dd class="govuk-summary-list__value"><!-- TODO --></dd>
+      <dd class="govuk-summary-list__value"><%= certificate.component.services.map(&:name).join(', ') %></dd>
     </div>
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key"><%= t 'components.environment' %></dt>

--- a/app/views/shared/_user_certificate_view.html.erb
+++ b/app/views/shared/_user_certificate_view.html.erb
@@ -2,7 +2,7 @@
   <% if full_details %>
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key"><%= t 'user_journey.certificate.used_by' %></dt>
-      <dd class="govuk-summary-list__value" id="<%= certificate.component.id %>"><%= certificate.component.services.map(&:name).join(', ') %></dd>
+      <dd class="govuk-summary-list__value" id="list-of-services"><%= certificate.component.services.map(&:name).join(', ') %></dd>
     </div>
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key"><%= t 'components.environment' %></dt>

--- a/app/views/shared/_user_component_certificates.html.erb
+++ b/app/views/shared/_user_component_certificates.html.erb
@@ -1,12 +1,11 @@
 <% if components.present? %>
   <% components.reverse.each do |component| %>
-    <table class="govuk-table">
+    <table class="govuk-table" id="<%= component.id %>">
       <h2 class="govuk-heading-m"><%= component.environment.capitalize %></h2>
       <caption class="govuk-table__caption govuk-!-margin-bottom-1">
        <%= t("user_journey.component_long_name.#{component.type}") %>
-        <span class="component-supporting-text">
-          <%= t 'user_journey.used_by' %>
-            <span class="govuk-body"><%= component.services.map(&:name).join(', ') %></span>     
+        <span class="govuk-body">
+          <%= t 'user_journey.used_by', services: component.services.map(&:name).join(', ') %>     
         </span>     
       </caption>
       <thead class="govuk-table__head govuk-visually-hidden">

--- a/app/views/shared/_user_component_certificates.html.erb
+++ b/app/views/shared/_user_component_certificates.html.erb
@@ -6,7 +6,8 @@
        <%= t("user_journey.component_long_name.#{component.type}") %>
         <span class="component-supporting-text">
           <%= t 'user_journey.used_by' %>
-        </span>
+            <span class="govuk-body"><%= component.services.map(&:name).join(', ') %></span>     
+        </span>     
       </caption>
       <thead class="govuk-table__head govuk-visually-hidden">
         <tr class="govuk-table__row">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -317,7 +317,7 @@ en:
       MSA: MSA
       VSP: VSP
       SP: service provider
-    used_by: used by
+    used_by: "used by %{services}"
     certificate: Certificate
     status: Status
     missing: MISSING

--- a/spec/system/visit_index_page_spec.rb
+++ b/spec/system/visit_index_page_spec.rb
@@ -35,6 +35,12 @@ RSpec.describe 'IndexPage', type: :system do
     expect(current_path).to eql view_certificate_path(msa_component.component_type, msa_component.id, msa_component.encryption_certificate_id)
   end
 
+  it 'Displays which services a component is used by' do
+    service = create(:service, sp_component: create(:sp_component))
+    visit root_path
+    expect(page).to have_content service.name
+  end
+
   it 'shows the primary signing certificate is deploying and secondary in use when deploying' do
     old_signing_certificate = create(:msa_signing_certificate, updated_at: 15.minutes.ago)
     new_signing_certificate = create(:msa_signing_certificate, component: old_signing_certificate.component)

--- a/spec/system/visit_index_page_spec.rb
+++ b/spec/system/visit_index_page_spec.rb
@@ -35,12 +35,13 @@ RSpec.describe 'IndexPage', type: :system do
     expect(current_path).to eql view_certificate_path(msa_component.component_type, msa_component.id, msa_component.encryption_certificate_id)
   end
 
-  it 'Displays which services a component is used by' do
-    service = create(:service, sp_component: create(:sp_component))
+  it 'displays which services a component is used by' do
+    service = create(:service, sp_component: create(:sp_component), name: 'test-service')
     visit root_path
-    expect(page).to have_content service.name
+    component_table = page.find("##{service.sp_component.id}")
+    expect(component_table).to have_content 'test-service'
   end
-
+  
   it 'shows the primary signing certificate is deploying and secondary in use when deploying' do
     old_signing_certificate = create(:msa_signing_certificate, updated_at: 15.minutes.ago)
     new_signing_certificate = create(:msa_signing_certificate, component: old_signing_certificate.component)

--- a/spec/system/visit_user_journey_view_certificate_page_spec.rb
+++ b/spec/system/visit_user_journey_view_certificate_page_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'View certificate page', type: :system do
     sp_component = sp_encryption_certificate.component
     service = create(:service, sp_component: sp_component, name: 'test-service')
     visit view_certificate_path(sp_component.component_type, sp_component.id, sp_component.encryption_certificate_id)
-    component_table = page.find("##{service.sp_component.id}")
+    component_table = page.find("#list-of-services")
     expect(component_table).to have_content 'test-service'
   end
 

--- a/spec/system/visit_user_journey_view_certificate_page_spec.rb
+++ b/spec/system/visit_user_journey_view_certificate_page_spec.rb
@@ -23,6 +23,14 @@ RSpec.describe 'View certificate page', type: :system do
     )
   end
 
+  it 'displays which services the certicificate is used by' do
+    sp_component = sp_encryption_certificate.component
+    service = create(:service, sp_component: sp_component, name: 'test-service')
+    visit view_certificate_path(sp_component.component_type, sp_component.id, sp_component.encryption_certificate_id)
+    component_table = page.find('#main-content > div.govuk-grid-row > div.govuk-grid-column-three-quarters > dl > div:nth-child(1) > dd')
+    expect(component_table).to have_content 'test-service'
+  end
+
   context 'shows existing msa' do
     it 'encryption certificate information and navigates to next page if not being deployed' do
       msa_component = msa_encryption_certificate.component

--- a/spec/system/visit_user_journey_view_certificate_page_spec.rb
+++ b/spec/system/visit_user_journey_view_certificate_page_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'View certificate page', type: :system do
     sp_component = sp_encryption_certificate.component
     service = create(:service, sp_component: sp_component, name: 'test-service')
     visit view_certificate_path(sp_component.component_type, sp_component.id, sp_component.encryption_certificate_id)
-    component_table = page.find('#main-content > div.govuk-grid-row > div.govuk-grid-column-three-quarters > dl > div:nth-child(1) > dd')
+    component_table = page.find("##{service.sp_component.id}")
     expect(component_table).to have_content 'test-service'
   end
 

--- a/spec/system/visit_user_journey_view_certificate_page_spec.rb
+++ b/spec/system/visit_user_journey_view_certificate_page_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'View certificate page', type: :system do
     )
   end
 
-  it 'displays which services the certicificate is used by' do
+  it 'displays which services the certificate is used by' do
     sp_component = sp_encryption_certificate.component
     service = create(:service, sp_component: sp_component, name: 'test-service')
     visit view_certificate_path(sp_component.component_type, sp_component.id, sp_component.encryption_certificate_id)


### PR DESCRIPTION
Previously the services used by a component were not shown on the dashboard
<img width="560" alt="Screen Shot 2019-11-06 at 13 12 22" src="https://user-images.githubusercontent.com/41922771/68411054-af333880-0181-11ea-9045-f264d82bdfbe.png">

They now are.

<img width="596" alt="Screen Shot 2019-11-07 at 17 12 11" src="https://user-images.githubusercontent.com/41922771/68411119-cb36da00-0181-11ea-9962-c6cec4cfd70a.png">


