### PR TITLE
Fevlnkrg: enable admins to reset passwords for users

### DIFF
--- a/app/controllers/password_controller.rb
+++ b/app/controllers/password_controller.rb
@@ -41,7 +41,7 @@ class PasswordController < ApplicationController
     @form = ForgottenPasswordForm.new
   end
 
-  def reset_user_password_send_code
+  def force_user_reset_password
     session[:email] = params[:email]
     request_password_reset(params)
     redirect_to reset_password_path

--- a/app/controllers/password_controller.rb
+++ b/app/controllers/password_controller.rb
@@ -41,6 +41,12 @@ class PasswordController < ApplicationController
     @form = ForgottenPasswordForm.new
   end
 
+  def reset_user_password_send_code
+    session[:email] = params[:email]
+    request_password_reset(params)
+    redirect_to reset_password_path
+  end
+
   def send_code
     @form = ForgottenPasswordForm.new(params[:forgotten_password_form] || {})
     if @form.valid?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -133,7 +133,7 @@ class UsersController < ApplicationController
       admin_reset_user_password(username: @user.email)
       ResetUserPasswordEvent.create(data: { username: @user.email, user_id: params[:user_id], name: @user.full_name })
     rescue AuthenticationBackend::AuthenticationBackendException
-      flash[:errors] = t('users.remove_user.errors.generic_error')
+      flash[:errors] = t('users.reset_user_password.errors.generic_error')
     end
     redirect_to users_path
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -123,6 +123,21 @@ class UsersController < ApplicationController
     render :show_update_email, status: :bad_request
   end
 
+  def show_reset_user_password
+    @user = as_team_member(cognito_user: get_user(user_id: params[:user_id]))
+  end
+
+  def reset_user_password
+    begin
+      @user = as_team_member(cognito_user: get_user(user_id: params[:user_id]))
+      admin_reset_user_password(username: @user.email)
+      ResetUserPasswordEvent.create(data: { username: @user.email, user_id: params[:user_id], name: @user.full_name })
+    rescue AuthenticationBackend::AuthenticationBackendException
+      flash[:errors] = t('users.remove_user.errors.generic_error')
+    end
+    redirect_to users_path
+  end
+
 private
 
   def team_valid?

--- a/app/models/reset_user_password_event.rb
+++ b/app/models/reset_user_password_event.rb
@@ -1,0 +1,2 @@
+class ResetUserPasswordEvent < Event
+end

--- a/app/policies/member_policy.rb
+++ b/app/policies/member_policy.rb
@@ -23,6 +23,8 @@ class MemberPolicy < ApplicationPolicy
   alias_method :remove_user?, :member_authorized?
   alias_method :show_update_name?, :member_authorized?
   alias_method :update_name?, :member_authorized?
+  alias_method :show_reset_user_password?, :member_authorized?
+  alias_method :reset_user_password?, :member_authorized?
 
 private
 

--- a/app/policies/password_controller_policy.rb
+++ b/app/policies/password_controller_policy.rb
@@ -33,4 +33,8 @@ class PasswordControllerPolicy < ApplicationPolicy
   def reset?
     true
   end
+
+  def reset_user_password_send_code?
+    true
+  end
 end

--- a/app/policies/password_controller_policy.rb
+++ b/app/policies/password_controller_policy.rb
@@ -34,7 +34,7 @@ class PasswordControllerPolicy < ApplicationPolicy
     true
   end
 
-  def reset_user_password_send_code?
+  def force_user_reset_password?
     true
   end
 end

--- a/app/policies/users_controller_policy.rb
+++ b/app/policies/users_controller_policy.rb
@@ -45,4 +45,12 @@ class UsersControllerPolicy < ApplicationPolicy
   def update_email?
     user.permissions.user_management
   end
+
+  def show_reset_user_password?
+    user.permissions.user_management
+  end
+
+  def reset_user_password?
+    user.permissions.user_management
+  end
 end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -7,8 +7,7 @@
 <%= form_for @form, url: update_user_post_path, class: 'govuk-form-group' do |f| %>
   <% if @gds || (@team_member.user_status?('FORCE_CHANGE_PASSWORD') || @team_member.user_status?('RESET_REQUIRED')) %>
     <p class="govuk-body">
-      <%= t('users.status_label') %> <%= t("users.status.#{@team_member.status}") %> 
-      <% if @team_member.user_status?('FORCE_CHANGE_PASSWORD') %>
+      <%= t('users.status_label') %> <%= t("users.status.#{@team_member.status}") %> <% if @team_member.user_status?('FORCE_CHANGE_PASSWORD') %>
          - <%= link_to t('users.update.resend_invitation.link'), resend_invitation_path, class: 'govuk-link'%>
       <% end %>
     </p>
@@ -20,7 +19,7 @@
 
   <% if @team_member.user_status?('CONFIRMED') %>
     <p class="govuk-body">
-      <%= link_to t('users.update.reset_user_password'), reset_user_password_path, class: 'govuk-link' %>
+      <%= link_to t('users.reset_user_password.title'), reset_user_password_path, class: 'govuk-link' %>
     </p>
   <% end %>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -6,6 +6,8 @@
 
 <%= form_for @form, url: update_user_post_path, class: 'govuk-form-group' do |f| %>
 
+<%= link_to 'reset users password', reset_user_password_path, class: 'govuk-link' %>
+
   <% if @gds || (@team_member.user_status?('FORCE_CHANGE_PASSWORD') || @team_member.user_status?('RESET_REQUIRED')) %>
     <p class="govuk-body">
       <%= t('users.status_label') %> <%= t("users.status.#{@team_member.status}") %> <% if @team_member.user_status?('FORCE_CHANGE_PASSWORD') %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -5,12 +5,10 @@
 <h1 class="govuk-heading-l"><%= @team_member.full_name %></h1>
 
 <%= form_for @form, url: update_user_post_path, class: 'govuk-form-group' do |f| %>
-
-<%= link_to 'reset users password', reset_user_password_path, class: 'govuk-link' %>
-
   <% if @gds || (@team_member.user_status?('FORCE_CHANGE_PASSWORD') || @team_member.user_status?('RESET_REQUIRED')) %>
     <p class="govuk-body">
-      <%= t('users.status_label') %> <%= t("users.status.#{@team_member.status}") %> <% if @team_member.user_status?('FORCE_CHANGE_PASSWORD') %>
+      <%= t('users.status_label') %> <%= t("users.status.#{@team_member.status}") %> 
+      <% if @team_member.user_status?('FORCE_CHANGE_PASSWORD') %>
          - <%= link_to t('users.update.resend_invitation.link'), resend_invitation_path, class: 'govuk-link'%>
       <% end %>
     </p>
@@ -19,6 +17,12 @@
   <p class="govuk-body">
     <%= @team_member.email %><%= link_to t('users.show.change_email'), update_user_email_address_path, class: 'govuk-!-padding-left-1 govuk-link--no-visited-state' %>
   </p>
+
+  <% if @team_member.user_status?('CONFIRMED') %>
+    <p class="govuk-body">
+      <%= link_to t('users.update.reset_user_password'), reset_user_password_path, class: 'govuk-link' %>
+    </p>
+  <% end %>
 
   <% unless @team_member.gds? %>
     <div class="govuk-form-group">

--- a/app/views/users/show_reset_user_password.html.erb
+++ b/app/views/users/show_reset_user_password.html.erb
@@ -1,7 +1,8 @@
-<%= page_title 'Reset user password' %>
+<%= page_title t('users.reset_user_password.title') %>
+
 <%= link_to t('common.back'), users_path, class: 'govuk-back-link' %>
 
-<h1 class="govuk-heading-l">Reset user password: <%= @user.first_name  %></h1>
+<h1 class="govuk-heading-l"><%= t('users.reset_user_password.heading', name: @user.full_name) %></h1>
 
-<%= link_to 'Confirm', reset_user_password_path, method: :post, class: 'govuk-button', data: { module: "govuk-button" } %>
+<%= link_to 'Confirm', reset_user_password_path, method: :post, class: 'govuk-button govuk-button--warning', data: { module: "govuk-button" } %>
 

--- a/app/views/users/show_reset_user_password.html.erb
+++ b/app/views/users/show_reset_user_password.html.erb
@@ -4,5 +4,5 @@
 
 <h1 class="govuk-heading-l"><%= t('users.reset_user_password.heading', name: @user.full_name) %></h1>
 
-<%= link_to 'Confirm', reset_user_password_path, method: :post, class: 'govuk-button govuk-button--warning', data: { module: "govuk-button" } %>
+<%= link_to t('users.reset_user_password.confirm'), reset_user_password_path, method: :post, class: 'govuk-button govuk-button--warning', data: { module: "govuk-button" } %>
 

--- a/app/views/users/show_reset_user_password.html.erb
+++ b/app/views/users/show_reset_user_password.html.erb
@@ -1,0 +1,7 @@
+<%= page_title 'Reset user password' %>
+<%= link_to t('common.back'), users_path, class: 'govuk-back-link' %>
+
+<h1 class="govuk-heading-l">Reset user password: <%= @user.first_name  %></h1>
+
+<%= link_to 'Confirm', reset_user_password_path, method: :post, class: 'govuk-button', data: { module: "govuk-button" } %>
+

--- a/config/initializers/remote_authenticatable.rb
+++ b/config/initializers/remote_authenticatable.rb
@@ -36,7 +36,7 @@ module Devise
           rescue AuthenticationBackend::PasswordResetRequiredException => error
             Rails.logger.error error
             clean_up_session
-            return redirect!(Rails.application.routes.url_helpers.reset_user_password_send_code_path(email: params[:user][:email]))
+            return redirect!(Rails.application.routes.url_helpers.force_user_reset_password_path(email: params[:user][:email]))
           rescue StandardError => error
             Rails.logger.error error
             clean_up_session

--- a/config/initializers/remote_authenticatable.rb
+++ b/config/initializers/remote_authenticatable.rb
@@ -33,6 +33,10 @@ module Devise
             clean_up_session
             Rails.logger.warn error
             return fail!(:temporary_password_expired)
+          rescue AuthenticationBackend::PasswordResetRequiredException => error
+            Rails.logger.error error
+            clean_up_session
+            return redirect!(Rails.application.routes.url_helpers.reset_user_password_send_code_path(email: params[:user][:email]))
           rescue StandardError => error
             Rails.logger.error error
             clean_up_session

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -87,6 +87,8 @@ en:
     reset_user_password:
       title: Reset user password
       heading: Are you sure you want to reset the password for %{name}?
+      errors:
+        generic_error: Something went wrong when removing the user, please try again
     permissions:
       can: Can
       cannot: Cannot
@@ -101,7 +103,6 @@ en:
         link: Resend
         success: The invitation has been successfully resent
         error: There was an error resending the invitation
-      reset_user_password: Reset user password
     roles:
       certmgr: Manage certificates
       usermgr: Add, edit and remove team members

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -84,6 +84,9 @@ en:
       save: Save
       errors:
         generic_error: Error occurred while updating name. Please try again.
+    reset_user_password:
+      title: Reset user password
+      heading: Are you sure you want to reset the password for %{name}?
     permissions:
       can: Can
       cannot: Cannot
@@ -98,6 +101,7 @@ en:
         link: Resend
         success: The invitation has been successfully resent
         error: There was an error resending the invitation
+      reset_user_password: Reset user password
     roles:
       certmgr: Manage certificates
       usermgr: Add, edit and remove team members

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -87,8 +87,9 @@ en:
     reset_user_password:
       title: Reset user password
       heading: Are you sure you want to reset the password for %{name}?
+      confirm: Confirm
       errors:
-        generic_error: Something went wrong when removing the user, please try again
+        generic_error: Something went wrong when resetting the user's password, please try again
     permissions:
       can: Can
       cannot: Cannot

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,6 +65,7 @@ Rails.application.routes.draw do
   post 'forgot-password', to: 'password#send_code'
   get 'reset-password', to: 'password#user_code'
   post 'reset-password', to: 'password#process_code'
+  get 'reset-user-password/:email', constraints: { email: /[^\/]+/}, to: 'password#reset_user_password_send_code', as: :reset_user_password_send_code
 
   get 'profile', to: 'profile#show'
   post 'profile/switch-client', to: 'profile#switch_client'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,7 +65,7 @@ Rails.application.routes.draw do
   post 'forgot-password', to: 'password#send_code'
   get 'reset-password', to: 'password#user_code'
   post 'reset-password', to: 'password#process_code'
-  get 'reset-user-password/:email', constraints: { email: /[^\/]+/}, to: 'password#reset_user_password_send_code', as: :reset_user_password_send_code
+  get 'reset-user-password/:email', constraints: { email: /[^\/]+/}, to: 'password#force_user_reset_password', as: :force_user_reset_password
 
   get 'profile', to: 'profile#show'
   post 'profile/switch-client', to: 'profile#switch_client'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,6 +49,8 @@ Rails.application.routes.draw do
   post '/users/:user_id/update-email', to: 'users#update_email', as: :update_user_email_address_post
   get '/users/:user_id/remove-user', to: 'users#show_remove_user', as: :remove_user
   delete '/users/:user_id/remove-user', to: 'users#remove_user', as: :remove_user_post
+  get '/users/:user_id/reset-user-password', to: 'users#show_reset_user_password', as: :reset_user_password
+  post '/users/:user_id/reset-user-password', to: 'users#reset_user_password', as: :reset_user_password_post
 
   get '/profile/change-password', to: 'password#password_form'
   post '/profile/change-password', to: 'password#update_password'

--- a/lib/auth/authentication_backend.rb
+++ b/lib/auth/authentication_backend.rb
@@ -71,6 +71,15 @@ module AuthenticationBackend
     raise UserNotFoundException.new(e)
   end
 
+  def admin_reset_user_password(username:)
+    client.admin_reset_user_password(
+      username: username,
+      user_pool_id: user_pool_id,
+    )
+  rescue Aws::CognitoIdentityProvider::Errors::ServiceError => e
+    raise AuthenticationBackendException.new(e)
+  end
+
   def create_group(name:, description:)
     client.create_group(
       group_name: name,

--- a/lib/auth/authentication_backend.rb
+++ b/lib/auth/authentication_backend.rb
@@ -15,6 +15,7 @@ module AuthenticationBackend
   class ExpiredConfirmationCodeException < StandardError; end
   class UserNotFoundException < StandardError; end
   class UserNotConfirmedException < StandardError; end
+  class PasswordResetRequiredException < StandardError; end
 
   MINIMUM_PASSWORD_LENGTH = 12
   AUTHENTICATED = 'authenticated'.freeze
@@ -76,6 +77,9 @@ module AuthenticationBackend
       username: username,
       user_pool_id: user_pool_id,
     )
+  rescue Aws::CognitoIdentityProvider::Errors::UserNotFoundException => e
+    Rails.logger.error("User #{params[:email]} is not present but is trying to reset their password")
+    raise UserNotFoundException.new(e)
   rescue Aws::CognitoIdentityProvider::Errors::ServiceError => e
     raise AuthenticationBackendException.new(e)
   end
@@ -388,6 +392,8 @@ private
     end
   rescue Aws::CognitoIdentityProvider::Errors::InvalidParameterException => e
     raise AuthenticationBackendException.new(e)
+  rescue Aws::CognitoIdentityProvider::Errors::PasswordResetRequiredException
+    raise PasswordResetRequiredException.new
   end
 
   # Returns an authentication response normally with JWT

--- a/lib/notify/notification.rb
+++ b/lib/notify/notification.rb
@@ -9,7 +9,7 @@ module Notification
     client.send_email(
       email_address: email_address,
       template_id: "a0578c4a-3373-48c0-b041-c61fcdf4f843",
-      personalisation: { team: "test"}
+      personalisation: { team: "test" },
      )
   end
 end

--- a/spec/controllers/session_controller_spec.rb
+++ b/spec/controllers/session_controller_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe SessionsController, type: :controller do
     @request.env['devise.mapping'] = Devise.mappings[:user]
     post :create, params: { user: { email: username, password: 'validpass' } }
     expect(response).to have_http_status(:redirect)
-    expect(subject).to redirect_to(reset_user_password_send_code_path(username))
+    expect(subject).to redirect_to(force_user_reset_password_path(username))
   end
 
   def setup_stub

--- a/spec/controllers/session_controller_spec.rb
+++ b/spec/controllers/session_controller_spec.rb
@@ -73,6 +73,16 @@ RSpec.describe SessionsController, type: :controller do
     expect(session[:challenge_parameters]).to be_nil
   end
 
+  it 'Redirect user straight to reset password page if user password has been reset' do
+    allow(request).to receive(:headers).and_return(user: 'name')
+    stub_cognito_response(method: :initiate_auth, payload: 'PasswordResetRequiredException')
+    username = 'test@test.com'
+    @request.env['devise.mapping'] = Devise.mappings[:user]
+    post :create, params: { user: { email: username, password: 'validpass' } }
+    expect(response).to have_http_status(:redirect)
+    expect(subject).to redirect_to(reset_user_password_send_code_path(username))
+  end
+
   def setup_stub
     user_hash = CognitoStubClient.stub_user_hash(role: ROLE::GDS, email_domain: TEAMS::GDS_EMAIL_DOMAIN, groups: %w[gds])
     token = CognitoStubClient.user_hash_to_jwt(user_hash)

--- a/spec/system/visit_sign_in_spec.rb
+++ b/spec/system/visit_sign_in_spec.rb
@@ -177,4 +177,12 @@ RSpec.describe 'Sign in', type: :system do
     expect(page.get_rack_session.has_key?(:challenge_name)).to eql false
     expect(page.get_rack_session.has_key?(:challenge_parameters)).to eql false
   end
+
+  scenario 'user redirected when PasswordResetRequiredException is raised' do
+    stub_cognito_response(method: :initiate_auth, payload: 'PasswordResetRequiredException')
+    user = FactoryBot.create(:user_manager_user)
+    sign_in(user.email, user.password)
+    expect(current_path).to eql reset_password_path
+    expect(page).to have_content t('password.reset_password_heading')
+  end
 end

--- a/spec/system/visit_users_reset_user_password_page_spec.rb
+++ b/spec/system/visit_users_reset_user_password_page_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Reset user password page', type: :system do
     it 'renders the page and resets the members password' do
       visit reset_user_password_path(user_id: member_user_id)
       expect(page).to have_content t('users.reset_user_password.heading', name: member_first_name + ' ' + member_family_name)
-      click_link 'Confirm'
+      click_link t('users.reset_user_password.confirm')
       expect(current_path).to eql users_path
     end
   end
@@ -53,7 +53,7 @@ RSpec.describe 'Reset user password page', type: :system do
     it 'renders the page and rests the members password' do
       visit reset_user_password_path(user_id: member_user_id)
       expect(page).to have_content t('users.reset_user_password.heading', name: member_first_name + ' ' + member_family_name)
-      click_link 'Confirm'
+      click_link t('users.reset_user_password.confirm')
       expect(current_path).to eql users_path
     end
   end

--- a/spec/system/visit_users_reset_user_password_page_spec.rb
+++ b/spec/system/visit_users_reset_user_password_page_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe 'Reset user password page', type: :system do
+  include CognitoSupport
+
+  let(:member_user_id) { SecureRandom::uuid }
+  let(:member_first_name) { 'Tester' }
+  let(:member_family_name) { 'Testerator' }
+  let(:member_email) { 'test@test.com' }
+
+  let(:cognito_user) {
+    { username: member_user_id,
+      user_attributes: [{name: "given_name", value: member_first_name},
+                        {name: "family_name", value: member_family_name},
+                        {name: "email", value: member_email},
+                        {name: "custom:roles", value: "certmgr"}]}
+  }
+
+  let(:cognito_users) {
+    { users: [
+      { username: member_user_id,
+        attributes: [{name: "given_name", value: member_first_name},
+                          {name: "family_name", value: member_family_name},
+                          {name: "email", value: member_email},
+                          {name: "custom:roles", value: "certmgr"}]}
+      ]}
+    }
+
+  before(:each) do
+    stub_cognito_response(method: :admin_get_user, payload: cognito_user)
+  end
+
+  context 'GDS user' do
+    before(:each) do
+      login_gds_user
+    end
+
+    it 'renders the page and resets the members password' do
+      visit reset_user_password_path(user_id: member_user_id)
+      expect(page).to have_content t('users.reset_user_password.heading', name: member_first_name + ' ' + member_family_name)
+      click_link 'Confirm'
+      expect(current_path).to eql users_path
+    end
+  end
+
+  context 'User Manager' do
+    before(:each) do
+      user = FactoryBot.create(:user_manager_user)
+      login_as(user, scope: :user)
+      stub_cognito_response(method: :list_users_in_group, payload: cognito_users)
+    end
+
+    it 'renders the page and rests the members password' do
+      visit reset_user_password_path(user_id: member_user_id)
+      expect(page).to have_content t('users.reset_user_password.heading', name: member_first_name + ' ' + member_family_name)
+      click_link 'Confirm'
+      expect(current_path).to eql users_path
+    end
+  end
+end


### PR DESCRIPTION
Admins now have the functionality to reset users passwords.
When viewing team members there is now a link to reset a users password. That then takes you to a confirmation page where you then can confirm. 
<img width="1439" alt="Screen Shot 2019-11-26 at 11 19 54" src="https://user-images.githubusercontent.com/24409958/69640179-d7fa6f80-1055-11ea-9ea4-489712f7b534.png">
<img width="1438" alt="Screen Shot 2019-11-26 at 11 20 00" src="https://user-images.githubusercontent.com/24409958/69640181-d7fa6f80-1055-11ea-9cec-47fe70e2ee19.png">
When the user tries to next log in an exception is raised: `PasswordResetRequiredException` redirecting them straight to the views which already exist for the forgot password flow, minus the part which wants the user to enter an email. We already know the email from when the user tries to log in. The verification code email is straight away sent and just requires the user to enter it and create a new password.

