### PR TITLE
BAU: Add the ability to trigger metadata publish manually

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,9 +1,21 @@
 class AdminController < ApplicationController
+  include ControllerConcern
+
   def index
     @sp_components = SpComponent.all
     @msa_components = MsaComponent.all
     @services = Service.all
     @certificates = Certificate.all
     @teams = Team.all
+  end
+
+  def publish_metadata
+    event_id = "manual-#{Time.now.to_i}"
+    PublishServicesMetadataEvent.create(
+      event_id: event_id,
+      environment: params[:environment],
+    )
+    check_metadata_published(event_id)
+    redirect_to admin_path(anchor: :publish)
   end
 end

--- a/app/policies/admin_controller_policy.rb
+++ b/app/policies/admin_controller_policy.rb
@@ -2,4 +2,8 @@ class AdminControllerPolicy < ApplicationPolicy
   def index?
     user.permissions.admin_management
   end
+
+  def publish_metadata?
+    user.permissions.admin_management
+  end
 end

--- a/app/views/admin/_publish.erb
+++ b/app/views/admin/_publish.erb
@@ -1,0 +1,4 @@
+<% Rails.configuration.hub_environments.keys.each do |environment| %>
+  <%= link_to "Publish to #{environment}", publish_metadata_path(environment), class: 'govuk-button' %>
+<% end %>
+

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -37,7 +37,13 @@
         Events
       </a>
     </li>
+    <li class="govuk-tabs__list-item">
+      <a class="govuk-tabs__tab" href="#publish">
+        Publish
+      </a>
+    </li>
   </ul>
+
   <section class="govuk-tabs__panel" id="SpComponent">
     <h2 class="govuk-heading-l">SP components</h2>
     <%= render "admin/sp_component", components: @sp_components %>
@@ -66,5 +72,10 @@
   <section class="govuk-tabs__panel govuk-tabs__panel--hidden" id="events">
     <h2 class="govuk-heading-l">Events</h2>
     <%= link_to t('layout.application.events'), admin_events_path %>
+  </section>
+
+  <section class="govuk-tabs__panel govuk-tabs__panel--hidden" id="publish">
+    <h2 class="govuk-heading-l">Publish metadata</h2>
+    <%= render "admin/publish" %>
   </section>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   get '/healthcheck', to: 'healthcheck#index'
 
   get '/admin', to: 'admin#index'
+  get '/admin/publish-metadata/:environment', to: 'admin#publish_metadata', as: :publish_metadata
 
   resources :sp_components, path: 'admin/sp-components' do
     patch 'associate_service'

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -2,7 +2,9 @@ require 'rails_helper'
 
 RSpec.describe AdminController, type: :controller do
   include AuthSupport
+  include StorageSupport
 
+  context 'GET #index' do
     it 'should render when GDS user' do
       gdsuser_stub_auth
       get :index
@@ -13,14 +15,34 @@ RSpec.describe AdminController, type: :controller do
     it 'should not render when user is certificate manager' do
       certmgr_stub_auth
       get :index
-      expect(flash[:warn]).to eq t('shared.errors.authorisation')    
+      expect(flash[:warn]).to eq t('shared.errors.authorisation')
       expect(subject).to_not render_template(:index)
     end
 
     it 'should not render when user is user manager' do
       usermgr_stub_auth
       get :index
-      expect(flash[:warn]).to eq t('shared.errors.authorisation')    
+      expect(flash[:warn]).to eq t('shared.errors.authorisation')
       expect(subject).to_not render_template(:index)
     end
+  end
+
+  context 'GET #publish_metadata' do
+    it 'should publish metadata for a given environment' do
+      gdsuser_stub_auth
+      PublishServicesMetadataEvent.delete_all
+      get :publish_metadata, params: { environment: 'staging'}
+      expect(PublishServicesMetadataEvent.all.count).to eq 1
+      expect(flash[:notice]).to be nil
+    end
+
+    it 'should display warning if publishing metadata fails' do
+      stub_storage_client_service_error
+      gdsuser_stub_auth
+      PublishServicesMetadataEvent.delete_all
+      get :publish_metadata, params: { environment: 'staging'}
+      expect(PublishServicesMetadataEvent.all.count).to eq 0
+      expect(flash[:notice]).to eq(t('certificates.errors.cannot_publish'))
+    end
+  end
 end


### PR DESCRIPTION
As admins we should be able to publish latest metadata manually - in case of previous
failures or any other reasons.

<img width="988" alt="image" src="https://user-images.githubusercontent.com/30629434/68532644-ef2c2400-0317-11ea-81e5-8cb900fe6412.png">
