### PR TITLE
BAU: Group by environment

### DIFF
--- a/app/views/shared/_user_component_certificates.html.erb
+++ b/app/views/shared/_user_component_certificates.html.erb
@@ -1,54 +1,56 @@
 <% if components.present? %>
-  <% components.reverse.each do |component| %>
-    <table class="govuk-table" id="<%= component.id %>">
-      <h2 class="govuk-heading-m"><%= component.environment.capitalize %></h2>
-      <caption class="govuk-table__caption govuk-!-margin-bottom-1">
-       <%= t("user_journey.component_long_name.#{component.type}") %>
-        <span class="govuk-body">
-          <%= t 'user_journey.used_by', services: component.services.map(&:name).join(', ') %>     
-        </span>     
-      </caption>
-      <thead class="govuk-table__head govuk-visually-hidden">
-        <tr class="govuk-table__row">
-          <th class="govuk-table__header" scope="col"><%= t 'user_journey.certificate' %></th>
-          <th class="govuk-table__header" scope="col"><%= t 'user_journey.status' %></th>
-        </tr>
-      </thead>
-      <tbody class="govuk-table__body app-table__body--noheading">
-        <% if component.encryption_certificate.present? %>
-          <tr class="govuk-table__row" id="<%= component.encryption_certificate_id %>">
-            <td class="govuk-table__cell"><%= link_to t('user_journey.encryption_certificate'), view_certificate_path(component.component_type, component.id, component.encryption_certificate_id) %></td>
+  <% components.group_by(&:environment).sort.reverse.each do |environment, grouped_components| %>
+    <h2 class="govuk-heading-m"><%= environment.capitalize %></h2>
+    <% grouped_components.reverse.each do |component| %>
+      <table class="govuk-table" id="<%= component.id %>">
+        <caption class="govuk-table__caption govuk-!-margin-bottom-1">
+        <%= t("user_journey.component_long_name.#{component.type}") %>
+          <span class="govuk-body">
+            <%= t 'user_journey.used_by', services: component.services.map(&:name).join(', ') %>     
+          </span>     
+        </caption>
+        <thead class="govuk-table__head govuk-visually-hidden">
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header" scope="col"><%= t 'user_journey.certificate' %></th>
+            <th class="govuk-table__header" scope="col"><%= t 'user_journey.status' %></th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body app-table__body--noheading">
+          <% if component.encryption_certificate.present? %>
+            <tr class="govuk-table__row" id="<%= component.encryption_certificate_id %>">
+              <td class="govuk-table__cell"><%= link_to t('user_journey.encryption_certificate'), view_certificate_path(component.component_type, component.id, component.encryption_certificate_id) %></td>
+              <td class="govuk-table__cell">
+                <div class="app-certificate-tag <%= 'app-certificate-tag-expiring' if component.encryption_certificate.expires_soon? %> <%= 'app-certificate-tag-deploying' if component.encryption_certificate.deploying? %>">
+                  <strong class="govuk-tag"><%= certificate_status(component.encryption_certificate) %></strong>
+                </div>
+              </td>
+            </tr>
+          <% else %>
+            <td class="govuk-table__cell"><%= t 'user_journey.encryption_certificate' %></td>
             <td class="govuk-table__cell">
-              <div class="app-certificate-tag <%= 'app-certificate-tag-expiring' if component.encryption_certificate.expires_soon? %> <%= 'app-certificate-tag-deploying' if component.encryption_certificate.deploying? %>">
+              <div class="app-certificate-tag">
                 <strong class="govuk-tag"><%= certificate_status(component.encryption_certificate) %></strong>
               </div>
             </td>
-          </tr>
-        <% else %>
-          <td class="govuk-table__cell"><%= t 'user_journey.encryption_certificate' %></td>
-          <td class="govuk-table__cell">
-            <div class="app-certificate-tag">
-              <strong class="govuk-tag"><%= certificate_status(component.encryption_certificate) %></strong>
-            </div>
-          </td>
-        <% end %>
-        <% component.enabled_signing_certificates.each do |signing| %>
-          <tr class="govuk-table__row" id="<%= signing.id %>">
-          <td class="govuk-table__cell">
-            <% if component.enabled_signing_certificates.length == 2 %>
-                <%= link_to t('user_journey.two_signing_certificate', type: t("user_journey.#{position(signing)}")) , view_certificate_path(signing.component_type, component.id, signing.id) %>
-              <% else %>
-                <%= link_to t('user_journey.signing_certificate'), view_certificate_path(signing.component_type, component.id, signing.id) %>
-              <% end %>
-            </td>
+          <% end %>
+          <% component.enabled_signing_certificates.each do |signing| %>
+            <tr class="govuk-table__row" id="<%= signing.id %>">
             <td class="govuk-table__cell">
-              <div class="app-certificate-tag <%= 'app-certificate-tag-deploying' if signing.deploying? %><%= 'app-certificate-tag-expiring' if signing.expires_soon? %>">
-                <strong class="govuk-tag"><%= certificate_status(signing) %></strong>
-              </div>
-            </td>
-          </tr>
+              <% if component.enabled_signing_certificates.length == 2 %>
+                  <%= link_to t('user_journey.two_signing_certificate', type: t("user_journey.#{position(signing)}")) , view_certificate_path(signing.component_type, component.id, signing.id) %>
+                <% else %>
+                  <%= link_to t('user_journey.signing_certificate'), view_certificate_path(signing.component_type, component.id, signing.id) %>
+                <% end %>
+              </td>
+              <td class="govuk-table__cell">
+                <div class="app-certificate-tag <%= 'app-certificate-tag-deploying' if signing.deploying? %><%= 'app-certificate-tag-expiring' if signing.expires_soon? %>">
+                  <strong class="govuk-tag"><%= certificate_status(signing) %></strong>
+                </div>
+              </td>
+            </tr>
+          <% end %>
         <% end %>
-      <% end %>
-    </tbody>
-  </table>
+        </tbody>
+      </table>
+    <% end %>
 <% end %>


### PR DESCRIPTION
Given the larger complexity of the other ticket which combines grouping and sorting.
For private beta we only need the grouping, since none of the certs will be expiring.

The diff is confusing, but all I did was added the `group_by` method first and move the logic one level down.