### PR TITLE
1XQnvb8P: Fix the change password layout and remove hint text

### DIFF
--- a/app/controllers/password_controller.rb
+++ b/app/controllers/password_controller.rb
@@ -6,7 +6,7 @@ class PasswordController < ApplicationController
   skip_before_action :authenticate_user!, except: %w[password_form update_password]
   skip_before_action :set_user, except: %w[password_form update_password]
 
-  layout 'main_layout', only: :password_form
+  layout 'two_thirds_layout', only: :password_form
 
   def password_form
     @password_form = ChangePasswordForm.new

--- a/app/views/password/password_form.html.erb
+++ b/app/views/password/password_form.html.erb
@@ -1,12 +1,11 @@
 <%= page_title t('password.title_change') %>
 
+<%= link_to t('common.back'), profile_path, class: 'govuk-back-link' %>
+
 <h1 class="govuk-heading-l"><%= t 'password.change_password_heading' %></h1>
 
 <%= form_for @password_form, url: profile_change_password_path do |f| %>
   <fieldset class="govuk-fieldset" aria-describedby="changed-password-hint">
-    <span id="changed-password-hint" class="govuk-hint">
-      <%= t 'password.change_password_legend' %>
-    </span>
     <div class="govuk-form-group">
       <%= f.label :old_password, t('password.current_password_lbl'), class: "govuk-label" %>
       <%= f.password_field :old_password, class: "govuk-input govuk-input--width-20" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -186,11 +186,10 @@ en:
     change_password_heading: Change your password
     reset_password_heading: Set your new password
     password_changed: Password changed successfully
-    change_password_legend: You can change your password by entering your current password followed by a new password in the space provide and the same new password again in the confirmation space.
     reset_password_legend: You can reset your password by entering the code you have received via email.
-    current_password_lbl: "Current password:"
-    new_password_lbl: "New password:"
-    confirm_password_lbl: "Confirm new password:"
+    current_password_lbl: Current password
+    new_password_lbl: New password
+    confirm_password_lbl: Confirm new password
     change_password_btn: Change password
     password_recovered: Your password has now been changed. Please login with your new password
     errors:


### PR DESCRIPTION
After speaking with Chris I removed the hint text on the change password isn't necessary.
The page is also now using the wrong layout