### PR TITLE
wSQ6uwPR: Allow admins to override cert expiry validation

### DIFF
--- a/app/controllers/certificates_controller.rb
+++ b/app/controllers/certificates_controller.rb
@@ -94,6 +94,7 @@ private
           .merge(
             component_id: component_id,
             component_type: component_type,
+            admin_upload: true,
           )
   end
 end

--- a/app/models/toggle_enable_event.rb
+++ b/app/models/toggle_enable_event.rb
@@ -21,7 +21,7 @@ private
   def not_only_certificate?
     return if certificate.encryption?
     return if enabled
-    return if certificate.component.enabled_signing_certificates.length == 2
+    return if certificate.component.enabled_signing_certificates.length >= 2
 
     errors.add(:certificate, I18n.t('certificates.errors.cannot_disable'))
   end

--- a/app/models/upload_certificate_event.rb
+++ b/app/models/upload_certificate_event.rb
@@ -3,7 +3,7 @@ class UploadCertificateEvent < AggregatedEvent
   include CertificateConcern
 
   belongs_to_aggregate :certificate
-  data_attributes :value, :usage, :component_id, :component_type
+  data_attributes :value, :usage, :component_id, :component_type, :admin_upload
   belongs_to :component, polymorphic: true
   before_save { |event| event.value = convert_to_inline_der(value) }
   after_save TriggerMetadataEventCallback.publish

--- a/app/models/x509_validator.rb
+++ b/app/models/x509_validator.rb
@@ -20,6 +20,8 @@ module X509Validator
   end
 
   def certificate_has_appropriate_not_after(record, x509)
+    return if record.respond_to?(:admin_upload) && record.admin_upload == true
+
     if x509.not_after < Time.now
       record.errors.add(:certificate, I18n.t('certificates.errors.expired'))
     elsif x509.not_after < Time.now + 30.days

--- a/lib/notify/notification.rb
+++ b/lib/notify/notification.rb
@@ -9,7 +9,7 @@ module Notification
     client.send_email(
       email_address: email_address,
       template_id: "a0578c4a-3373-48c0-b041-c61fcdf4f843",
-      personalisation: { team: "test"}
+      personalisation: { team: "test" },
      )
   end
 end


### PR DESCRIPTION
Admins should be able to upload certs which expire at any time. This will enable us to
onboard services which are expiring within less than 30 days.
The rest of the validation remains the same.

Also fixed a linting issue and a small bug (separate commits)