### PR TITLE
tBLqcTb2: Change the content for MSA signing rotation

### DIFF
--- a/app/views/user_journey/before_you_start.html.erb
+++ b/app/views/user_journey/before_you_start.html.erb
@@ -27,12 +27,19 @@
 <% else %>
   <p><%= t 'user_journey.before_you_start.rotate_certificate_read_steps' %></p>
   <p><%= t "user_journey.before_you_start.#{@certificate.component.type}", type: @certificate.usage %>
-  <% if @certificate.signing? %>
+  <% if @certificate.signing? && @certificate.component.type == COMPONENT_TYPE::MSA_SHORT %>
+    <%= t 'user_journey.before_you_start.you_must' %>
+    <ul class="govuk-list govuk-list--number">
+      <li><%= t('user_journey.before_you_start.create_key_and_certificate', type: @certificate.usage) %></li>
+      <li><%= t('user_journey.before_you_start.add_signing_key_and_certificate_as_secondary', component: @certificate.component.display) %></li>
+      <li><%= t('user_journey.restart_component', component: @certificate.component.display) %></li>
+    </ul>
+  <% elsif @certificate.signing? %>
     <%= t 'user_journey.before_you_start.create_signing_key_and_certificate' %>
   <% else %>
     <%= t 'user_journey.before_you_start.you_must' %>
     <ul class="govuk-list govuk-list--number">
-      <li><%= t 'user_journey.before_you_start.create_key_and_certificate' %></li>
+      <li><%= t('user_journey.before_you_start.create_key_and_certificate', type: @certificate.usage) %></li>
       <li><%= t('user_journey.before_you_start.create_encryption_key_and_certificate', component: @certificate.component.display) %></li>
       <li><%= t('user_journey.restart_component', component: @certificate.component.display) %></li>
     </ul>
@@ -55,5 +62,9 @@
 <% if @not_dual_running %>
   <%= link_to t('user_journey.continue'), upload_certificate_path(dual_running: @not_dual_running), class: "govuk-button", data: { module: "govuk-button" }, role:"button" %> 
 <% else %>
-  <%= link_to @certificate.encryption? ? t('user_journey.before_you_start.have_updated', component: @certificate.component.display) : t('user_journey.continue'), upload_certificate_path, class: "govuk-button", data: { module: "govuk-button" }, role:"button" %> 
+  <% if @certificate.encryption? || (@certificate.signing? && @certificate.component.type == COMPONENT_TYPE::MSA_SHORT) %>
+    <%= link_to t('user_journey.before_you_start.have_updated', component: @certificate.component.display), upload_certificate_path, class: "govuk-button", data: { module: "govuk-button" }, role:"button" %> 
+  <% else %>
+    <%= link_to t('user_journey.continue'), upload_certificate_path, class: "govuk-button", data: { module: "govuk-button" }, role:"button" %> 
+  <% end %>
 <% end %>

--- a/app/views/user_journey/confirmation.html.erb
+++ b/app/views/user_journey/confirmation.html.erb
@@ -33,13 +33,13 @@
   <ul class="govuk-list govuk-list--number">
     <li><%= t('user_journey.confirmation.received_email_to_promote', usage: @certificate.usage, component: @certificate.component.display) %></li>
     <li><%= @certificate.component.display == COMPONENT_TYPE::SP_LONG ? t('user_journey.confirmation.apply_changes') : t('user_journey.restart_component', component: @certificate.component.display) %></li>
-    <li><%= t 'user_journey.confirmation.tell_verify_old' %></li>
+    <li><%= t('user_journey.confirmation.stop_using_old_html', href: link_to(t('user_journey.confirmation.tell_verify'), root_path)) %></li>
   </ul>
 <% else @certificate.component_type == COMPONENT_TYPE::SP %>
   <ul class="govuk-list govuk-list--number">
     <li><%= t('user_journey.confirmation.received_email_to_replace', usage: @certificate.usage, component: @certificate.component.display) %></li>
     <li><%= @certificate.component.display == COMPONENT_TYPE::SP_LONG ? t('user_journey.confirmation.apply_changes') : t('user_journey.restart_component', component: @certificate.component.display) %></li>
-    <li><%= t 'user_journey.confirmation.tell_verify' %></li>
+    <li><%= t('user_journey.confirmation.stop_using_secondary_html', href: link_to(t('user_journey.confirmation.tell_verify'), root_path)) %></li>
   </ul>
 <% end %>
 

--- a/app/views/user_journey/confirmation.html.erb
+++ b/app/views/user_journey/confirmation.html.erb
@@ -31,13 +31,11 @@
   </ul>
 <% elsif @certificate.component_type == COMPONENT_TYPE::MSA %>
   <ul class="govuk-list govuk-list--number">
-    <li><%= t 'user_journey.confirmation.msa_add_new_key_and_certificate' %></li>
-    <li><%= t('user_journey.restart_component', component: @certificate.component.display) %></li>
-    <li><%= t('user_journey.confirmation.received_email', usage: @certificate.usage, component: @certificate.component.display) %></li>
-    <li><%= t('user_journey.restart_component', component: @certificate.component.display) %></li>
-    <li><%= t 'user_journey.confirmation.tell_verify' %></li>
+    <li><%= t('user_journey.confirmation.received_email_to_promote', usage: @certificate.usage, component: @certificate.component.display) %></li>
+    <li><%= @certificate.component.display == COMPONENT_TYPE::SP_LONG ? t('user_journey.confirmation.apply_changes') : t('user_journey.restart_component', component: @certificate.component.display) %></li>
+    <li><%= t 'user_journey.confirmation.tell_verify_old' %></li>
   </ul>
-<% elsif @certificate.component_type == COMPONENT_TYPE::SP %>
+<% else @certificate.component_type == COMPONENT_TYPE::SP %>
   <ul class="govuk-list govuk-list--number">
     <li><%= t('user_journey.confirmation.received_email_to_replace', usage: @certificate.usage, component: @certificate.component.display) %></li>
     <li><%= @certificate.component.display == COMPONENT_TYPE::SP_LONG ? t('user_journey.confirmation.apply_changes') : t('user_journey.restart_component', component: @certificate.component.display) %></li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -212,7 +212,6 @@ en:
       missing_name: "Enter a name"
   layout:
     application:
-      title: Verify Self-Service
       verify: Verify
       admin: Admin
       documentation: Documentation
@@ -356,7 +355,7 @@ en:
     continue: Continue
     'no': 'No'
     'yes': 'Yes'
-    restart_component: Apply the changes to your configuration
+    restart_component: Apply the changes to your configuration.
     urls:
       MSA:
         encryption: https://prototype-docs.cloudapps.digital/rotating-your-keys-and-certificates/msa-encryption/#rotate-your-msa-encryption-key-and-certificate
@@ -391,9 +390,9 @@ en:
         SP: 'Before you upload your service provider encryption certificate:'
       you_must: "you must:"
       create_signing_key_and_certificate: "you must create a new signing key and certificate."
-      create_key_and_certificate: "Create a new %{type} key and certificate"
-      create_encryption_key_and_certificate: Add your new encryption key and certificate to your %{component} configuration
-      add_signing_key_and_certificate_as_secondary: Add your new signing key and certificate to your %{component} configuration as secondary
+      create_key_and_certificate: Create a new %{type} key and certificate.
+      create_encryption_key_and_certificate: Add your new encryption key and certificate to your %{component} configuration.
+      add_signing_key_and_certificate_as_secondary: Add your new signing key and certificate to your %{component} configuration  in the 'secondary' position.
       must_update: You must update your %{component} configuration before going to the next step, or your service's connection to GOV.UK Verify will break.
       have_updated: I have updated my %{component} configuration
       not_support_dual_running: Because your service provider does not support dual running, there will be an outage when you rotate the encryption key.
@@ -447,12 +446,12 @@ en:
       rotate_other_certificates: You can rotate other certificates straight away - you do not need to wait for the email.
       received_email: Once you've received the email, delete the old %{usage} key and certificate from your %{component} configuration.
       received_email_to_replace: Once you've received the email, replace the old %{usage} key with the new one in your %{component} configuration.
-      received_email_to_promote: Once you've received the email, promote your secondary %{usage} key and certificate to the primary position and delete the old one in your %{component} configuration.
+      received_email_to_promote: Once you've received the email, go to your %{component} configuration. Move your 'secondary' %{usage} key and certificate to the 'primary' position, and delete the old key and certificate.
       rotate_more: Rotate more certificates
       msa_add_new_key_and_certificate: Add the new signing key and certificate to your Matching Service Adapter (MSA) configuration.
-      tell_us_to_stop_using_old_certificate: Tell GOV.UK Verify to stop using your old certificate using this tool.
       configuration_warning: You must update your %{component} configuration by %{date}, or your service’s connection to GOV.UK Verify will break.
       certificate_rotations_are_independent: You can rotate other certificates while you wait for the email - certificate rotations are independent of each other.
-      tell_verify: Tell GOV.UK Verify to stop using your old (or 'secondary') certificate using this tool.
-      tell_verify_old: Tell GOV.UK Verify to stop using your old certificate using this tool.
+      tell_verify: Tell GOV.UK Verify to stop using your old certificate
+      stop_using_secondary_html: "%{href} (or 'secondary') through the dashboard."
+      stop_using_old_html: "%{href} through the dashboard."
       apply_changes: Apply the changes.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -391,8 +391,9 @@ en:
         SP: 'Before you upload your service provider encryption certificate:'
       you_must: "you must:"
       create_signing_key_and_certificate: "you must create a new signing key and certificate."
-      create_key_and_certificate: Create a new encryption key and certificate
+      create_key_and_certificate: "Create a new %{type} key and certificate"
       create_encryption_key_and_certificate: Add your new encryption key and certificate to your %{component} configuration
+      add_signing_key_and_certificate_as_secondary: Add your new signing key and certificate to your %{component} configuration as secondary
       must_update: You must update your %{component} configuration before going to the next step, or your service's connection to GOV.UK Verify will break.
       have_updated: I have updated my %{component} configuration
       not_support_dual_running: Because your service provider does not support dual running, there will be an outage when you rotate the encryption key.
@@ -446,10 +447,12 @@ en:
       rotate_other_certificates: You can rotate other certificates straight away - you do not need to wait for the email.
       received_email: Once you've received the email, delete the old %{usage} key and certificate from your %{component} configuration.
       received_email_to_replace: Once you've received the email, replace the old %{usage} key with the new one in your %{component} configuration.
+      received_email_to_promote: Once you've received the email, promote your secondary %{usage} key and certificate to the primary position and delete the old one in your %{component} configuration.
       rotate_more: Rotate more certificates
       msa_add_new_key_and_certificate: Add the new signing key and certificate to your Matching Service Adapter (MSA) configuration.
       tell_us_to_stop_using_old_certificate: Tell GOV.UK Verify to stop using your old certificate using this tool.
       configuration_warning: You must update your %{component} configuration by %{date}, or your service’s connection to GOV.UK Verify will break.
       certificate_rotations_are_independent: You can rotate other certificates while you wait for the email - certificate rotations are independent of each other.
       tell_verify: Tell GOV.UK Verify to stop using your old (or 'secondary') certificate using this tool.
+      tell_verify_old: Tell GOV.UK Verify to stop using your old certificate using this tool.
       apply_changes: Apply the changes.

--- a/spec/system/visit_user_journey_before_you_start_page_spec.rb
+++ b/spec/system/visit_user_journey_before_you_start_page_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe 'Before you start page', type: :system do
       msa_component = certificate.component
       visit before_you_start_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
       expect(page).to have_content 'Matching Service Adapter (MSA) signing certificate'
-      click_link 'Continue'
+      click_link t('user_journey.before_you_start.have_updated', component: certificate.component.display)
       expect(current_path).to eql upload_certificate_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
     end
 

--- a/spec/system/visit_user_journey_confirmation_page_spec.rb
+++ b/spec/system/visit_user_journey_confirmation_page_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Confirmation page', type: :system do
       msa_component = certificate.component
       visit confirmation_path(msa_component.component_type, msa_component.id, msa_component.signing_certificates[0])
       expect(page).to have_content COMPONENT_TYPE::MSA_SHORT
-      expect(page).to have_content 'delete the old signing key and certificate from your MSA configuration'
+      expect(page).to have_content t('user_journey.confirmation.received_email_to_promote', usage: certificate.usage, component: certificate.component.display)
       click_link 'Rotate more certificates'
       expect(current_path).to eql root_path
     end


### PR DESCRIPTION
The instructions are not accurate and can be confusing (as highlighted during the
private beta testing).
This PR:
- changes the instructions for MSA signing so
that Before you start advises users to add the new signing key to secondary position.
- changes the next steps on confirmation advising to promote the secondary cert to primary and delete it

There will be corresponding changes in the docs.

**Before on "Before you start"**
<img width="716" alt="image" src="https://user-images.githubusercontent.com/30629434/68873129-15c2d400-06f7-11ea-9ed7-601018165b81.png">

**After on "Before you start"**
<img width="717" alt="image" src="https://user-images.githubusercontent.com/30629434/68873087-fdeb5000-06f6-11ea-9147-d56b1823bafd.png">

== == == == ==

**Before on confirmation**
<img width="770" alt="image" src="https://user-images.githubusercontent.com/30629434/68873068-f1ff8e00-06f6-11ea-9143-07cf4b8b3bcb.png">

**After on confirmation**
<img width="728" alt="image" src="https://user-images.githubusercontent.com/30629434/68873053-e744f900-06f6-11ea-8abb-5dc07582bb78.png">
