### PR TITLE
BAU: Disable turbolinks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'uglifier', '>= 1.3.0'
 # gem 'mini_racer', platforms: :ruby
 
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
+# gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -290,9 +290,6 @@ GEM
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
@@ -349,7 +346,6 @@ DEPENDENCIES
   sentry-raven
   spring
   spring-watcher-listen (~> 2.0.0)
-  turbolinks (~> 5)
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,6 +12,5 @@
 //
 //= require rails-ujs
 //= # require activestorage
-//= require turbolinks
 //= require_tree .
 //= require govuk-frontend/govuk/all

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,8 +9,8 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload', nonce: true %>
+    <%= stylesheet_link_tag    'application', media: 'all' %>
+    <%= javascript_include_tag 'application', nonce: true %>
     <%= favicon_link_tag        asset_path('govuk-frontend/govuk/assets/images/favicon.ico'), sizes: "16x16 32x32 48x48" %>
 
     <link rel="mask-icon" href="<%= asset_path('govuk-frontend/govuk/assets/images/govuk-mask-icon.svg')%>" color="blue">

--- a/app/views/shared/_error_summary.html.erb
+++ b/app/views/shared/_error_summary.html.erb
@@ -7,7 +7,7 @@
       <ul class="govuk-list govuk-error-summary__list">
       <% errors.keys.each do |key| %>
         <% errors.full_messages_for(key).each do |error| %>
-          <li data-turbolinks="false">
+          <li>
             <%= link_to error, "##{name}_#{key}" %>
           </li>
         <% end %>

--- a/app/views/shared/_upload_errors.html.erb
+++ b/app/views/shared/_upload_errors.html.erb
@@ -6,7 +6,7 @@
     <div class="govuk-error-summary__body">
       <ul class="govuk-list govuk-error-summary__list">
         <% @upload.errors.each do |key| %>
-          <li data-turbolinks="false">
+          <li>
             <%=
               link_to "#{@upload.errors&.full_messages_for(key).first}" ,
               "#certificate_#{params[:certificate].key?(:cert_file) ? 'cert_file' : 'value'}"


### PR DESCRIPTION
Turbolinks don't work super well. Especially in our admin area and the scrolling
is not ideal when navigating between pages and it doesn't scroll to the top of the page.
I think it's better to disable now. Open to comments though!