### PR TITLE
P8ifzwdc: small content changes

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,7 +6,7 @@ module ApplicationHelper
   end
 
   def date_to_readable_long_format(cert_date_time)
-    cert_date_time.strftime("%d %B %Y, %H:%M%P")
+    cert_date_time.strftime("%d %B %Y, %I:%M%P")
   end
 
   def page_title(title)

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -37,6 +37,6 @@ class Certificate < Aggregate
   end
 
   def deploying?
-    updated_at >= 1.minutes.ago
+    updated_at >= 10.minutes.ago
   end
 end

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -37,6 +37,6 @@ class Certificate < Aggregate
   end
 
   def deploying?
-    updated_at >= 10.minutes.ago
+    updated_at >= 1.minutes.ago
   end
 end

--- a/app/views/user_journey/confirmation.html.erb
+++ b/app/views/user_journey/confirmation.html.erb
@@ -36,8 +36,6 @@
   </ul>
 <% end %>
 
-<%= render 'shared/component_certificate_doc_links', certificate: @certificate  %>
-
 <% if @not_dual_running.nil? && @certificate.signing? %>
   <div class="govuk-warning-text">
     <span class="govuk-warning-text__icon" aria-hidden="true">!</span>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -425,15 +425,15 @@ en:
       upload_new: Upload your new %{certificate} certificate
       upload_certificate_file_header: Upload a certificate file
       paste_certificate: Paste certificate text into a text box
-      certificate_will_be_replaced: Once you confirm you wish to use this certificate, your old %{component} %{certificate} certificate will be replaced with the new one in the GOV.UK Verify Hub configuration.
-      certificate_will_be_added: Once you confirm you wish to use this certificate, it will be added to the GOV.UK Verify Hub configuration alongside your old signing certificate.
-      encrypt_messages_for_your_service: The GOV.UK Verify Hub will then be using your new certificate to encrypt messages for your service.
+      certificate_will_be_replaced: Once you confirm you want to use this certificate, your old %{component} %{certificate} certificate will be replaced with the new one in the GOV.UK Verify Hub configuration.
+      certificate_will_be_added: Once you confirm you want to use this certificate, it will be added to the GOV.UK Verify Hub configuration alongside your old signing certificate.
+      encrypt_messages_for_your_service: The GOV.UK Verify Hub will then use your new certificate to encrypt messages for your service.
       signed_mesages_from_your_service: The GOV.UK Verify Hub will then trust your old and new certificates to verify signatures on messages from your service.
       how_long_it_takes: This takes around 10 minutes. Your connection will not break.
       will_replace_old_certificate: Using this certificate will replace your old encryption certificate in GOV.UK Verify's configuration within 10 minutes.
       sp_doesnt_support_dual_running: Because your service provider does not support dual running, your connection will break when the GOV.UK Verify Hub starts using your new certificate.
-      restore_connection: At this point, you will need to restore your connection.
-      choose_one: 'Choose one of the following:'
+      restore_connection: As soon as this happens, you will need to restore your connection to GOV.UK Verify.
+      choose_one: 'Choose one option:'
       stop_using_primary_heading: Stop using this primary certificate
       stop_using_primary_warning_html: "This is your primary (most recent) certificate. During a normal certificate rotation you should be disabling your %{href} instead."
       stop_using_secondary_link: secondary certificate


### PR DESCRIPTION
Here are the content changes that we need to make following the content 2i: https://docs.google.com/document/d/1y9NDF-XQrqoTsQyStKJN0VuD65eVou-FUmZmtivJTqE/edit# 

In summary, we need to: 
- Change the time convention in all flows to 12 hour, not 24 hour, if possible 
<img width="579" alt="Screen Shot 2019-11-27 at 11 39 22" src="https://user-images.githubusercontent.com/24409958/69721057-edca6c00-110b-11ea-85e5-285b46e8957f.png">

- Remove the link to the documentation on all the 'confirmation' pages
<img width="1440" alt="Screen Shot 2019-11-27 at 10 27 13" src="https://user-images.githubusercontent.com/24409958/69721062-eefb9900-110b-11ea-9256-9a423b93a162.png">

- Simplify some text on all the 'upload cert' pages
<img width="1439" alt="Screen Shot 2019-11-27 at 10 29 14" src="https://user-images.githubusercontent.com/24409958/69721063-eefb9900-110b-11ea-95b6-301bb8a218bc.png">

- Simplify some text on all the 'check cert' pages
<img width="1440" alt="Screen Shot 2019-11-27 at 11 05 15" src="https://user-images.githubusercontent.com/24409958/69721064-eefb9900-110b-11ea-9426-e21881a74d62.png">

- Clarify a sentence on the ‘check cert page’ for the encryption cert flow, for service providers that do not support dual running
<img width="1437" alt="Screen Shot 2019-11-27 at 11 24 07" src="https://user-images.githubusercontent.com/24409958/69721208-426de700-110c-11ea-93ad-07e5c17b98c2.png">
