### PR TITLE
BUGFIX: Publish metadata for specific environments

### DIFF
--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -23,19 +23,20 @@ class Component < Aggregate
 
   belongs_to :team
 
-  def self.to_service_metadata(event_id, published_at = Time.now)
-    service_providers = SpComponent.all_components_for_metadata
+  def self.to_service_metadata(event_id, environment, published_at = Time.now)
+    service_providers = SpComponent.all_components_for_metadata(environment)
     {
       published_at: published_at,
       event_id: event_id,
       connected_services: service_providers.map(&:services_to_metadata).flatten,
-      matching_service_adapters: MsaComponent.all_components_for_metadata.map(&:to_metadata),
+      matching_service_adapters: MsaComponent.all_components_for_metadata(environment).map(&:to_metadata),
       service_providers: service_providers.map(&:to_metadata),
     }
   end
 
-  def self.all_components_for_metadata
-    self.includes(:services)
+  def self.all_components_for_metadata(environment)
+    self.where(environment: environment)
+        .includes(:services)
         .includes(:enabled_signing_certificates)
         .includes(:encryption_certificate)
   end

--- a/app/models/publish_services_metadata_event.rb
+++ b/app/models/publish_services_metadata_event.rb
@@ -29,7 +29,7 @@ class PublishServicesMetadataEvent < Event
 private
 
   def services_metadata
-    Component.to_service_metadata(event_id)
+    Component.to_service_metadata(event_id, environment)
   end
 
   def hub_environment_bucket


### PR DESCRIPTION
We're currently publishing metadata for all the components regardless of
their environment. Meaning we publish the same JSON file to different buckets.
The correct behaviour should be that only the components for that environment are present
and published in the metadata.