### PR TITLE
8Dakh37S: Add entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+bundle exec rake assets:precompile
+bundle exec puma -p 8080 -b tcp://0.0.0.0


### PR DESCRIPTION
We want to pre-compile the assets before we let the app start. Fargate is going to use
this file to start the app.

Corresponding startup change https://github.com/alphagov/verify-infrastructure/pull/329