### PR TITLE
OFCDsnoA: Test connection between self-service and hub

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,4 +1,5 @@
 class AdminController < ApplicationController
+  require 'net/http'
   include ControllerConcern
 
   def index
@@ -17,5 +18,17 @@ class AdminController < ApplicationController
     )
     check_metadata_published(event_id)
     redirect_to admin_path(anchor: :publish)
+  end
+
+  # Temporary for testing purposes
+  def test_connection
+    url = URI.parse(params[:address])
+    req = Net::HTTP::Get.new(url.to_s)
+    res = Net::HTTP.start(url.host, url.port) { |http|
+      http.request(req)
+    }
+    render plain: res.body
+  rescue StandardError => e
+    render plain: e
   end
 end

--- a/app/policies/admin_controller_policy.rb
+++ b/app/policies/admin_controller_policy.rb
@@ -6,4 +6,8 @@ class AdminControllerPolicy < ApplicationPolicy
   def publish_metadata?
     user.permissions.admin_management
   end
+
+  def test_connection?
+    user.permissions.admin_management
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,9 @@ Rails.application.routes.draw do
   get '/admin', to: 'admin#index'
   get '/admin/publish-metadata/:environment', to: 'admin#publish_metadata', as: :publish_metadata
 
+  # Temporary for testing only
+  get '/admin/test-connection/:address', to: 'admin#test_connection'
+
   resources :sp_components, path: 'admin/sp-components' do
     patch 'associate_service'
     resources :services


### PR DESCRIPTION
This is a temporary testing mechanism to figure out what needs to be changed/configured
for allowing traffic between self-service and hub.