### PR TITLE
plgVsdxI: Update user journey content if certificate fails to publish

### DIFF
--- a/app/controllers/concerns/controller_concern.rb
+++ b/app/controllers/concerns/controller_concern.rb
@@ -10,8 +10,16 @@ module ControllerConcern
     key.gsub('_id', '').split('_').map(&:titleize).join
   end
 
+  def publish_event_has_not_occured(event_id)
+    PublishServicesMetadataEvent.where("data->>'event_id' = ?", event_id).empty?
+  end
+
+  def check_metadata_published_user_journey(event_id)
+    publish_event_has_not_occured(event_id) ? false : true
+  end
+
   def check_metadata_published(event_id)
-    if PublishServicesMetadataEvent.where("data->>'event_id' = ?", event_id).empty?
+    if publish_event_has_not_occured(event_id)
       flash[:notice] = t('certificates.errors.cannot_publish')
     end
   end

--- a/app/controllers/user_journey_controller.rb
+++ b/app/controllers/user_journey_controller.rb
@@ -88,17 +88,20 @@ class UserJourneyController < ApplicationController
       component = klass_component(@upload.component_type).find_by_id(@upload.component_id)
 
       if @upload.certificate.encryption?
-        replace_event = ReplaceEncryptionCertificateEvent.create(
+        replace = ReplaceEncryptionCertificateEvent.create(
           component: component,
           encryption_certificate_id: @upload.certificate.id,
         )
-
-        check_metadata_published(replace_event.id)
+        replaced_certicate_published = check_metadata_published_user_journey(replace.id)
       end
 
-      check_metadata_published(@upload.id)
+      certicate_published = check_metadata_published_user_journey(@upload.id)
 
-      render :confirmation
+      if certicate_published && replaced_certicate_published
+        render :confirmation
+      else
+        render :publish_failed
+      end
     else
       Rails.logger.info(@upload.errors.full_messages.join(', '))
       render :upload_certificate

--- a/app/views/user_journey/confirmation.html.erb
+++ b/app/views/user_journey/confirmation.html.erb
@@ -48,4 +48,4 @@
   </div>
 <% end %>
 
-<%= link_to t('user_journey.confirmation.rotate_more'), root_path, class: "secondary-link secondary-link__confirmation" %> 
+<%= link_to t('user_journey.confirmation.rotate_more'), root_path, class: "secondary-link secondary-link__confirmation" %>

--- a/app/views/user_journey/publish_failed.html.erb
+++ b/app/views/user_journey/publish_failed.html.erb
@@ -1,0 +1,11 @@
+<%= page_title t('user_journey.confirmation.publish_failed_title') %>
+
+<%= render 'shared/certificate_details', certificate: @certificate %>
+
+<h1 class="govuk-heading-l"><%= t('user_journey.confirmation.failed_to_publish_heading') %></h1>
+<p><%= t('user_journey.confirmation.please_contact') %> <a href="mailto:<%=t('user_journey.confirmation.support_email') %> class="govuk-link"><%= t('user_journey.confirmation.support_email')%></a>.</p>
+<p><%= t('user_journey.confirmation.team_help_publish', component: @certificate.component.display, usage: @certificate.usage) %></p>
+<p><%= t('user_journey.confirmation.publish_time') %></p>
+<p><%= t('user_journey.confirmation.will_not_break') %></p>
+
+<%= link_to t('user_journey.confirmation.rotate_more'), root_path, class: "secondary-link secondary-link__confirmation" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -346,7 +346,7 @@ en:
     how_long_it_takes: This usually takes around 10 minutes from the time you uploaded the new signing certificate.
     delete_old_signing_key_and_cert: Then you can delete the old signing key and certificate from your %{component} configuration.
     maintain_connection: You need to manage your certificates to make sure your service stays connected to GOV.UK Verify.
-    connection_broken_or_compromised_guidance: If your connection has been broken or compromised, read 
+    connection_broken_or_compromised_guidance: If your connection has been broken or compromised, read
     connection_broken_or_compromised_link: this guidance
     certificates_expiring: "%{number} certificates are expiring soon."
     find_out_more: Find out more about %{link} in the documentation.
@@ -423,7 +423,7 @@ en:
       certificate_will_be_replaced: Once you confirm you wish to use this certificate, your old %{component} %{certificate} certificate will be replaced with the new one in the GOV.UK Verify Hub configuration.
       certificate_will_be_added: Once you confirm you wish to use this certificate, it will be added to the GOV.UK Verify Hub configuration alongside your old signing certificate.
       encrypt_messages_for_your_service: The GOV.UK Verify Hub will then be using your new certificate to encrypt messages for your service.
-      signed_mesages_from_your_service: The GOV.UK Verify Hub will then trust your old and new certificates to verify signatures on messages from your service. 
+      signed_mesages_from_your_service: The GOV.UK Verify Hub will then trust your old and new certificates to verify signatures on messages from your service.
       how_long_it_takes: This takes around 10 minutes. Your connection will not break.
       will_replace_old_certificate: Using this certificate will replace your old encryption certificate in GOV.UK Verify's configuration within 10 minutes.
       sp_doesnt_support_dual_running: Because your service provider does not support dual running, your connection will break when the GOV.UK Verify Hub starts using your new certificate.
@@ -437,6 +437,7 @@ en:
       stop_using: Stop using this certificate
     confirmation:
       title: Confirmation
+      publish_failed_title: Publish failed
       what_to_expect: This usually takes around 10 minutes. We'll email you when your new %{type} certificate is in use.
       next_steps: Next steps
       rotate_other_certificates: You can rotate other certificates straight away - you do not need to wait for the email.
@@ -451,3 +452,9 @@ en:
       stop_using_secondary_html: "%{href} (or 'secondary') through the dashboard."
       stop_using_old_html: "%{href} through the dashboard."
       apply_changes: Apply the changes.
+      support_email: idasupport@digital.cabinet-office.gov.uk
+      failed_to_publish_heading: Your certificate has failed to publish
+      please_contact: Please contact the GOV.UK Verify team at
+      team_help_publish: The team will help publish your %{component} %{usage} certificate.
+      publish_time: It will take up to 24 hours for your new certificate to be published by the team.
+      will_not_break: Your connection to GOV.UK Verify will not break because of this error.

--- a/spec/system/visit_user_journey_check_your_certificate_page_spec.rb
+++ b/spec/system/visit_user_journey_check_your_certificate_page_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe 'Check your certificate page', type: :system do
       expect(page).to have_content 'Encryption'
       click_button 'Use this certificate'
       expect(current_path).to eql confirmation_path(sp_encryption_certificate.id)
-      expect(page).to have_content(t('certificates.errors.cannot_publish'))
+      expect(page).to have_content t('user_journey.confirmation.failed_to_publish_heading')
     end
 
     it 'sp encryption journey with dual running set to no displays unique content' do

--- a/spec/system/visit_user_journey_confirmation_page_spec.rb
+++ b/spec/system/visit_user_journey_confirmation_page_spec.rb
@@ -84,4 +84,54 @@ RSpec.describe 'Confirmation page', type: :system do
       expect(page).to have_content 'Because your service provider does not support dual running'
     end
   end
+
+  context 'fails to publish' do
+    before(:each) do
+      stub_storage_client_service_error
+    end
+
+    it 'displays failed to publish content for MSA encryption certificate' do
+      visit upload_certificate_path(msa_encryption_certificate.id)
+      fill_in 'certificate_value', with: msa_encryption_certificate.value
+      click_button t('user_journey.continue')
+      click_button t('user_journey.certificate.use_certificate')
+
+      expect(current_path).to eql confirmation_path(msa_encryption_certificate.id)
+      expect(page).to have_content t('user_journey.confirmation.failed_to_publish_heading')
+      expect(page).to have_content 'The team will help publish your MSA encryption certificate.'
+    end
+
+    it 'displays failed to publish content for VSP encryption certificate' do
+      visit upload_certificate_path(vsp_encryption_certificate.id)
+      fill_in 'certificate_value', with: vsp_encryption_certificate.value
+      click_button t('user_journey.continue')
+      click_button t('user_journey.certificate.use_certificate')
+
+      expect(current_path).to eql confirmation_path(vsp_encryption_certificate.id)
+      expect(page).to have_content t('user_journey.confirmation.failed_to_publish_heading')
+      expect(page).to have_content 'The team will help publish your VSP encryption certificate.'
+    end
+
+    it 'displays failed to publish content for MSA signing certificate' do
+      visit upload_certificate_path(msa_signing_certificate.id)
+      fill_in 'certificate_value', with: msa_signing_certificate.value
+      click_button t('user_journey.continue')
+      click_button t('user_journey.certificate.use_certificate')
+      expect(current_path).to eql confirmation_path(msa_signing_certificate.id)
+
+      expect(page).to have_content t('user_journey.confirmation.failed_to_publish_heading')
+      expect(page).to have_content 'The team will help publish your MSA signing certificate.'
+    end
+
+    it 'displays failed to publish content for SP signing certificate' do
+      visit upload_certificate_path(sp_signing_certificate.id)
+      fill_in 'certificate_value', with: sp_signing_certificate.value
+      click_button t('user_journey.continue')
+      click_button t('user_journey.certificate.use_certificate')
+
+      expect(current_path).to eql confirmation_path(sp_signing_certificate.id)
+      expect(page).to have_content t('user_journey.confirmation.failed_to_publish_heading')
+      expect(page).to have_content 'The team will help publish your service provider signing certificate.'
+    end
+  end
 end

--- a/spec/system/visit_user_journey_confirmation_page_spec.rb
+++ b/spec/system/visit_user_journey_confirmation_page_spec.rb
@@ -11,24 +11,11 @@ RSpec.describe 'Confirmation page', type: :system do
   let(:sp_signing_certificate) { create(:sp_signing_certificate, component: create(:sp_component, team_id: user.team)) }
   let(:vsp_signing_certificate) { create(:vsp_signing_certificate, component: create(:sp_component, vsp: true, team_id: user.team)) }
 
-  before(:each) do
-    ReplaceEncryptionCertificateEvent.create(
-      component: sp_encryption_certificate.component,
-      encryption_certificate_id: sp_encryption_certificate.id
-    )
-    ReplaceEncryptionCertificateEvent.create(
-      component: msa_encryption_certificate.component,
-      encryption_certificate_id: msa_encryption_certificate.id
-    )
-    ReplaceEncryptionCertificateEvent.create(
-      component: vsp_encryption_certificate.component,
-      encryption_certificate_id: vsp_encryption_certificate.id
-    )
-  end
-
   context 'shows confirmation page for msa' do
     it 'encryption and successfully goes to next page' do
-      visit confirmation_path(msa_encryption_certificate.id)
+      event = create(:replace_encryption_certificate_event, component: msa_encryption_certificate.component, encryption_certificate_id: msa_encryption_certificate.id)
+
+      visit confirmation_path(event.component.encryption_certificate.id)
       expect(page).to have_content COMPONENT_TYPE::MSA_SHORT
       expect(page).to have_content 'delete the old encryption key and certificate from your MSA configuration'
       click_link 'Rotate more certificates'
@@ -36,7 +23,9 @@ RSpec.describe 'Confirmation page', type: :system do
     end
 
     it 'signing and successfully goes to next page' do
-      visit confirmation_path(msa_signing_certificate.id)
+      event = create(:upload_certificate_event, component: msa_signing_certificate.component)
+
+      visit confirmation_path(event.component.signing_certificates.first.id)
       expect(page).to have_content COMPONENT_TYPE::MSA_SHORT
       expect(page).to have_content t('user_journey.confirmation.received_email_to_promote', usage: msa_signing_certificate.usage, component: msa_signing_certificate.component.display)
       click_link 'Rotate more certificates'
@@ -46,7 +35,9 @@ RSpec.describe 'Confirmation page', type: :system do
 
   context 'shows confirmation page for vsp' do
     it 'encryption and successfully goes to next page' do
-      visit confirmation_path(vsp_encryption_certificate.id)
+      event = create(:replace_encryption_certificate_event, component: vsp_encryption_certificate.component, encryption_certificate_id: vsp_encryption_certificate.id)
+
+      visit confirmation_path(event.component.encryption_certificate.id)
       expect(page).to have_content COMPONENT_TYPE::VSP_SHORT
       expect(page).to have_content 'delete the old encryption key and certificate from your VSP configuration'
       click_link 'Rotate more certificates'
@@ -54,7 +45,9 @@ RSpec.describe 'Confirmation page', type: :system do
     end
 
     it 'signing and successfully goes to next page' do
-      visit confirmation_path(vsp_signing_certificate.id)
+      event = create(:upload_certificate_event, component: vsp_signing_certificate.component)
+
+      visit confirmation_path(event.component.signing_certificates.first.id)
       expect(page).to have_content COMPONENT_TYPE::VSP_SHORT
       expect(page).to have_content t('user_journey.confirmation.received_email_to_replace', usage: vsp_signing_certificate.usage, component: COMPONENT_TYPE::VSP_SHORT)
       click_link 'Rotate more certificates'
@@ -64,7 +57,9 @@ RSpec.describe 'Confirmation page', type: :system do
 
   context 'shows confirmation page for sp' do
     it 'encryption and successfully goes to next page' do
-      visit confirmation_path(sp_encryption_certificate.id)
+      event = create(:replace_encryption_certificate_event, component: sp_encryption_certificate.component, encryption_certificate_id: sp_encryption_certificate.id)
+
+      visit confirmation_path(event.component.encryption_certificate.id)
       expect(page).to have_content COMPONENT_TYPE::SP_LONG
       expect(page).to have_content 'delete the old encryption key and certificate from your service provider configuration'
       click_link 'Rotate more certificates'
@@ -72,7 +67,9 @@ RSpec.describe 'Confirmation page', type: :system do
     end
 
     it 'signing and successfully goes to next page' do
-      visit confirmation_path(sp_signing_certificate.id)
+      event = create(:upload_certificate_event, component: sp_signing_certificate.component)
+
+      visit confirmation_path(event.component.signing_certificates.first.id)
       expect(page).to have_content COMPONENT_TYPE::SP_LONG
       expect(page).to have_content t('user_journey.confirmation.received_email_to_replace', usage: sp_signing_certificate.usage, component: COMPONENT_TYPE::SP_LONG)
       click_link 'Rotate more certificates'
@@ -80,7 +77,9 @@ RSpec.describe 'Confirmation page', type: :system do
     end
 
     it 'signing with dual running set to no displays unique content' do
-      visit confirmation_path(sp_encryption_certificate.id, true)
+      event = create(:replace_encryption_certificate_event, component: sp_encryption_certificate.component, encryption_certificate_id: sp_encryption_certificate.id)
+
+      visit confirmation_path(event.component.encryption_certificate.id, true)
       expect(page).to have_content 'Because your service provider does not support dual running'
     end
   end


### PR DESCRIPTION
Confirmation page when cert fails to publish to S3:

<img width="1208" alt="publish-failed" src="https://user-images.githubusercontent.com/5963488/69247283-1699b100-0ba2-11ea-8f90-58f1f279fcd5.png">


Confirmation page when cert publishes to S3:

<img width="1109" alt="publish-success" src="https://user-images.githubusercontent.com/5963488/69247292-1ac5ce80-0ba2-11ea-8ff1-63ca5e8bb14b.png">