### PR TITLE
X7Gs9ssq: Fix the website responsiveness

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,8 @@
 <html lang="en" class="govuk-template">
   <head>
     <meta name="robots" content="noindex,nofollow">
-
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    
     <title><%= display_page_title %></title>
 
     <%= csrf_meta_tags %>


### PR DESCRIPTION
On mobile devices, the website doesn't scale properly. It's shown in a full-desktop view. We're using responsive components so we should take the advantage of it.

Added missing meta tag from the page template on the design system