### PR TITLE
eq8a6mon - Enable adding services to multiple components (part 2: MSA components)

### DIFF
--- a/app/controllers/msa_components_controller.rb
+++ b/app/controllers/msa_components_controller.rb
@@ -19,6 +19,7 @@ class MsaComponentsController < ApplicationController
 
   def show
     @component = MsaComponent.find_by_id(params[:id])
+    @available_services = Service.msa_available
   end
 
   def create
@@ -55,6 +56,26 @@ class MsaComponentsController < ApplicationController
       DeleteComponentEvent.create(component: component, data: { component_id: component.id, component_name: component.name, component_type: component.type })
     end
     redirect_to admin_path(anchor: component&.component_type)
+  end
+
+  def associate_service
+    is_component_present = MsaComponent.exists?(params[:msa_component_id])
+    service = Service.find_by_id(params[:service_id])
+
+    if is_component_present && service.present?
+      @event = AssignMsaComponentToServiceEvent.create(service: service, msa_component_id: params[:msa_component_id])
+
+      if @event.valid?
+        redirect_to msa_component_path(params[:msa_component_id])
+      else
+        Rails.logger.info(@event.errors.full_messages)
+
+        render :show
+      end
+    else
+      flash[:error] = I18n.t('service.errors.unknown_component_or_service') unless is_component_present && service.present?
+      redirect_to admin_path(anchor: 'MsaComponent')
+    end
   end
 
 private

--- a/app/models/assign_msa_component_to_service_event.rb
+++ b/app/models/assign_msa_component_to_service_event.rb
@@ -1,0 +1,20 @@
+class AssignMsaComponentToServiceEvent < AggregatedEvent
+  belongs_to_aggregate :service
+  data_attributes :msa_component_id, :name
+  validate :component_is_correct_type?
+  after_save TriggerMetadataEventCallback.publish
+
+  def attributes_to_apply
+    {
+      msa_component_id: msa_component_id,
+    }
+  end
+
+private
+
+  def component_is_correct_type?
+    return if MsaComponent.exists?(msa_component_id)
+
+    errors.add(:service, I18n.t('services.errors.wrong_component_type'))
+  end
+end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -3,4 +3,5 @@ class Service < Aggregate
   belongs_to :msa_component, optional: true
   validates_uniqueness_of :entity_id
   scope :sp_available, -> { where(sp_component_id: [nil, '']) }
+  scope :msa_available, -> { where(msa_component_id: [nil, '']) }
 end

--- a/app/models/trigger_metadata_event_callback.rb
+++ b/app/models/trigger_metadata_event_callback.rb
@@ -16,7 +16,7 @@ private
     if model.aggregate.respond_to?(:component)
       model.aggregate.component.environment
     elsif model.respond_to?(:service)
-      if SpComponent.find_by_id(model.sp_component_id).present?
+      if model.respond_to?(:sp_component_id)
         SpComponent.find_by_id(model.sp_component_id).environment
       else
         MsaComponent.find_by_id(model.msa_component_id).environment

--- a/app/views/msa_components/show.html.erb
+++ b/app/views/msa_components/show.html.erb
@@ -73,3 +73,23 @@
   <%= render "services/list/services_table" %>
 <% end %>
 
+<% unless @available_services.empty? %>
+  <%= form_tag(msa_component_associate_service_url(msa_component_id: @component.id), method: "patch") do %>
+    <div class="govuk-form-group">
+      <h3 class="govuk-heading-m"><%= t 'components.service' %></h3>
+      <div class="govuk-form-group">
+        <%= select_tag(
+          :service_id,
+          options_from_collection_for_select(@available_services, "id", "name"),
+          include_blank: 'Select',
+          class: 'govuk-select'
+        ) %>
+      </div>
+
+      <div class="govuk-form-group">
+        <%=submit_tag t('components.add_service', type: COMPONENT_TYPE::MSA_SHORT ), class: "govuk-button", data: { module: "govuk-button" } %>
+      </div>
+    </div>
+  <% end %>
+<% end %>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
   end
 
   resources :msa_components, path: 'admin/msa-components' do
+    patch 'associate_service'
     resources :services
     resources :certificates do
       member do

--- a/spec/controllers/msa_components_controller_spec.rb
+++ b/spec/controllers/msa_components_controller_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe MsaComponentsController, type: :controller do
   include AuthSupport
 
   let(:msa_component) { create(:msa_component) }
+  let(:sp_component) { create(:sp_component) }
+  let(:service) { create(:service) }
 
   describe "GET #index" do
     it "returns http success" do
@@ -70,6 +72,25 @@ RSpec.describe MsaComponentsController, type: :controller do
       expect(MsaComponent.exists?(msa_component.id)).to be false
       delete :destroy, params: { id: msa_component.id }
       expect(subject).to redirect_to(admin_path)
+    end
+  end
+
+  describe "PATCH #associate_service" do
+    it "returns http redirect" do
+      compmgr_stub_auth
+
+      patch :associate_service, params: { msa_component_id: msa_component.id, service_id: service.id }
+
+      expect(subject).to redirect_to(msa_component_path(msa_component.id))
+    end
+
+    it "returns to admin page and flashes error when invalid" do
+      compmgr_stub_auth
+
+      patch :associate_service, params: { msa_component_id: sp_component.id, service_id: service.id }
+
+      expect(flash[:error]).to eq(t('service.errors.unknown_component_or_service'))
+      expect(subject).to redirect_to(admin_path(anchor: 'MsaComponent'))
     end
   end
 end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -48,4 +48,9 @@ FactoryBot.define do
     service { create(:service) }
     sp_component_id { create(:sp_component).id }
   end
+
+  factory :assign_msa_component_to_service_event do
+    service { create(:service) }
+    msa_component_id { create(:msa_component).id }
+  end
 end

--- a/spec/models/assign_msa_component_to_service_spec.rb
+++ b/spec/models/assign_msa_component_to_service_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe AssignSpComponentToServiceEvent, type: :model do
+
+  let(:service) { create(:service) }
+  let(:component_1) { create(:msa_component) }
+  let(:component_2) { create(:msa_component) }
+  let(:sp_component) { create(:sp_component) }
+
+  it 'must be persisted' do
+    event = create(:assign_msa_component_to_service_event, service: service, msa_component_id: component_1.id)
+    expect(event).to be_valid
+    expect(event).to be_persisted
+  end
+
+  it "updates the service's MSA component assignment" do
+    create(:assign_msa_component_to_service_event, service: service, msa_component_id: component_1.id)
+    expect(service.msa_component_id).to eq(component_1.id)
+    create(:assign_msa_component_to_service_event,service: service, msa_component_id: component_2.id)
+    expect(service.msa_component_id).to eq(component_2.id)
+  end
+
+  it 'does not error if same component is assigned twice' do
+    create(:assign_msa_component_to_service_event, service: service, msa_component_id: component_1.id)
+    expect(service.msa_component_id).to eq(component_1.id)
+
+    event = create(:assign_msa_component_to_service_event, service: service, msa_component_id: component_1.id)
+    expect(event).to be_valid
+    expect(event).to be_persisted
+    expect(service.msa_component_id).to eq(component_1.id)
+  end
+
+  it 'is not valid if component id is for an SP component' do
+    event = AssignMsaComponentToServiceEvent.create(service: service, msa_component_id: sp_component.id)
+    expect(event).not_to be_valid
+    expect(event).not_to be_persisted
+    expect(event.errors.full_messages.first).to eq('Service Wrong component type')
+  end
+
+  context '#trigger_publish_event' do
+    it 'when component is assigned to service is enabled' do
+      event = create(:assign_msa_component_to_service_event, service: service, msa_component_id: component_1.id)
+
+      resulting_event = PublishServicesMetadataEvent.all.select do |evt|
+        evt.event_id == event.id
+      end.first
+
+      expect(resulting_event).to be_present
+    end
+  end
+end


### PR DESCRIPTION
This is the equivalent to earlier PR 261 but for MSA components, and with equivalent changes from PR 270 also included.

https://trello.com/c/eq8a6mon/688-enable-adding-a-service-to-multiple-components