### PR TITLE
tv2hoipg record whether cert is being used by hub

### DIFF
--- a/app/models/certificate_in_use_event.rb
+++ b/app/models/certificate_in_use_event.rb
@@ -1,0 +1,8 @@
+class CertificateInUseEvent < AggregatedEvent
+  belongs_to_aggregate :certificate
+  data_attributes :in_use_at
+
+  def attributes_to_apply
+    { in_use_at: Time.now }
+  end
+end

--- a/app/models/certificate_notification_sent_event.rb
+++ b/app/models/certificate_notification_sent_event.rb
@@ -1,0 +1,8 @@
+class CertificateNotificationSentEvent < AggregatedEvent
+  belongs_to_aggregate :certificate
+  data_attributes :notification_sent
+
+  def attributes_to_apply
+    { notification_sent: true }
+  end
+end

--- a/db/migrate/20191122125659_add_hub_use_notification_to_certificate.rb
+++ b/db/migrate/20191122125659_add_hub_use_notification_to_certificate.rb
@@ -1,0 +1,6 @@
+class AddHubUseNotificationToCertificate < ActiveRecord::Migration[6.0]
+  def change
+    add_column :certificates, :in_use_at, :datetime, null: true
+    add_column :certificates, :notification_sent, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_31_100615) do
+ActiveRecord::Schema.define(version: 2019_11_22_125659) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -24,6 +24,8 @@ ActiveRecord::Schema.define(version: 2019_08_31_100615) do
     t.uuid "component_id"
     t.boolean "enabled", default: true
     t.string "component_type"
+    t.datetime "in_use_at"
+    t.boolean "notification_sent", default: false, null: false
     t.index ["component_id"], name: "index_certificates_on_component_id"
   end
 

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -53,4 +53,12 @@ FactoryBot.define do
     service { create(:service) }
     msa_component_id { create(:msa_component).id }
   end
+
+  factory :certificate_in_use_event do
+    certificate { create(:sp_signing_certificate) }
+  end
+
+  factory :certificate_notification_sent_event do
+    certificate { create(:sp_signing_certificate) }
+  end
 end

--- a/spec/models/certificate_in_use_event_spec.rb
+++ b/spec/models/certificate_in_use_event_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe CertificateInUseEvent, type: :model do
+  it 'is valid and persisted with hub_use_confirmation_at not nil' do
+    certificate = create(:sp_signing_certificate)
+    expect(certificate.in_use_at).to be_nil
+    certificate_in_use_event = create(:certificate_in_use_event, certificate: certificate)
+    expect(certificate_in_use_event).to be_valid
+    expect(certificate_in_use_event).to be_persisted
+    expect(certificate.in_use_at).not_to be_nil
+  end
+end

--- a/spec/models/certificate_notification_sent_spec.rb
+++ b/spec/models/certificate_notification_sent_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe CertificateNotificationSentEvent, type: :model do
+  it 'is valid and persisted with notification_sent updated to true' do
+    certificate = create(:sp_signing_certificate)
+    expect(certificate.notification_sent).to eql(false)
+    certificate_notification_sent_event = create(:certificate_notification_sent_event, certificate: certificate)
+    expect(certificate_notification_sent_event).to be_valid
+    expect(certificate_notification_sent_event).to be_persisted
+    expect(certificate.notification_sent).to eql(true)
+  end
+end

--- a/spec/models/certificate_spec.rb
+++ b/spec/models/certificate_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Certificate, type: :model do
+
   it 'is valid with valid attributes' do
     expect(build(:msa_signing_certificate)).to be_valid
     expect(build(:msa_encryption_certificate)).to be_valid


### PR DESCRIPTION
Scope: This task is just to add suitable database fields, and events to update their values; other tasks will build on this.

Acceptance criteria:
Certificate objects have an optional date field which indicates when that cert is expected to start being used throughout Hub, and a boolean field which indicates whether an email notification to confirm that the cert is in use has been sent.
When a new certificate object is created, the optional date field should be empty and the boolean flag should be false.
Events exist to update the optional date field and the boolean flag.
Tests exist for the previous two acceptance criteria
Note: Making the fields actually sync up with the real cert status in Hub is NOT in scope for this task.