### PR TITLE
8ahctkdg: change the ordering logic on the dashboard

### DIFF
--- a/app/controllers/user_journey_controller.rb
+++ b/app/controllers/user_journey_controller.rb
@@ -13,12 +13,11 @@ class UserJourneyController < ApplicationController
 
   def index
     if current_user.permissions.component_management
-      @sp_components = SpComponent.all
-      @msa_components = MsaComponent.all
+      @components = SpComponent.all + MsaComponent.all
     else
-      @sp_components = SpComponent.where(team_id: current_user.team)
-      @msa_components = MsaComponent.where(team_id: current_user.team)
+      @components = SpComponent.for_user(current_user) + MsaComponent.for_user(current_user)
     end
+    @total_certificates_expiring_soon = helpers.certificate_expiry_count(@components)
   end
 
   def is_dual_running

--- a/app/helpers/user_journey_helper.rb
+++ b/app/helpers/user_journey_helper.rb
@@ -19,7 +19,7 @@ module UserJourneyHelper
     if certificate.nil?
       "MISSING"
     elsif certificate.expires_soon?
-      "EXPIRES IN #{(certificate.x509.not_after.to_date - Time.now.to_date).to_i} DAYS"
+      "EXPIRES IN #{certificate.days_left} DAYS"
     elsif certificate.deploying?
       "DEPLOYING"
     else
@@ -27,7 +27,7 @@ module UserJourneyHelper
     end
   end
 
-  def certificate_expiry_count(msa_components, sp_components)
-    (msa_components + sp_components).map(&:certificates).flatten.select(&:expires_soon?).count
+  def certificate_expiry_count(components)
+    components.map(&:current_certificates).flatten.select(&:expires_soon?).count
   end
 end

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -28,6 +28,10 @@ class Certificate < Aggregate
     x509.not_after - Time.now < 30.day
   end
 
+  def days_left
+    (x509.not_after.to_date - Time.now.to_date).to_i
+  end
+
   def expired?
     x509.not_after < Time.now
   end

--- a/app/views/shared/_user_component_certificates.html.erb
+++ b/app/views/shared/_user_component_certificates.html.erb
@@ -1,13 +1,13 @@
 <% if components.present? %>
-  <% components.group_by(&:environment).sort.reverse.each do |environment, grouped_components| %>
+  <% @components.group_by(&:environment).sort.reverse.each do |environment, grouped_components|%>
     <h2 class="govuk-heading-m"><%= environment.capitalize %></h2>
-    <% grouped_components.reverse.each do |component| %>
+    <% grouped_components.sort_by(&:days_left).each do |component| %>
       <table class="govuk-table" id="<%= component.id %>">
         <caption class="govuk-table__caption govuk-!-margin-bottom-1">
-        <%= t("user_journey.component_long_name.#{component.type}") %>
-          <span class="govuk-body">
-            <%= t 'user_journey.used_by', services: component.services.map(&:name).join(', ') %>     
-          </span>     
+          <%= t("user_journey.component_long_name.#{component.type}") %>
+            <span class="govuk-body">
+              <%= t 'user_journey.used_by', services: component.services.map(&:name).join(', ') %>
+            </span>
         </caption>
         <thead class="govuk-table__head govuk-visually-hidden">
           <tr class="govuk-table__row">
@@ -16,35 +16,40 @@
           </tr>
         </thead>
         <tbody class="govuk-table__body app-table__body--noheading">
-          <% if component.encryption_certificate.present? %>
-            <tr class="govuk-table__row" id="<%= component.encryption_certificate_id %>">
-              <td class="govuk-table__cell"><%= link_to t('user_journey.encryption_certificate'), view_certificate_path(component.component_type, component.id, component.encryption_certificate_id) %></td>
-              <td class="govuk-table__cell">
-                <div class="app-certificate-tag <%= 'app-certificate-tag-expiring' if component.encryption_certificate.expires_soon? %> <%= 'app-certificate-tag-deploying' if component.encryption_certificate.deploying? %>">
-                  <strong class="govuk-tag"><%= certificate_status(component.encryption_certificate) %></strong>
-                </div>
-              </td>
-            </tr>
-          <% else %>
-            <td class="govuk-table__cell"><%= t 'user_journey.encryption_certificate' %></td>
-            <td class="govuk-table__cell">
-              <div class="app-certificate-tag">
-                <strong class="govuk-tag"><%= certificate_status(component.encryption_certificate) %></strong>
-              </div>
-            </td>
+          <% component.sorted_certificates.each do |cert| %>
+              <% if cert.signing? %>
+                <tr class="govuk-table__row" id="<%= cert.id %>">
+                  <td class="govuk-table__cell">
+                    <% if component.enabled_signing_certificates.length == 2 %>
+                      <%= link_to t('user_journey.two_signing_certificate', type: t("user_journey.#{position(cert)}")) , view_certificate_path(cert.component_type, component.id, cert.id) %>
+                    <% else %>
+                      <%= link_to t('user_journey.signing_certificate'), view_certificate_path(cert.component_type, component.id, cert.id) %>
+                    <% end %>
+                  </td>
+                  <td class="govuk-table__cell">
+                    <div class="app-certificate-tag <%= 'app-certificate-tag-deploying' if cert.deploying? %><%= 'app-certificate-tag-expiring' if cert.expires_soon? %>">
+                      <strong class="govuk-tag"><%= certificate_status(cert) %></strong>
+                    </div>
+                  </td>
+                </tr>
+              <%end%>
+            <% if cert.encryption? %>
+              <tr class="govuk-table__row" id="<%= cert.id %>">
+                <td class="govuk-table__cell"><%= link_to t('user_journey.encryption_certificate'), view_certificate_path(component.component_type, component.id, cert.id) %></td>
+                <td class="govuk-table__cell">
+                  <div class="app-certificate-tag <%= 'app-certificate-tag-expiring' if cert.expires_soon? %> <%= 'app-certificate-tag-deploying' if cert.deploying? %>">
+                    <strong class="govuk-tag"><%= certificate_status(cert) %></strong>
+                  </div>
+                </td>
+              </tr>
+            <%end %>
           <% end %>
-          <% component.enabled_signing_certificates.each do |signing| %>
-            <tr class="govuk-table__row" id="<%= signing.id %>">
-            <td class="govuk-table__cell">
-              <% if component.enabled_signing_certificates.length == 2 %>
-                  <%= link_to t('user_journey.two_signing_certificate', type: t("user_journey.#{position(signing)}")) , view_certificate_path(signing.component_type, component.id, signing.id) %>
-                <% else %>
-                  <%= link_to t('user_journey.signing_certificate'), view_certificate_path(signing.component_type, component.id, signing.id) %>
-                <% end %>
-              </td>
+          <% if component.encryption_certificate.nil? %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell"><%= t 'user_journey.encryption_certificate' %></td>
               <td class="govuk-table__cell">
-                <div class="app-certificate-tag <%= 'app-certificate-tag-deploying' if signing.deploying? %><%= 'app-certificate-tag-expiring' if signing.expires_soon? %>">
-                  <strong class="govuk-tag"><%= certificate_status(signing) %></strong>
+                <div class="app-certificate-tag">
+                  <strong class="govuk-tag"><%= certificate_status(component.encryption_certificate) %></strong>
                 </div>
               </td>
             </tr>

--- a/app/views/user_journey/index.html.erb
+++ b/app/views/user_journey/index.html.erb
@@ -2,11 +2,11 @@
 
 <h1 class="govuk-heading-l"><%= t 'components.title' %></h1>
 
-<% if certificate_expiry_count(@msa_components, @sp_components) > 0 %>
-  <p><%= t('user_journey.certificates_expiring', number: certificate_expiry_count(@msa_components, @sp_components)) %></p>
+<% if @total_certificates_expiring_soon  > 0 %>
+  <p><%= t('user_journey.certificates_expiring', number: @total_certificates_expiring_soon) %></p>
 <% end %>
 
 <p><%= t('user_journey.maintain_connection') %></p>
 <p><%= t('user_journey.connection_broken_or_compromised_guidance') %> <%= link_to t('user_journey.connection_broken_or_compromised_link'), t('user_journey.urls.connection_broken_or_compromised') %>.</p>
 
-<%= render "shared/user_component_certificates", components: @msa_components + @sp_components %>
+<%= render "shared/user_component_certificates", components: @components %>

--- a/spec/controllers/user_journey_controller_spec.rb
+++ b/spec/controllers/user_journey_controller_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe UserJourneyController, type: :controller do
       sp_component = create(:sp_component, team_id: @user.team)
       get :index
       expect(response).to have_http_status(:success)
-      expect(@controller.instance_variable_get(:@sp_components).length).to eq(1)
-      expect(@controller.instance_variable_get(:@sp_components)[0].team_id).to eq(sp_component.team_id)
+      expect(@controller.instance_variable_get(:@components).length).to eq(1)
+      expect(@controller.instance_variable_get(:@components)[0].team_id).to eq(sp_component.team_id)
     end
 
     it 'should not show user components with different id' do
@@ -58,8 +58,8 @@ RSpec.describe UserJourneyController, type: :controller do
       create(:sp_component)
       get :index
       expect(response).to have_http_status(:success)
-      expect(@controller.instance_variable_get(:@sp_components).length).to eq(0)
-      expect(@controller.instance_variable_get(:@sp_components)[0]).to eq(nil)
+      expect(@controller.instance_variable_get(:@components).length).to eq(0)
+      expect(@controller.instance_variable_get(:@components)[0]).to eq(nil)
     end
 
     it 'should only show the user their team components with the same id' do
@@ -68,8 +68,8 @@ RSpec.describe UserJourneyController, type: :controller do
       create(:sp_component)
       get :index
       expect(response).to have_http_status(:success)
-      expect(@controller.instance_variable_get(:@sp_components).length).to eq(1)
-      expect(@controller.instance_variable_get(:@sp_components)[0].team_id).to eq(sp_component.team_id)
+      expect(@controller.instance_variable_get(:@components).length).to eq(1)
+      expect(@controller.instance_variable_get(:@components)[0].team_id).to eq(sp_component.team_id)
     end
   end
 

--- a/spec/models/component_spec.rb
+++ b/spec/models/component_spec.rb
@@ -14,52 +14,52 @@ RSpec.describe Component, type: :model do
     let(:sp_component) { create(:new_sp_component_event).sp_component }
     let(:root) { PKI.new }
     let!(:upload_signing_certificate_event_1) do
-      UploadCertificateEvent.create(
+      create(:upload_certificate_event,
         usage: CERTIFICATE_USAGE::SIGNING,
         value: root.generate_encoded_cert(expires_in: 6.months),
         component: msa_component
       )
     end
     let!(:upload_signing_certificate_event_2) do
-      UploadCertificateEvent.create(
+      create(:upload_certificate_event,
         usage: CERTIFICATE_USAGE::SIGNING,
         value: root.generate_encoded_cert(expires_in: 6.months),
         component: msa_component
       )
     end
     let!(:upload_signing_certificate_event_3) do
-      UploadCertificateEvent.create(
+      create(:upload_certificate_event,
         usage: CERTIFICATE_USAGE::SIGNING,
         value: root.generate_encoded_cert(expires_in: 6.months),
         component: sp_component
       )
     end
     let!(:upload_signing_certificate_event_4) do
-      UploadCertificateEvent.create(
+      create(:upload_certificate_event,
         usage: CERTIFICATE_USAGE::SIGNING,
         value: root.generate_encoded_cert(expires_in: 2.months),
         component: sp_component
       )
     end
     let!(:upload_encryption_event_1) do
-      event = UploadCertificateEvent.create(
+      event = create(:upload_certificate_event,
         usage: CERTIFICATE_USAGE::ENCRYPTION,
         value: root.generate_encoded_cert(expires_in: 6.months),
         component: msa_component
       )
-      ReplaceEncryptionCertificateEvent.create(
+      create(:replace_encryption_certificate_event,
         component: msa_component,
         encryption_certificate_id: event.certificate.id
       )
       event
     end
     let!(:upload_encryption_event_2) do
-      event = UploadCertificateEvent.create(
+      event = create(:upload_certificate_event,
         usage: CERTIFICATE_USAGE::ENCRYPTION,
         value: root.generate_encoded_cert(expires_in: 3.months),
         component: sp_component
       )
-      ReplaceEncryptionCertificateEvent.create(
+      create(:replace_encryption_certificate_event,
         component: sp_component,
         encryption_certificate_id: event.certificate.id
       )
@@ -181,4 +181,202 @@ RSpec.describe Component, type: :model do
       expect(actual_config[:service_providers][0][:encryption_certificate]).to be_nil
     end
   end
+  context 'sorting certificates' do
+    before(:each) do
+      SpComponent.destroy_all
+      MsaComponent.destroy_all
+    end
+
+    let(:root) { PKI.new }
+    let(:msa_component) { create(:new_msa_component_event).msa_component }
+    let(:sp_component) { create(:new_sp_component_event).sp_component }
+
+    def encryption_certificate(expires_in: 129.days, component: )
+      @msa_encryption_event = create(:upload_certificate_event,
+        usage: CERTIFICATE_USAGE::ENCRYPTION,
+        value: root.generate_encoded_cert(expires_in: expires_in),
+        component: component
+      )
+      create(:replace_encryption_certificate_event,
+        component: msa_component,
+        encryption_certificate_id: @msa_encryption_event.certificate.id
+      ) unless msa_component.encryption_certificate_id == @msa_encryption_event.certificate.id
+
+      @msa_encryption_event.certificate
+    end
+
+    it 'maintains order from (lowest to highest) days left' do
+      msa_primary = create(:upload_certificate_event,
+        usage: CERTIFICATE_USAGE::SIGNING,
+        value: root.generate_encoded_cert(expires_in: 128.days),
+        component: msa_component).certificate
+      msa_secondary = create(:upload_certificate_event,
+        usage: CERTIFICATE_USAGE::SIGNING,
+        value: root.generate_encoded_cert(expires_in: 105.days),
+        component: msa_component).certificate
+      msa_encryption = encryption_certificate(component: msa_component, expires_in: 118.days)
+
+      travel_to Time.now + 100.days
+
+      expect(msa_component.sorted_certificates.map(&:days_left))
+        .to eql [105-100, 118-100, 128-100]
+      expect(msa_component.sorted_certificates)
+        .to eql [msa_secondary, msa_encryption, msa_primary]
+    end
+
+    it 'does not maintains order from (lowest to highest) when certificates are not about to expire' do
+      msa_primary = create(:upload_certificate_event,
+        usage: CERTIFICATE_USAGE::SIGNING,
+        value: root.generate_encoded_cert(expires_in: 360.days),
+        component: msa_component).certificate
+      msa_secondary = create(:upload_certificate_event,
+        usage: CERTIFICATE_USAGE::SIGNING,
+        value: root.generate_encoded_cert(expires_in: 345.days),
+        component: msa_component).certificate
+      msa_encryption = encryption_certificate(component: msa_component, expires_in: 327.days)
+
+      travel_to Time.now + 100.days
+
+      expect(msa_component.sorted_certificates.map(&:days_left))
+        .not_to eql [327-100, 345-100, 360-100]
+      expect(msa_component.sorted_certificates)
+        .not_to eql [msa_encryption, msa_secondary, msa_primary]
+    end
+
+    it 'maintains order from (lowest to highest) when signing certificate is disabled' do
+      msa_primary = create(:upload_certificate_event,
+        usage: CERTIFICATE_USAGE::SIGNING,
+        value: root.generate_encoded_cert(expires_in: 128.days),
+        component: msa_component).certificate
+      msa_secondary = create(:upload_certificate_event,
+        usage: CERTIFICATE_USAGE::SIGNING,
+        value: root.generate_encoded_cert(expires_in: 105.days),
+        component: msa_component).certificate
+      msa_encryption = encryption_certificate(component: msa_component, expires_in: 138.days)
+
+      travel_to Time.now + 100.days
+
+      event = DisableSigningCertificateEvent.create(
+        certificate: msa_secondary
+      )
+
+      expect(msa_component.sorted_certificates)
+        .to eql [msa_primary, msa_encryption]
+    end
+
+    it 'maintains order from (lowest to highest) when encryption certificate is replaced' do
+      msa_primary = create(:upload_certificate_event,
+        usage: CERTIFICATE_USAGE::SIGNING,
+        value: root.generate_encoded_cert(expires_in: 128.days),
+        component: msa_component).certificate
+      msa_secondary = create(:upload_certificate_event,
+        usage: CERTIFICATE_USAGE::SIGNING,
+        value: root.generate_encoded_cert(expires_in: 105.days),
+        component: msa_component).certificate
+      msa_encryption = encryption_certificate(component: msa_component, expires_in: 138.days)
+
+      travel_to Time.now + 100.days
+
+      event = DisableSigningCertificateEvent.create(
+        certificate: msa_secondary
+      )
+      new_encryption_certificate = create(:msa_encryption_certificate)
+      create(:replace_encryption_certificate_event,
+        component: msa_component,
+        encryption_certificate_id: new_encryption_certificate.id
+      )
+
+      expect(msa_component.sorted_certificates)
+        .to eql [msa_primary, new_encryption_certificate]
+    end
+
+    it "shows encryption certificate first, when it's to expire first maintains order (lowest to highest)" do
+      msa_primary = create(:upload_certificate_event,
+        usage: CERTIFICATE_USAGE::SIGNING,
+        value: root.generate_encoded_cert(expires_in: 364.days),
+        component: msa_component).certificate
+      msa_secondary = create(:upload_certificate_event,
+        usage: CERTIFICATE_USAGE::SIGNING,
+        value: root.generate_encoded_cert(expires_in: 122.days),
+        component: msa_component).certificate
+      msa_encryption = encryption_certificate(expires_in: 104.days, component: msa_component)
+
+      travel_to Time.now + 100.days
+
+      expect(msa_component.sorted_certificates.map(&:days_left))
+        .to eql [104-100, 122-100, 364-100]
+      expect(msa_component.sorted_certificates)
+        .to eql [msa_encryption, msa_secondary, msa_primary]
+    end
+
+    it 'orders components according lowest certificate present from (lowest to highest) days_left' do
+      zeus_msa = create(:msa_component, name: 'MSA Zeus')
+      zeus_sp = create(:sp_component, name: 'SP Zeus')
+      aphrodite_msa = create(:msa_component, name: 'MSA Aphrodite')
+      aphrodite_sp = create(:sp_component, name: 'SP Aphrodite')
+
+      zeus_sp_primary = create(:upload_certificate_event,
+        usage: CERTIFICATE_USAGE::SIGNING,
+        value: root.generate_encoded_cert(expires_in: 116.days),
+        component: zeus_sp).certificate
+      zeus_sp_secondary = create(:upload_certificate_event,
+        usage: CERTIFICATE_USAGE::SIGNING,
+        value: root.generate_encoded_cert(expires_in: 102.days),
+        component: zeus_sp).certificate
+      zeus_sp_encryption = encryption_certificate(component: zeus_sp, expires_in: 108.days)
+
+      aphrodite_sp_primary = create(:upload_certificate_event,
+        usage: CERTIFICATE_USAGE::SIGNING,
+        value: root.generate_encoded_cert(expires_in: 364.days),
+        component: aphrodite_sp).certificate
+      aphrodite_sp_secondary = create(:upload_certificate_event,
+        usage: CERTIFICATE_USAGE::SIGNING,
+        value: root.generate_encoded_cert(expires_in: 125.days),
+        component: aphrodite_sp).certificate
+      aphrodite_sp_encryption = encryption_certificate(expires_in: 130.days, component: aphrodite_sp)
+
+      aphrodite_msa_primary = create(:upload_certificate_event,
+        usage: CERTIFICATE_USAGE::SIGNING,
+        value: root.generate_encoded_cert(expires_in: 364.days),
+        component: aphrodite_msa).certificate
+      aphrodite_msa_secondary = create(:upload_certificate_event,
+        usage: CERTIFICATE_USAGE::SIGNING,
+        value: root.generate_encoded_cert(expires_in: 122.days),
+        component: aphrodite_msa).certificate
+      aphrodite_sp_encryption = encryption_certificate(expires_in: 140.days, component: aphrodite_msa)
+
+      zeus_msa_primary = create(:upload_certificate_event,
+        usage: CERTIFICATE_USAGE::SIGNING,
+        value: root.generate_encoded_cert(expires_in: 128.days),
+        component: zeus_msa).certificate
+      zeus_msa_secondary = create(:upload_certificate_event,
+        usage: CERTIFICATE_USAGE::SIGNING,
+        value: root.generate_encoded_cert(expires_in: 105.days),
+        component: zeus_msa).certificate
+      zeus_msa_encryption = encryption_certificate(component: zeus_msa, expires_in: 138.days)
+
+      travel_to Time.now + 100.days
+      components = MsaComponent.where(name: ['MSA Zeus','MSA Aphrodite']) + SpComponent.where(name: ['SP Zeus','SP Aphrodite'])
+
+      expect(components.sort_by(&:days_left)).to eq [zeus_sp, zeus_msa, aphrodite_msa, aphrodite_sp]
+      expect(components.sort_by(&:days_left).map(&:days_left)).to eq [2, 5, 22, 25]
+    end
+
+    it 'uses a NON-SORTING-SEED value when any component does not contain a certificate' do
+      zeus_msa = create(:msa_component, name: 'MSA Zeus')
+      zeus_sp = create(:sp_component, name: 'SP Zeus')
+      aphrodite_msa = create(:msa_component, name: 'MSA Aphrodite')
+      aphrodite_sp = create(:sp_component, name: 'SP Aphrodite')
+
+      travel_to Time.now + 100.days
+      components = MsaComponent.where(name: ['MSA Zeus','MSA Aphrodite']) + SpComponent.where(name: ['SP Zeus','SP Aphrodite'])
+
+      expect(components.map(&:sorted_certificates)).to eql [[], [], [], []]
+      expect(components.map(&:days_left))
+        .to eq [Component::NON_SORTING_SEED, Component::NON_SORTING_SEED, Component::NON_SORTING_SEED, Component::NON_SORTING_SEED]
+      expect(components.sort_by(&:days_left)).to eq [zeus_msa, aphrodite_msa, zeus_sp, aphrodite_sp]
+    end
+  end
 end
+
+

--- a/spec/support/matchers/appear_before.rb
+++ b/spec/support/matchers/appear_before.rb
@@ -1,0 +1,5 @@
+RSpec::Matchers.define :appear_before do |later_content|
+  match do |earlier_content|
+    page.body.index(earlier_content).to_i < page.body.index(later_content).to_i
+  end
+end


### PR DESCRIPTION
[**Change the ordering logic on the dashboard**](https://trello.com/c/8ahctkdG/738-change-the-ordering-logic-on-the-dashboard)
On the dashboard, the components should be grouped by environment. Production first, Integration second, within each group/section, any components with an expiring cert should at the top of the group.

