### PR TITLE
BAU: Don't show the Team Members link to the user without permissions

### DIFF
--- a/app/views/layouts/main_layout.html.erb
+++ b/app/views/layouts/main_layout.html.erb
@@ -6,9 +6,11 @@
         <li class="<%= 'active' if 'user_journey'.include?(params[:controller])  %>">
           <%= link_to t('components.title'), root_path, class: "govuk-link--no-visited-state" %>
         </li>
-        <li class="<%= 'active' if 'users'.include?(params[:controller]) %>">
-          <%= link_to t('layout.main_layout.team_members'), users_path, class: "govuk-link--no-visited-state" %>
-        </li>
+        <% if current_user.roles.include?(ROLE::USER_MANAGER) %>
+          <li class="<%= 'active' if 'users'.include?(params[:controller]) %>">
+            <%= link_to t('layout.main_layout.team_members'), users_path, class: "govuk-link--no-visited-state" %>
+          </li>
+        <% end %>
       </ul>
     </div>
     </div>

--- a/spec/system/visit_index_page_spec.rb
+++ b/spec/system/visit_index_page_spec.rb
@@ -112,4 +112,11 @@ RSpec.describe 'IndexPage', type: :system do
     visit root_path
     expect(page).to have_content '2 certificates are expiring soon.'
   end
+
+  it 'does not show the Team Members link if user does not have permissions' do
+    login_certificate_manager_user
+    visit root_path
+    expect(page).not_to have_link t('layout.main_layout.team_members')
+    expect(page).to have_link t('components.title')
+  end
 end


### PR DESCRIPTION
Users who don't have user manager role, should not see that option on dashboard.