### PR TITLE
Fix the Sentry 404 exclusion

### DIFF
--- a/lib/support/raven/logger.rb
+++ b/lib/support/raven/logger.rb
@@ -41,7 +41,7 @@ module Support
             (
               message.is_a?(String) &&
                 (
-                   message.start_with?('ActionController::RoutingError') ||
+                   message.include?('ActionController::RoutingError') ||
                    message == UNLABELED_EVENT
                 )
             )


### PR DESCRIPTION
We're meant to be excluding 404 errors in Sentry. However, our current logic does not seem to be working properly.
The reason is that the message might start with empty space (e.g.`  \nActionController::RoutingError (No route matches [GET]`)) and in AWS it's
prepended with the instance ID.