### PR TITLE
OFCDsnoA: Add healthcheck for the hub connection

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,5 +1,4 @@
 class AdminController < ApplicationController
-  require 'net/http'
   include ControllerConcern
 
   def index
@@ -18,20 +17,5 @@ class AdminController < ApplicationController
     )
     check_metadata_published(event_id)
     redirect_to admin_path(anchor: :publish)
-  end
-
-  # Temporary for testing purposes
-  def test_connection
-    url = URI.parse(params[:address])
-    req = Net::HTTP::Get.new(url.to_s)
-    res = Net::HTTP.start(url.host, url.port,
-                          use_ssl: url.scheme == 'https',
-                          open_timeout: 3,
-                          read_timeout: 3) { |http|
-      http.request(req)
-    }
-    render plain: res.body
-  rescue StandardError => e
-    render plain: e
   end
 end

--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -8,6 +8,7 @@ class HealthcheckController < ApplicationController
       Healthcheck::CognitoCheck,
       Healthcheck::DbCheck,
       Healthcheck::StorageCheck,
+      Healthcheck::HubCheck,
     ]
     result = Healthcheck::Checker.new(checks).run
 

--- a/app/models/healthcheck/hub_check.rb
+++ b/app/models/healthcheck/hub_check.rb
@@ -1,0 +1,22 @@
+require 'net/http'
+
+module Healthcheck
+  class HubCheck
+    def name
+      :hub_connectivity
+    end
+
+    def status
+      url = URI.join(Rails.configuration.hub_config_host, 'service-status')
+      req = Net::HTTP::Get.new(url.to_s)
+      res = Net::HTTP.start(url.host, url.port,
+                            use_ssl: url.scheme == 'https',
+                            open_timeout: 3,
+                            read_timeout: 3) { |http|
+        http.request(req)
+      }
+
+      return OK if res.code == "200"
+    end
+  end
+end

--- a/app/policies/admin_controller_policy.rb
+++ b/app/policies/admin_controller_policy.rb
@@ -6,8 +6,4 @@ class AdminControllerPolicy < ApplicationPolicy
   def publish_metadata?
     user.permissions.admin_management
   end
-
-  def test_connection?
-    user.permissions.admin_management
-  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -51,6 +51,5 @@ module VerifySelfService
     # workaround until https://github.com/sass/libsass/milestone/35 is shipped
     config.assets.css_compressor = nil
 
-    config.hub_config_host = ENV.fetch('HUB_CONFIG_HOST')
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,5 +50,7 @@ module VerifySelfService
     # Set a css_compressor so sassc-rails does not overwrite the compressor when running 
     # workaround until https://github.com/sass/libsass/milestone/35 is shipped
     config.assets.css_compressor = nil
+
+    config.hub_config_host = ENV.fetch('HUB_CONFIG_HOST')
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -79,4 +79,6 @@ Rails.application.configure do
      require 'data/integrity_checker'
      IntegrityChecker.new
    end
+
+  config.hub_config_host = ENV.fetch('HUB_CONFIG_HOST', 'http://localhost:50240')
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -142,4 +142,6 @@ Rails.application.configure do
     require 'data/integrity_checker'
     IntegrityChecker.new unless ENV['DISABLE_INTEGRITY_CHECKER'].present?
   end
+
+  config.hub_config_host = ENV.fetch('HUB_CONFIG_HOST')
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -56,4 +56,7 @@ Rails.application.configure do
   config.cognito_aws_secret_access_key = ENV['COGNITO_AWS_SECRET_ACCESS_KEY']
   config.cognito_client_id = ENV['AWS_COGNITO_CLIENT_ID']
   config.cognito_user_pool_id = ENV['AWS_COGNITO_USER_POOL_ID']
+
+  config.hub_config_host = 'http://config-service.test'
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,9 +11,6 @@ Rails.application.routes.draw do
   get '/admin', to: 'admin#index'
   get '/admin/publish-metadata/:environment', to: 'admin#publish_metadata', as: :publish_metadata
 
-  # Temporary for testing only
-  get '/admin/test-connection/:address', to: 'admin#test_connection'
-
   resources :sp_components, path: 'admin/sp-components' do
     patch 'associate_service'
     resources :services

--- a/spec/controllers/healthcheck_controller_spec.rb
+++ b/spec/controllers/healthcheck_controller_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe HealthcheckController, type: :controller do
       allow_any_instance_of(Healthcheck::CognitoCheck).to receive(:status).and_return(:ok)
       allow_any_instance_of(Healthcheck::DbCheck).to receive(:status).and_return(:ok)
       allow_any_instance_of(Healthcheck::StorageCheck).to receive(:status).and_return(:ok)
+      allow_any_instance_of(Healthcheck::HubCheck).to receive(:status).and_return(:ok)
 
       get :index
       json_response = JSON.parse(response.body)
@@ -27,6 +28,9 @@ RSpec.describe HealthcheckController, type: :controller do
       allow_any_instance_of(
         Healthcheck::StorageCheck
       ).to receive(:status).and_raise(Aws::S3::Errors::ServiceError)
+      allow_any_instance_of(
+        Healthcheck::HubCheck
+      ).to receive(:status).and_raise(StandardError)
 
       get :index
       json_response = JSON.parse(response.body)

--- a/spec/system/visit_healthcheck_spec.rb
+++ b/spec/system/visit_healthcheck_spec.rb
@@ -3,6 +3,6 @@ require 'rails_helper'
 RSpec.describe 'Healthcheck Page', type: :system do
   it 'displays healthcheck' do
     visit healthcheck_path
-    expect(page).to have_content '{"status":"ok","checks":{"cognito_connectivity":{"status":"ok"},"database_connectivity":{"status":"ok"},"storage_connectivity":{"status":"ok"}}}'
+    expect(page).to have_content '{"status":"ok","checks":{"cognito_connectivity":{"status":"ok"},"database_connectivity":{"status":"ok"},"storage_connectivity":{"status":"ok"},"hub_connectivity":{"status":"ok"}}}'
   end
 end

--- a/spec/system/visit_healthcheck_spec.rb
+++ b/spec/system/visit_healthcheck_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 RSpec.describe 'Healthcheck Page', type: :system do
   it 'displays healthcheck' do
+    # TODO: Once we implement the proper HTTP client for talking to the hub, we should do proper stubbing
     visit healthcheck_path
-    expect(page).to have_content '{"status":"ok","checks":{"cognito_connectivity":{"status":"ok"},"database_connectivity":{"status":"ok"},"storage_connectivity":{"status":"ok"},"hub_connectivity":{"status":"ok"}}}'
+    expect(page).to have_content '{"status":"service_unavailable","checks":{"cognito_connectivity":{"status":"ok"},"database_connectivity":{"status":"ok"},"storage_connectivity":{"status":"ok"},"hub_connectivity":{"status":"service_unavailable"}}}'
   end
 end


### PR DESCRIPTION
We've merged required terraform changes to enable traffic between self service
and hub.
Now adding a healthcheck to monitor the connection

Also removed the old test code (the second commit)

To be merged only after: https://github.com/alphagov/verify-infrastructure/pull/332