### PR TITLE
BAU: Fix content inaccuracy on confirmation page for signing SP

### DIFF
--- a/app/views/user_journey/confirmation.html.erb
+++ b/app/views/user_journey/confirmation.html.erb
@@ -39,7 +39,7 @@
   </ul>
 <% elsif @certificate.component_type == COMPONENT_TYPE::SP %>
   <ul class="govuk-list govuk-list--number">
-    <li><%= t('user_journey.confirmation.received_email', usage: @certificate.usage, component: @certificate.component.display) %></li>
+    <li><%= t('user_journey.confirmation.received_email_to_replace', usage: @certificate.usage, component: @certificate.component.display) %></li>
     <li><%= @certificate.component.display == COMPONENT_TYPE::SP_LONG ? t('user_journey.confirmation.apply_changes') : t('user_journey.restart_component', component: @certificate.component.display) %></li>
     <li><%= t 'user_journey.confirmation.tell_verify' %></li>
   </ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -444,6 +444,7 @@ en:
       next_steps: Next steps
       rotate_other_certificates: You can rotate other certificates straight away - you do not need to wait for the email.
       received_email: Once you've received the email, delete the old %{usage} key and certificate from your %{component} configuration.
+      received_email_to_replace: Once you've received the email, replace the old %{usage} key with the new one in your %{component} configuration.
       rotate_more: Rotate more certificates
       msa_add_new_key_and_certificate: Add the new signing key and certificate to your Matching Service Adapter (MSA) configuration.
       tell_us_to_stop_using_old_certificate: Tell GOV.UK Verify to stop using your old certificate using this tool.

--- a/spec/system/visit_user_journey_confirmation_page_spec.rb
+++ b/spec/system/visit_user_journey_confirmation_page_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'Confirmation page', type: :system do
       vsp_component = certificate.component
       visit confirmation_path(vsp_component.component_type, vsp_component.id, vsp_component.signing_certificates[0])
       expect(page).to have_content COMPONENT_TYPE::VSP_SHORT
-      expect(page).to have_content 'delete the old signing key and certificate from your VSP configuration'
+      expect(page).to have_content t('user_journey.confirmation.received_email_to_replace', usage: certificate.usage, component: COMPONENT_TYPE::VSP_SHORT)
       click_link 'Rotate more certificates'
       expect(current_path).to eql root_path
     end
@@ -80,7 +80,7 @@ RSpec.describe 'Confirmation page', type: :system do
       sp_component = certificate.component
       visit confirmation_path(sp_component.component_type, sp_component.id, sp_component.signing_certificates[0])
       expect(page).to have_content COMPONENT_TYPE::SP_LONG
-      expect(page).to have_content 'delete the old signing key and certificate from your service provider configuration'
+      expect(page).to have_content t('user_journey.confirmation.received_email_to_replace', usage: certificate.usage, component: COMPONENT_TYPE::SP_LONG)
       click_link 'Rotate more certificates'
       expect(current_path).to eql root_path
     end


### PR DESCRIPTION
The instructions said to delete signing key, but it actually is to replace.

From `Once you've received the email, delete the old %{usage} key and certificate from your %{component} configuration.`
to `Once you've received the email, replace the old %{usage} key with the new one in your %{component} configuration.`