### PR TITLE
Jo4SzZ0J: Update end to end tests

### DIFF
--- a/spec/acceptance/user_journey_spec.rb
+++ b/spec/acceptance/user_journey_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'User journey', type: :feature, acceptance: true do
   end
 
   def rotate_msa_encryption_certificate
-    click_link t('user_journey.encryption_certificate')
+    find('.govuk-table__row', text: "#{t('user_journey.encryption_certificate')}\n#{t('user_journey.in_use')}", match: :first).click_link
 
     expect(page).to have_content 'Matching Service Adapter: encryption certificate'
 


### PR DESCRIPTION
- Changes have been made which break the current end to end tests.
- These changes are that a user cannot rotate the a which is being deployed.
- If the acceptance tests run quickly in sequence, the second test would fail as the cert is still deploying.

- This commit updates the spec to only upload a certificate which is not currently deploying.
- More components + msa encryption certs have been added to the acceptance test staging account for cases where there are multiple deployments in quick succession (aka lots of acceptance tests are run and we need to take into account the real-time deployment time).