### PR TITLE
BUGFIX: Fix grouping

### DIFF
--- a/app/views/user_journey/index.html.erb
+++ b/app/views/user_journey/index.html.erb
@@ -9,5 +9,4 @@
 <p><%= t('user_journey.maintain_connection') %></p>
 <p><%= t('user_journey.connection_broken_or_compromised_guidance') %> <%= link_to t('user_journey.connection_broken_or_compromised_link'), t('user_journey.urls.connection_broken_or_compromised') %>.</p>
 
-<%= render "shared/user_component_certificates", components: @msa_components, name: COMPONENT_TYPE::MSA %>
-<%= render "shared/user_component_certificates", components: @sp_components, name: COMPONENT_TYPE::SP %> 
+<%= render "shared/user_component_certificates", components: @msa_components + @sp_components %>

--- a/spec/system/visit_index_page_spec.rb
+++ b/spec/system/visit_index_page_spec.rb
@@ -31,7 +31,9 @@ RSpec.describe 'IndexPage', type: :system do
     msa_component = msa_encryption_certificate.component
     visit root_path
     expect(page).to have_content 'Manage certificates'
-    click_link('Encryption certificate', match: :first)
+    within("##{msa_component.id}") do 
+      click_link('Encryption certificate')
+    end
     expect(current_path).to eql view_certificate_path(msa_component.component_type, msa_component.id, msa_component.encryption_certificate_id)
   end
 


### PR DESCRIPTION
We were still grouping components by type. This changes uses one list of components,
instead of splitting them to MSA and SPs, which was creating
duplicate environment groupings for each type.