### PR TITLE
BUGFIX: Inconsistencies in the view and buttons when deploying

### DIFF
--- a/app/views/user_journey/view_certificate.html.erb
+++ b/app/views/user_journey/view_certificate.html.erb
@@ -46,20 +46,23 @@
   <% else %>
     <%= link_to t('user_journey.certificate.replace'), before_you_start_path, class: "govuk-button", data: { module: "govuk-button" }, role:"button" %>
   <% end %>
+<% end %>
 
-<% else %>
+<% if @certificate.signing? %>
   <% if @certificate.component.enabled_signing_certificates.length < 2 %>
     <%= link_to t('user_journey.certificate.add_new'), before_you_start_path, class: "govuk-button", data: { module: "govuk-button" }, role:"button" %> 
-  <% elsif secondary_signing_certificate?(@certificate) && !deployment_in_progress?(@certificate) %>
-    <div class="govuk-error-summary govuk-error-summary--grey" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
-      <h2 class="govuk-error-summary__title" id="error-summary-title"><%= t('user_journey.certificate.stop_using_secondary_heading')%></h2>
-      <div class="govuk-error-summary__body">
-        <p><%= t('user_journey.certificate.stop_using_secondary_warning')%></p>
-        <p><%= render 'shared/component_certificate_doc_links', certificate: @certificate %></p>
-        <%= link_to t('user_journey.certificate.stop_using'), disable_certificate_path, method: :patch, class: "govuk-button", data: { module: "govuk-button" }, role:"button" %> 
+  <% elsif secondary_signing_certificate?(@certificate) %>
+    <% unless deployment_in_progress?(@certificate)%>
+      <div class="govuk-error-summary govuk-error-summary--grey" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
+        <h2 class="govuk-error-summary__title" id="error-summary-title"><%= t('user_journey.certificate.stop_using_secondary_heading')%></h2>
+        <div class="govuk-error-summary__body">
+          <p><%= t('user_journey.certificate.stop_using_secondary_warning')%></p>
+          <p><%= render 'shared/component_certificate_doc_links', certificate: @certificate %></p>
+          <%= link_to t('user_journey.certificate.stop_using'), disable_certificate_path, method: :patch, class: "govuk-button", data: { module: "govuk-button" }, role:"button" %> 
+        </div>
       </div>
-    </div>
-  <% else %>
+    <% end %>
+  <% elsif !@certificate.deploying?%>
     <div class="govuk-error-summary govuk-error-summary--orange" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
       <h2 class="govuk-error-summary__title" id="error-summary-title"><%= t('user_journey.certificate.stop_using_primary_heading')%></h2>
       <div class="govuk-error-summary__body">


### PR DESCRIPTION
There was insufficient isolation between the encryption and signing, and primary and secondary certs.
Causing some of the text and buttons to display incorrectly.

Co-Authored-By: Amrit Sidhu <amrit.sidhu@digital.cabinet-office.gov.uk>