### PR TITLE
FIX: accordion in admin view for components certificates

### DIFF
--- a/app/views/sp_components/show.html.erb
+++ b/app/views/sp_components/show.html.erb
@@ -27,7 +27,7 @@
 
 <% if @component.certificates.present? %>
 
-  <div class="govuk-accordion" data-module="accordion" id="accordion-default">
+  <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
     <div class="govuk-accordion__section ">
       <div class="govuk-accordion__section-header">
         <h2 class="govuk-accordion__section-heading">


### PR DESCRIPTION
The accordion was missing the updated 'govuk' tag. You can now view previous encryption certificates and all certificates

<img width="919" alt="Screen Shot 2019-11-11 at 15 04 22" src="https://user-images.githubusercontent.com/24409958/68597272-9635ca80-0494-11ea-864b-b87da2fa8d99.png">