### PR TITLE
Change form fields on invite user form

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -141,8 +141,8 @@ private
   def setup_user_in_cognito
     add_user(
       email: @form.email,
-      given_name: @form.given_name,
-      family_name: @form.family_name,
+      given_name: @form.first_name,
+      family_name: @form.last_name,
       roles: @form.roles,
     )
   end

--- a/app/models/invite_user_form.rb
+++ b/app/models/invite_user_form.rb
@@ -1,16 +1,16 @@
 class InviteUserForm
   include ActiveModel::Model
 
-  attr_reader :email, :given_name, :family_name, :roles
+  attr_reader :email, :first_name, :last_name, :roles
 
-  validates_presence_of :email, :given_name, :family_name, :roles
+  validates_presence_of :email, :first_name, :last_name, :roles
 
   validate :email_is_valid, :validate_roles
 
   def initialize(hash)
     @email = hash[:email]
-    @given_name = hash[:given_name]
-    @family_name = hash[:family_name]
+    @first_name = hash[:first_name]
+    @last_name = hash[:last_name]
     @roles = hash[:roles]
   end
 

--- a/app/models/remote_authenticatable.rb
+++ b/app/models/remote_authenticatable.rb
@@ -41,8 +41,8 @@ module Devise
         self.roles = claims['custom:roles']
         self.permissions = UserRolePermissions.new(claims['custom:roles'], claims['email'])
         self.full_name = "#{claims['given_name']} #{claims['family_name']}"
-        self.given_name = claims['given_name']
-        self.family_name = claims['family_name']
+        self.first_name = claims['given_name']
+        self.last_name = claims['family_name']
         self.team = Team.find_by_team_alias(claims['cognito:groups'][0])&.id unless claims['cognito:groups'].nil?
         self.cognito_groups = claims['cognito:groups']
         self.session_start_time = Time.now.to_s
@@ -77,8 +77,8 @@ module Devise
           resource.roles = data['roles']
           resource.permissions = UserRolePermissions.new(data['roles'], data['email'])
           resource.full_name = "#{data['given_name']} #{data['family_name']}"
-          resource.given_name = data['given_name']
-          resource.family_name = data['family_name']
+          resource.last_name = data['given_name']
+          resource.last_name = data['family_name']
           resource.session_start_time = data['session_start_time']
           resource.team = data['team']
           resource.cognito_groups = data['cognito_groups']&.split(',')
@@ -101,8 +101,8 @@ module Devise
               login_id: record.login_id,
               user_id: record.user_id,
               roles: record.roles,
-              given_name: record.given_name,
-              family_name: record.family_name,
+              first_name: record.first_name,
+              last_name: record.last_name,
               session_start_time: record.session_start_time,
               team: record.team,
               cognito_groups: groups,

--- a/app/models/team_member.rb
+++ b/app/models/team_member.rb
@@ -1,17 +1,17 @@
 class TeamMember
-  attr_reader :user_id, :given_name, :family_name, :email, :roles, :status
+  attr_reader :user_id, :first_name, :last_name, :email, :roles, :status
 
-  def initialize(user_id:, given_name:, family_name:, email:, roles:, status:)
+  def initialize(user_id:, first_name:, last_name:, email:, roles:, status:)
     @user_id = user_id
     @email = email
-    @given_name = given_name
-    @family_name = family_name
+    @first_name = first_name
+    @last_name = last_name
     @roles = roles
     @status = status
   end
 
   def full_name
-    @given_name + " " + @family_name
+    @first_name + " " + @last_name
   end
 
   def cert_manager?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,8 +9,8 @@ class User
 
   # create getter and setter methods internally for the fields below
   attr_accessor :email, :access_token, :challenge_name, :cognito_session_id,
-                :mfa, :challenge_parameters, :roles, :full_name, :family_name,
-                :given_name, :phone_number, :user_id, :login_id, :password, :new_password,
+                :mfa, :challenge_parameters, :roles, :full_name, :last_name,
+                :first_name, :phone_number, :user_id, :login_id, :password, :new_password,
                 :totp_code, :permissions, :session_start_time, :team, :cognito_groups, :secret_code
 
   #required by Devise

--- a/app/views/users/invite.html.erb
+++ b/app/views/users/invite.html.erb
@@ -4,25 +4,25 @@
 
 <h1 class="govuk-heading-l"><%= t 'users.invite.title' %></h1>
 
-<%=error_summary_for(@form&.errors, :form) %>
+<%=error_summary_for(@form&.errors, :invite_user_form) %>
 <%= form_for @form, url: invite_to_team_post_path do |f| %>
 
   <div class="govuk-form-group <%= 'govuk-form-group--error' if @form.errors.key?(:email) %>">
     <%= f.label :email, class: "govuk-label" %>
-    <%= error_message_on(f.object.errors, :email) %>
+    <%= error_message_on(f.object.errors, :email) if @form.errors.key?(:email)  %>
     <%= f.email_field :email, autofocus: true, class: "govuk-input" %>
   </div>
 
-  <div class="govuk-form-group <%= 'govuk-form-group--error' if @form.errors.key?(:given_name) %>">
-    <%= f.label :given_name, class: "govuk-label" %>
-    <%= error_message_on(f.object.errors, :given_name) %>
-    <%= f.text_field :given_name, class: "govuk-input" %>
+  <div class="govuk-form-group <%= 'govuk-form-group--error' if @form.errors.key?(:first_name) %>">
+    <%= f.label :first_name, class: "govuk-label" %>
+    <%= error_message_on(f.object.errors, :first_name) if @form.errors.key?(:first_name) %>
+    <%= f.text_field :first_name, class: "govuk-input"%>
   </div>
 
-  <div class="govuk-form-group <%= 'govuk-form-group--error' if @form.errors.key?(:family_name) %>">
-    <%= f.label :family_name, class: "govuk-label" %>
-    <%= error_message_on(f.object.errors, :family_name) %>
-    <%= f.text_field :family_name, class: "govuk-input" %>
+  <div class="govuk-form-group <%= 'govuk-form-group--error' if @form.errors.key?(:last_name) %>">
+    <%= f.label :last_name, class: "govuk-label" %>
+    <%= error_message_on(f.object.errors, :last_name) if @form.errors.key?(:last_name)  %>
+    <%= f.text_field :last_name, class: "govuk-input" %>
   </div>
 
   <% if @gds_team %>
@@ -44,9 +44,10 @@
       </strong>
     </div>
   <% else %>
-    <div class="govuk-form-group">
+    <div class="govuk-form-group <%= 'govuk-form-group--error' if @form.errors.key?(:roles) %>">
+      <%= error_message_on(f.object.errors, :roles) if @form.errors.key?(:roles) %>
       <fieldset class="govuk-fieldset">
-        <div class="govuk-checkboxes">
+        <div class="govuk-checkboxes" id="invite_user_form_roles">
           <div class="govuk-checkboxes__item">
             <%= f.check_box(:roles, { class: 'govuk-checkboxes__input', multiple: true }, ROLE::CERTIFICATE_MANAGER, nil) %>
             <%= f.label :roles, t("users.roles.#{ROLE::CERTIFICATE_MANAGER}"), class: 'govuk-label govuk-checkboxes__label' %>
@@ -59,8 +60,6 @@
       </fieldset>
     </div>
   <% end %>
-  
-
 
   <div class="actions">
     <%= f.submit t('users.invite.button'), class: "govuk-button", data: { module: "govuk-button" } %>

--- a/lib/auth/authentication_backend.rb
+++ b/lib/auth/authentication_backend.rb
@@ -273,11 +273,11 @@ module AuthenticationBackend
     status = user[:user_status]
     attributes_key = user.key?(:user_attributes) ? :user_attributes : :attributes
     attributes = user[attributes_key].to_h { |attr| [attr[:name], attr[:value]] }
-    given_name = attributes['given_name']
-    family_name = attributes['family_name']
+    first_name = attributes['given_name']
+    last_name = attributes['family_name']
     email = attributes['email']
     roles = attributes['custom:roles'].split(%r{,\s*})
-    TeamMember.new(user_id: user_id, given_name: given_name, family_name: family_name, email: email, roles: roles, status: status)
+    TeamMember.new(user_id: user_id, first_name: first_name, last_name: last_name, email: email, roles: roles, status: status)
   end
 
   def set_mfa_preferences(access_token:)

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -113,8 +113,8 @@ RSpec.describe UsersController, type: :controller do
           invite_user_form:
             {
               email: 'test@test.test',
-              given_name: 'First Name',
-              family_name: 'Surname',
+              first_name: 'First Name',
+              last_name: 'Surname',
               roles: [ROLE::USER_MANAGER, ROLE::CERTIFICATE_MANAGER]
             }
         }
@@ -312,8 +312,8 @@ RSpec.describe UsersController, type: :controller do
           invite_user_form:
             {
               email: 'test@test.test',
-              given_name: 'First Name',
-              family_name: 'Surname',
+              first_name: 'First Name',
+              last_name: 'Surname',
               roles: [ROLE::USER_MANAGER, ROLE::CERTIFICATE_MANAGER]
             }
         }
@@ -332,8 +332,8 @@ RSpec.describe UsersController, type: :controller do
           invite_user_form:
             {
               email: 'test@test.test',
-              given_name: 'First Name',
-              family_name: 'Surname',
+              first_name: 'First Name',
+              last_name: 'Surname',
               roles: [ROLE::USER_MANAGER, ROLE::CERTIFICATE_MANAGER]
             }
         }
@@ -350,8 +350,8 @@ RSpec.describe UsersController, type: :controller do
           invite_user_form:
             {
               email: 'test@test.test',
-              given_name: 'First Name',
-              family_name: 'Surname',
+              first_name: 'First Name',
+              last_name: 'Surname',
               roles: [ROLE::USER_MANAGER, ROLE::CERTIFICATE_MANAGER]
             }
         }
@@ -365,7 +365,7 @@ RSpec.describe UsersController, type: :controller do
         stub_cognito_response(method: :admin_get_user, payload: cognito_user)
         stub_cognito_response(method: :list_users_in_group, payload: cognito_users)
         expect_any_instance_of(AuthenticationBackend).to receive(:resend_invite)
-        get :resend_invitation, params: { user_id: user_id} 
+        get :resend_invitation, params: { user_id: user_id}
         expect(subject).to redirect_to(update_user_path(user_id: user_id))
         expect(flash[:error]).to be_nil
         expect(flash[:success]).to eq(t('users.update.resend_invitation.success'))
@@ -375,7 +375,7 @@ RSpec.describe UsersController, type: :controller do
         stub_cognito_response(method: :admin_get_user, payload: cognito_user)
         stub_cognito_response(method: :list_users_in_group, payload: cognito_users)
         stub_cognito_response(method: :admin_create_user, payload: 'Aws::CognitoIdentityProvider::Errors::ServiceError')
-        get :resend_invitation, params: { user_id: user_id} 
+        get :resend_invitation, params: { user_id: user_id}
         expect(subject).to redirect_to(update_user_path(user_id: user_id))
         expect(flash[:error]).to eq(t('users.update.resend_invitation.error'))
         expect(flash[:success]).to be_nil

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :user do
     user_id { '000000'}
-    given_name { 'John' }
-    family_name  { 'Doe' }
+    first_name { 'John' }
+    last_name  { 'Doe' }
     email { 'test@test.test' }
     password { 'validpassword' }
     roles { ROLE::USER_MANAGER }

--- a/spec/models/invite_user_form_spec.rb
+++ b/spec/models/invite_user_form_spec.rb
@@ -3,26 +3,26 @@ require 'rails_helper'
 RSpec.describe InviteUserForm, type: :model do
 
   it 'is valid with valid attributes' do
-    expect(InviteUserForm.new({email: 'test@test.test', given_name: 'First Name', family_name: 'Surname', roles: [ROLE::CERTIFICATE_MANAGER] })).to be_valid
+    expect(InviteUserForm.new(email: 'test@test.test', first_name: 'First Name', last_name: 'Surname', roles: [ROLE::CERTIFICATE_MANAGER])).to be_valid
   end
 
   it 'is not valid with non-valid attributes' do
-    expect(InviteUserForm.new({blah: 'blah'})).to_not be_valid
+    expect(InviteUserForm.new(blah: 'blah')).to_not be_valid
   end
 
   it 'is not valid with non-existent roles' do
-    expect(InviteUserForm.new({email: 'test@test.test', given_name: 'First Name', family_name: 'Surname', roles: [ROLE::CERTIFICATE_MANAGER, 'blah'] })).to_not be_valid
+    expect(InviteUserForm.new(email: 'test@test.test', first_name: 'First Name', last_name: 'Surname', roles: [ROLE::CERTIFICATE_MANAGER, 'blah'])).to_not be_valid
   end
 
   it 'is not valid with an invalid email' do
-    expect(InviteUserForm.new({email: 'notanemailaddress', given_name: 'First Name', family_name: 'Surname' })).to_not be_valid
+    expect(InviteUserForm.new(email: 'notanemailaddress', first_name: 'First Name', last_name: 'Surname')).to_not be_valid
   end
 
   it 'is not valid when GDS role is being assigned to a non-GDS email' do
-    expect(InviteUserForm.new({email: 'test@test.test', given_name: 'First Name', family_name: 'Surname', roles: [ROLE::GDS] })).to_not be_valid
+    expect(InviteUserForm.new(email: 'test@test.test', first_name: 'First Name', last_name: 'Surname', roles: [ROLE::GDS])).to_not be_valid
   end
 
   it 'is valid when GDS role is being assigned to a GDS email' do
-    expect(InviteUserForm.new({email: 'test@digital.cabinet-office.gov.uk', given_name: 'First Name', family_name: 'Surname', roles: [ROLE::GDS] })).to be_valid
+    expect(InviteUserForm.new(email: 'test@digital.cabinet-office.gov.uk', first_name: 'First Name', last_name: 'Surname', roles: [ROLE::GDS])).to be_valid
   end
 end

--- a/spec/system/visit_invite_user_spec.rb
+++ b/spec/system/visit_invite_user_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe 'InviteToTeam', type: :system do
     stub_cognito_response(method: :admin_create_user, payload: { user: { username:'test@test.test' } })
     visit invite_to_team_path(Team.first.id)
     fill_in 'invite_user_form_email', with: 'test@test.com'
-    fill_in 'invite_user_form_given_name', with: "test"
-    fill_in 'invite_user_form_family_name', with: "User"
+    fill_in 'invite_user_form_first_name', with: "test"
+    fill_in 'invite_user_form_last_name', with: "User"
     check 'invite_user_form_roles_certmgr'
     check 'invite_user_form_roles_usermgr'
     click_button 'Invite user'
@@ -27,7 +27,7 @@ RSpec.describe 'InviteToTeam', type: :system do
     visit invite_to_team_path(Team.first.id)
     click_button 'Invite user'
     expect(page).to have_content "Email can't be blank"
-    expect(page).to have_content "Given name can't be blank"
-    expect(page).to have_content "Family name can't be blank"
+    expect(page).to have_content "First name can't be blank"
+    expect(page).to have_content "Last name can't be blank"
   end
 end


### PR DESCRIPTION
- The invite user form should be displaying First / Last name over Given / Family name.
- Due to Cognito reasons we still should be using Family / Given name in the backend.

- Displays validations with updated content.
- Fixing displaying validations for the role checkboxes has also been snuck in...
- Linking from the error summary at the top of the form to the form fields was also previously broken and is now fixed.

<img width="1134" alt="invite-form" src="https://user-images.githubusercontent.com/5963488/68965808-91df1980-07d4-11ea-8311-02058a2c15d0.png">


<img width="1072" alt="invite-form02" src="https://user-images.githubusercontent.com/5963488/68965865-bc30d700-07d4-11ea-85a5-40d50ef98f57.png">
