### PR TITLE
{do not merge} iJMydfG2g: Initial set up for Notify integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ gem 'pundit'
 gem 'request_store'
 gem 'rqrcode'
 
+gem 'notifications-ruby-client'
 gem 'email_validator'
 
 gem 'sentry-raven'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,6 +168,8 @@ GEM
     nio4r (2.5.2)
     nokogiri (1.10.5)
       mini_portile2 (~> 2.4.0)
+    notifications-ruby-client (5.1.0)
+      jwt (>= 1.5, < 3)
     orm_adapter (0.5.0)
     parallel (1.18.0)
     parser (2.6.5.0)
@@ -328,6 +330,7 @@ DEPENDENCIES
   jwt
   kaminari (~> 1.1)
   listen (>= 3.0.5, < 3.2)
+  notifications-ruby-client
   pg
   pry
   puma (~> 3.11)

--- a/lib/notify/notification.rb
+++ b/lib/notify/notification.rb
@@ -1,0 +1,15 @@
+require 'notifications/client'
+
+module Notification
+  def client
+    Notifications::Client.new(ENV.fetch('NOTIFY_KEY'))
+  end
+
+  def send_email(email_address:)
+    client.send_email(
+      email_address: email_address,
+      template_id: "a0578c4a-3373-48c0-b041-c61fcdf4f843",
+      personalisation: { team: "test"}
+     )
+  end
+end


### PR DESCRIPTION
Do not merge until: https://github.com/alphagov/verify-infrastructure/pull/333 has been merged.

- You will need to set the `NOTIFY_KEY` in your ENV file

example of sending an email from a controller method:

```
require 'notify/notification'
class TestMailController < ApplicationController
  include Notification
  def test_email
    send_email(email_address: "rosa.fox@digital.cabinet-office.gov.uk")
  end
end
```