### PR TITLE
BUGFIX: Do not validate twice on disable/enable event

### DIFF
--- a/app/controllers/certificates_controller.rb
+++ b/app/controllers/certificates_controller.rb
@@ -35,7 +35,7 @@ class CertificatesController < ApplicationController
   def enable
     certificate = Certificate.find_by_id(params[:id])
     event = EnableSigningCertificateEvent.create(certificate: certificate)
-    unless event.valid?
+    unless event.errors.empty?
       error_message = event.errors.full_messages
       Rails.logger.error(error_message)
       flash[:error] = error_message
@@ -51,7 +51,7 @@ class CertificatesController < ApplicationController
   def disable
     certificate = Certificate.find_by_id(params[:id])
     event = DisableSigningCertificateEvent.create(certificate: certificate)
-    unless event.valid?
+    unless event.errors.empty?
       error_message = event.errors.full_messages
       Rails.logger.error(error_message)
       flash[:error] = error_message

--- a/spec/controllers/certificates_controller_spec.rb
+++ b/spec/controllers/certificates_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe CertificatesController, type: :controller do
       post :create, params: { certificate: { value: '', usage: CERTIFICATE_USAGE::SIGNING }, sp_component_id: sp_component }
 
       expect(response).to have_http_status(:success)
-      expect(response).to render_template("new")
+      expect(response).to render_template(:new)
     end
   end
 

--- a/spec/controllers/certificates_controller_spec.rb
+++ b/spec/controllers/certificates_controller_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+include AuthSupport
+include CertificateSupport
+
+RSpec.describe CertificatesController, type: :controller do
+  let(:sp_component) { create(:sp_component) }
+  let(:root) { PKI.new }
+  let(:cert_value) { root.generate_encoded_cert(expires_in: 2.months) }
+  let(:sp_signing_certificate) { create(:sp_signing_certificate) }
+
+  describe 'GET #new' do
+    it 'returns http success' do
+      certmgr_stub_auth
+      get :new, params: { sp_component_id: sp_component }
+
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe 'POST #create' do
+    it 'redirects after creating a certificate' do
+      certmgr_stub_auth
+      post :create, params: { certificate: { value: sp_signing_certificate.value, usage: CERTIFICATE_USAGE::SIGNING }, sp_component_id: sp_component }
+
+      expect(subject).to redirect_to(sp_component_path(sp_component))
+      expect(flash.now[:errors]).to be_nil
+    end
+
+    it 'renders new when invalid' do
+      certmgr_stub_auth
+      post :create, params: { certificate: { value: '', usage: CERTIFICATE_USAGE::SIGNING }, sp_component_id: sp_component }
+
+      expect(response).to have_http_status(:success)
+      expect(response).to render_template("new")
+    end
+  end
+
+  describe 'PATCH #enable' do
+    it 'redirects after enabling a certificate' do
+      certmgr_stub_auth
+      patch :enable, params: { id: sp_signing_certificate, sp_component_id: sp_component }
+
+      expect(subject).to redirect_to(sp_component_path(sp_signing_certificate.component_id))
+      expect(flash.now[:errors]).to be_nil
+    end
+ end
+
+  describe 'PATCH #disable' do
+    it 'redirects after disabling a certificate' do
+      certmgr_stub_auth
+      patch :disable, params: { id: sp_signing_certificate, sp_component_id: sp_component }
+
+      expect(subject).to redirect_to(sp_component_path(sp_signing_certificate.component_id))
+      expect(flash.now[:errors]).to be_nil
+    end
+  end
+
+  describe 'PATCH #replace' do
+    it 'redirects after replacing a certificate' do
+      certmgr_stub_auth
+      patch :replace, params: { certificate: sp_signing_certificate, component: sp_component, sp_component_id: sp_component, id: sp_signing_certificate }
+
+      expect(subject).to redirect_to(sp_component_path(sp_component))
+      expect(flash.now[:errors]).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Currently, when we disable a cert, we get a confusing error message saying
the component has to have at least one certificate.
This is due to the fact, that validation happens during the event creation and
then we call `valid?` again, which now adds the error because
the cert was disabled during the event itself.
This change looks at the errors on the model instead of re-running the validation.