### PR TITLE
kvCAeS84: Pluralize the expiring notice on the dashboard correctly

### DIFF
--- a/app/views/user_journey/index.html.erb
+++ b/app/views/user_journey/index.html.erb
@@ -2,8 +2,8 @@
 
 <h1 class="govuk-heading-l"><%= t 'components.title' %></h1>
 
-<% if @total_certificates_expiring_soon  > 0 %>
-  <p><%= t('user_journey.certificates_expiring', number: @total_certificates_expiring_soon) %></p>
+<% if @total_certificates_expiring_soon > 0 %>
+  <p><%= t('user_journey.certificates_expiring', number: pluralize(@total_certificates_expiring_soon, 'certificate')) %></p>
 <% end %>
 
 <p><%= t('user_journey.maintain_connection') %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -353,7 +353,7 @@ en:
     maintain_connection: You need to manage your certificates to make sure your service stays connected to GOV.UK Verify.
     connection_broken_or_compromised_guidance: If your connection has been broken or compromised, read
     connection_broken_or_compromised_link: this guidance
-    certificates_expiring: "%{number} certificates are expiring soon."
+    certificates_expiring: "%{number} expiring soon."
     find_out_more: Find out more about %{link} in the documentation.
     rotate_key_and_certificate: rotating your %{component} %{certificate} key and certificate
     continue: Continue

--- a/spec/system/visit_index_page_spec.rb
+++ b/spec/system/visit_index_page_spec.rb
@@ -126,7 +126,13 @@ RSpec.describe 'IndexPage', type: :system do
     first_expiring_certificate = create(:msa_signing_certificate, value: PKI.new.generate_encoded_cert(expires_in: 29.days))
     second_expiring_certificate = create(:msa_signing_certificate, value: PKI.new.generate_encoded_cert(expires_in: 29.days))
     visit root_path
-    expect(page).to have_content '2 certificates are expiring soon.'
+    expect(page).to have_content '2 certificates expiring soon.'
+  end
+
+  it 'shows the number of expiring certificatesat the top of the page correctley pluralized' do
+    one_expiring_certificate = create(:msa_signing_certificate, value: PKI.new.generate_encoded_cert(expires_in: 29.days))
+    visit root_path
+    expect(page).to have_content '1 certificate expiring soon.'
   end
 
   it 'orders by environment and shows least expiring certificate first' do


### PR DESCRIPTION
When only one cert is expiring it says `1 certificates are expiring soon.` It should say `1 certificate expiring soon.`

Before:
<img width="391" alt="Screen Shot 2019-11-27 at 12 23 51" src="https://user-images.githubusercontent.com/24409958/69723174-de015680-1110-11ea-9ce7-ecd8f095d474.png">
<img width="397" alt="Screen Shot 2019-11-27 at 12 24 05" src="https://user-images.githubusercontent.com/24409958/69723177-de015680-1110-11ea-86c8-72834ad87b5e.png">

After:
<img width="405" alt="Screen Shot 2019-11-27 at 12 09 17" src="https://user-images.githubusercontent.com/24409958/69722702-aba32980-110f-11ea-9466-02f9655ff567.png">
<img width="367" alt="Screen Shot 2019-11-27 at 12 10 07" src="https://user-images.githubusercontent.com/24409958/69722703-ac3bc000-110f-11ea-91fe-10ce20fe6580.png">

