### PR TITLE
BAU: Correct the content for signing cert on confirmation page

### DIFF
--- a/app/views/user_journey/check_your_certificate.html.erb
+++ b/app/views/user_journey/check_your_certificate.html.erb
@@ -7,13 +7,21 @@
 
 <%= render 'shared/user_certificate_view', certificate: @new_certificate, full_details: false %>
 
-<% if @not_dual_running %>
-  <p><%= t 'user_journey.certificate.will_replace_old_certificate' %></p>
-  <p><%= t 'user_journey.certificate.sp_doesnt_support_dual_running' %></p>
-  <p><%= t 'user_journey.certificate.restore_connection' %></p>
-<% else %>
-  <p><%= t('user_journey.certificate.certificate_will_be_replaced', component: @certificate.component.display, certificate: @certificate.usage) %></p>
-  <p><%= t('user_journey.certificate.encrypt_messages_for_your_service', component: @certificate.component.display, certificate: @certificate.usage) %></p>
+<% if @certificate.encryption? %>
+  <% if @not_dual_running %>
+    <p><%= t 'user_journey.certificate.will_replace_old_certificate' %></p>
+    <p><%= t 'user_journey.certificate.sp_doesnt_support_dual_running' %></p>
+    <p><%= t 'user_journey.certificate.restore_connection' %></p>
+  <% else %>
+    <p><%= t('user_journey.certificate.certificate_will_be_replaced', component: @certificate.component.display, certificate: @certificate.usage) %></p>
+    <p><%= t('user_journey.certificate.encrypt_messages_for_your_service', component: @certificate.component.display, certificate: @certificate.usage) %></p>
+    <p><%= t 'user_journey.certificate.how_long_it_takes' %></p>
+  <% end %>
+<% end %>
+
+<% if @certificate.signing? %>
+  <p><%= t 'user_journey.certificate.certificate_will_be_added' %></p>
+  <p><%= t 'user_journey.certificate.signed_mesages_from_your_service' %></p>
   <p><%= t 'user_journey.certificate.how_long_it_takes' %></p>
 <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -424,7 +424,9 @@ en:
       upload_certificate_file_header: Upload a certificate file
       paste_certificate: Paste certificate text into a text box
       certificate_will_be_replaced: Once you confirm you wish to use this certificate, your old %{component} %{certificate} certificate will be replaced with the new one in the GOV.UK Verify Hub configuration.
+      certificate_will_be_added: Once you confirm you wish to use this certificate, it will be added to the GOV.UK Verify Hub configuration alongside your old signing certificate.
       encrypt_messages_for_your_service: The GOV.UK Verify Hub will then be using your new certificate to encrypt messages for your service.
+      signed_mesages_from_your_service: The GOV.UK Verify Hub will then trust your old and new certificates to verify signatures on messages from your service. 
       how_long_it_takes: This takes around 10 minutes. Your connection will not break.
       will_replace_old_certificate: Using this certificate will replace your old encryption certificate in GOV.UK Verify's configuration within 10 minutes.
       sp_doesnt_support_dual_running: Because your service provider does not support dual running, your connection will break when the GOV.UK Verify Hub starts using your new certificate.

--- a/spec/system/visit_user_journey_check_your_certificate_page_spec.rb
+++ b/spec/system/visit_user_journey_check_your_certificate_page_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe 'Check your certificate page', type: :system do
       fill_in 'certificate_value', with: sp_signing_certificate.value
       click_button 'Continue'
       expect(current_path).to eql check_your_certificate_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])
-      expect(page).to have_content COMPONENT_TYPE::SP_LONG
+      expect(page).to have_content t('user_journey.certificate.signed_mesages_from_your_service')
       expect(page).to have_content 'Signing'
       click_button 'Use this certificate'
       expect(current_path).to eql confirmation_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])


### PR DESCRIPTION
The current content is relevant to encryption certs, not signing. Adding a new content for signing.

**Before:**
<img width="739" alt="image" src="https://user-images.githubusercontent.com/30629434/68692646-be452c80-056d-11ea-941d-570a6502c8ab.png">


**After:**
<img width="751" alt="image" src="https://user-images.githubusercontent.com/30629434/68692616-b1c0d400-056d-11ea-987a-b471b4c79957.png">
