### PR TITLE
REFACTOR: Don't display Team management to users without permissions

### DIFF
--- a/app/views/layouts/main_layout.html.erb
+++ b/app/views/layouts/main_layout.html.erb
@@ -6,7 +6,7 @@
         <li class="<%= 'active' if 'user_journey'.include?(params[:controller])  %>">
           <%= link_to t('components.title'), root_path, class: "govuk-link--no-visited-state" %>
         </li>
-        <% if current_user.roles.include?(ROLE::USER_MANAGER) %>
+        <% if policy(UsersController).index? %>
           <li class="<%= 'active' if 'users'.include?(params[:controller]) %>">
             <%= link_to t('layout.main_layout.team_members'), users_path, class: "govuk-link--no-visited-state" %>
           </li>


### PR DESCRIPTION
Previous change forgot about GDS users, i.e. it was hidden for GDS roles.
Using policy should be more realiable and consistent.