### PR TITLE
j8OJ2sMr: Remove unnecessary sub heading

### DIFF
--- a/app/views/user_journey/confirmation.html.erb
+++ b/app/views/user_journey/confirmation.html.erb
@@ -13,7 +13,6 @@
   <p><%= t 'user_journey.dual_running.not_support_dual_running' %></p>
   <p><%= t 'user_journey.dual_running.how_long_it_takes' %></p>
   <h2 class="govuk-heading-m"><%= t 'user_journey.confirmation.next_steps' %></h2>
-  <h3 class="govuk-heading-s"><%= t 'user_journey.dual_running.if_you_already_added' %></h3>
   <ul class="govuk-list govuk-list--number">
     <li><%= t 'user_journey.dual_running.connection_break' %></li>
     <li><%= t 'user_journey.dual_running.apply_changes' %></li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -373,8 +373,7 @@ en:
       title_support_dual_running: Does your service provider support dual running?
       support_dual_running: If your service provider supports dual running, it can try to decrypt messages from the GOV.UK Verify Hub using both your old and new encryption keys. Your connection will not break.
       not_support_dual_running: Because your service provider does not support dual running, your connection to GOV.UK Verify will break when the GOV.UK Verify Hub starts using your new encryption certificate.
-      how_long_it_takes: This usually takes around 10 minutes
-      if_you_already_added: 'If you have already added the new key and certificate to your service provider configuration:'
+      how_long_it_takes: This usually takes around 10 minutes.
       connection_break: Wait for your connection to GOV.UK Verify to break.
       apply_changes: You should have added your new encryption key and certificate to your service provider configuration earlier. Apply the changes to fix the connection.
     before_you_start:


### PR DESCRIPTION
Beth also requested we remove this heading as its unnecessary.
Also added a full stop at the end of a sentence

Before:
<img width="1440" alt="Screen Shot 2019-11-19 at 10 05 18" src="https://user-images.githubusercontent.com/24409958/69153155-9ad23280-0ad5-11ea-9df8-0d00faa1ad46.png">


After:
<img width="1438" alt="Screen Shot 2019-11-19 at 14 00 29" src="https://user-images.githubusercontent.com/24409958/69153099-842bdb80-0ad5-11ea-9b60-a5b794e4ab53.png">
