### PR TITLE
j8OJ2sMr: Content change to non-dual running flow

### DIFF
--- a/app/views/user_journey/confirmation.html.erb
+++ b/app/views/user_journey/confirmation.html.erb
@@ -18,12 +18,6 @@
     <li><%= t 'user_journey.dual_running.connection_break' %></li>
     <li><%= t 'user_journey.dual_running.apply_changes' %></li>
   </ul>
-  <h3 class="govuk-heading-s"><%= t 'user_journey.dual_running.if_you_have_not_already_added' %></h3>
-  <ul class="govuk-list govuk-list--number">
-    <li><%= t 'user_journey.dual_running.add_new_signing_key_and_certificate' %></li>
-    <li><%= t 'user_journey.dual_running.connection_break' %></li>
-    <li><%= t 'user_journey.dual_running.apply_changes' %></li>
-  </ul>
 <% elsif @certificate.encryption? %>
   <ul class="govuk-list govuk-list--number">
     <li><%= t('user_journey.confirmation.received_email', usage: @certificate.usage, component: @certificate.component.display) %></li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -376,9 +376,7 @@ en:
       how_long_it_takes: This usually takes around 10 minutes
       if_you_already_added: 'If you have already added the new key and certificate to your service provider configuration:'
       connection_break: Wait for your connection to GOV.UK Verify to break.
-      apply_changes: Apply the changes to fix the connection.
-      if_you_have_not_already_added: 'If you have not already added the new key and certificate to your service provider configuration:'
-      add_new_signing_key_and_certificate: the new signing key and certificate to your service provider.
+      apply_changes: You should have added your new encryption key and certificate to your service provider configuration earlier. Apply the changes to fix the connection.
     before_you_start:
       title: Before you start
       rotate_certificate_read_steps: The process for rotating each certificate is slightly different. Read the steps on each page carefully, even if you’ve rotated certificates before.


### PR DESCRIPTION
https://trello.com/c/j8OJ2sMr/756-content-change-to-non-dual-running-flow

We've moved this instruction to earlier in the flow, to hopefully minimise any downtime

Before:
<img width="1436" alt="Screen Shot 2019-11-19 at 10 08 20" src="https://user-images.githubusercontent.com/24409958/69137427-a8c38b80-0ab4-11ea-9cb1-2d623e39ac98.png">

After:
<img width="1440" alt="Screen Shot 2019-11-19 at 10 05 18" src="https://user-images.githubusercontent.com/24409958/69137426-a8c38b80-0ab4-11ea-83bf-8ab617dd9e0a.png">

