### PR TITLE
Create CertStatusUpdater module

### DIFF
--- a/app/models/polling/cert_status_updater.rb
+++ b/app/models/polling/cert_status_updater.rb
@@ -1,0 +1,41 @@
+class CertStatusUpdater
+  def initialize(hub_config_api)
+    @hub_config_api = hub_config_api
+  end
+
+  def update_hub_usage_status_for_cert(certificate_to_check)
+    outcomes = entity_ids_for(certificate_to_check).map { |entity_id| cert_is_in_use_for_entity_id?(entity_id, certificate_to_check) }
+
+    if outcomes.all?
+      update_cert_status_for(certificate_to_check)
+    end
+  end
+
+private
+
+  def entity_ids_for(certificate)
+    if certificate.component.type == COMPONENT_TYPE::MSA_SHORT
+      [certificate.component.entity_id]
+    else
+      certificate.component.services.map(&:entity_id)
+    end
+  end
+
+  def cert_is_in_use_for_entity_id?(entity_id, certificate_to_check)
+    certs_in_use = get_certs_from_hub(entity_id, certificate_to_check.encryption?)
+    certs_in_use.include?(certificate_to_check.value)
+  end
+
+  def get_certs_from_hub(entity_id, is_for_encryption)
+    if is_for_encryption
+      Array.wrap(@hub_config_api.encryption_certificate(entity_id))
+    else
+      Array.wrap(@hub_config_api.signing_certificates(entity_id))
+    end
+  end
+
+  def update_cert_status_for(certificate_to_check)
+    time_cache_will_have_cleared_by = Time.now + Rails.configuration.hub_certs_cache_expiry
+    CertificateInUseEvent.create(certificate: certificate_to_check, in_use_at: time_cache_will_have_cleared_by)
+  end
+end

--- a/app/models/polling/cert_status_updater.rb
+++ b/app/models/polling/cert_status_updater.rb
@@ -6,7 +6,7 @@ class CertStatusUpdater
   def update_hub_usage_status_for_cert(certificate_to_check)
     outcomes = entity_ids_for(certificate_to_check).map { |entity_id| cert_is_in_use_for_entity_id?(entity_id, certificate_to_check) }
 
-    if outcomes.all?
+    if outcomes.present? && outcomes.all?
       update_cert_status_for(certificate_to_check)
     end
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -47,6 +47,11 @@ module VerifySelfService
     # The cache reload time for the JWKS file from amazon
     config.jwks_cache_expiry = 1.hour
 
+    # The maximum amount of time it could take for Hub's various cert caches to clear
+    # This should be set to the length of the cert cache on the config service, plus the
+    # longest cache on any of: saml-proxy, saml-soap-proxy, saml-engine
+    config.hub_certs_cache_expiry = 90.seconds
+
     # Set a css_compressor so sassc-rails does not overwrite the compressor when running 
     # workaround until https://github.com/sass/libsass/milestone/35 is shipped
     config.assets.css_compressor = nil

--- a/spec/factories/certificate.rb
+++ b/spec/factories/certificate.rb
@@ -1,6 +1,8 @@
 FactoryBot.define do
   factory :cert do
     value { PKI.new.generate_encoded_cert(expires_in: 9.months) }
+    in_use_at { nil }
+    notification_sent { false }
 
     factory :msa_encryption_certificate, class: Certificate do
       usage { CERTIFICATE_USAGE::ENCRYPTION }

--- a/spec/models/polling/cert_status_updater_spec.rb
+++ b/spec/models/polling/cert_status_updater_spec.rb
@@ -1,0 +1,130 @@
+require 'rails_helper'
+require 'polling/cert_status_updater'
+
+RSpec.describe CertStatusUpdater, type: :model do
+
+  let(:root) { PKI.new }
+
+  let(:msa_enc_cert_1) { create(:msa_encryption_certificate, in_use_at: nil) }
+  let(:msa_enc_cert_2) { create(:msa_encryption_certificate, in_use_at: nil) }
+  let(:msa_sgn_cert_1) { create(:msa_signing_certificate, in_use_at: nil) }
+  let(:msa_sgn_cert_2) { create(:msa_signing_certificate, in_use_at: nil) }
+  let(:msa_sgn_cert_3) { create(:msa_signing_certificate, in_use_at: nil) }
+
+  let(:service_1) { create(:service, entity_id: 'entity 1') }
+  let(:service_2) { create(:service, entity_id: 'entity 2') }
+  let(:service_3) { create(:service, entity_id: 'entity 3') }
+  let(:sp_component_1) { create(:sp_component, services: [service_1]) }
+  let(:sp_component_123) { create(:sp_component, services: [service_1, service_2, service_3]) }
+  let(:sp_enc_cert_for_single_entity) { create(:sp_encryption_certificate, component: sp_component_1, in_use_at: nil) }
+  let(:sp_enc_cert_for_multiple_entities) { create(:sp_encryption_certificate, component: sp_component_123, in_use_at: nil) }
+  let(:sp_sgn_cert_for_single_entity) { create(:sp_signing_certificate, component: sp_component_1, in_use_at: nil) }
+  let(:sp_sgn_cert_for_multiple_entities) { create(:sp_signing_certificate, component: sp_component_123, in_use_at: nil) }
+  let(:sp_sgn_cert_other) { create(:sp_signing_certificate, in_use_at: nil) }
+
+  describe '#update_hub_usage_status_for_cert' do
+    context 'When given an encryption cert belonging to an MSA component' do
+      it "leaves the cert unchanged if a call to the Hub does not show it is in use" do
+        hub_config_api = double('hub_config_api')
+        allow(hub_config_api).to receive(:encryption_certificate).and_return(msa_enc_cert_2.value)
+
+        cert_status_updater = CertStatusUpdater.new(hub_config_api)
+
+        expect(msa_enc_cert_1.in_use_at).to be(nil)
+        cert_status_updater.update_hub_usage_status_for_cert(msa_enc_cert_1)
+        expect(msa_enc_cert_1.in_use_at).to be(nil)
+      end
+
+      it "updates the cert's timestamp if a call to the Hub shows it is in use" do
+        hub_config_api = double('hub_config_api')
+        allow(hub_config_api).to receive(:encryption_certificate).and_return(msa_enc_cert_1.value)
+
+        cert_status_updater = CertStatusUpdater.new(hub_config_api)
+
+        expect(msa_enc_cert_1.in_use_at).to be(nil)
+        cert_status_updater.update_hub_usage_status_for_cert(msa_enc_cert_1)
+        expect(msa_enc_cert_1.in_use_at).not_to be(nil)
+      end
+    end
+
+    context 'When given a signing cert belonging to an MSA component' do
+      it "leaves the cert unchanged if a call to the Hub does not show it is in use" do
+        hub_config_api = double('hub_config_api')
+        allow(hub_config_api).to receive(:signing_certificates).and_return([msa_sgn_cert_2.value, msa_sgn_cert_3.value])
+
+        cert_status_updater = CertStatusUpdater.new(hub_config_api)
+
+        expect(msa_sgn_cert_1.in_use_at).to be(nil)
+        cert_status_updater.update_hub_usage_status_for_cert(msa_sgn_cert_1)
+        expect(msa_sgn_cert_1.in_use_at).to be(nil)
+      end
+
+      it "updates the cert's timestamp if a call to the Hub shows it is in use" do
+        hub_config_api = double('hub_config_api')
+        allow(hub_config_api).to receive(:signing_certificates).and_return([msa_sgn_cert_1.value, msa_sgn_cert_2.value])
+
+        cert_status_updater = CertStatusUpdater.new(hub_config_api)
+
+        expect(msa_sgn_cert_1.in_use_at).to be(nil)
+        cert_status_updater.update_hub_usage_status_for_cert(msa_sgn_cert_1)
+        expect(msa_sgn_cert_1.in_use_at).not_to be(nil)
+      end
+    end
+
+    context 'When given an encryption cert belonging to an SP component' do
+      it "leaves the cert unchanged if a call to the Hub does not show it is in use for all relevant entity IDs" do
+        hub_config_api = double('hub_config_api')
+        allow(hub_config_api).to receive(:encryption_certificate).with('entity 1').and_return(sp_enc_cert_for_multiple_entities.value)
+        allow(hub_config_api).to receive(:encryption_certificate).with('entity 2').and_return(sp_enc_cert_for_single_entity.value)
+        allow(hub_config_api).to receive(:encryption_certificate).with('entity 3').and_return(sp_enc_cert_for_multiple_entities.value)
+
+        cert_status_updater = CertStatusUpdater.new(hub_config_api)
+
+        expect(sp_enc_cert_for_multiple_entities.in_use_at).to be(nil)
+        cert_status_updater.update_hub_usage_status_for_cert(sp_enc_cert_for_multiple_entities)
+        expect(sp_enc_cert_for_multiple_entities.in_use_at).to be(nil)
+      end
+
+      it "updates the cert's timestamp if a call to the Hub shows it is in use for all relevant entity IDs" do
+        hub_config_api = double('hub_config_api')
+        allow(hub_config_api).to receive(:encryption_certificate).with('entity 1').and_return(sp_enc_cert_for_multiple_entities.value)
+        allow(hub_config_api).to receive(:encryption_certificate).with('entity 2').and_return(sp_enc_cert_for_multiple_entities.value)
+        allow(hub_config_api).to receive(:encryption_certificate).with('entity 3').and_return(sp_enc_cert_for_multiple_entities.value)
+
+        cert_status_updater = CertStatusUpdater.new(hub_config_api)
+
+        expect(sp_enc_cert_for_multiple_entities.in_use_at).to be(nil)
+        cert_status_updater.update_hub_usage_status_for_cert(sp_enc_cert_for_multiple_entities)
+        expect(sp_enc_cert_for_multiple_entities.in_use_at).not_to be(nil)
+      end
+    end
+
+    context 'When given a signing cert belonging to an SP component' do
+      it "leaves the cert unchanged if a call to the Hub does not show it is in use for all relevant entity IDs" do
+        hub_config_api = double('hub_config_api')
+        allow(hub_config_api).to receive(:signing_certificates).with('entity 1').and_return(sp_sgn_cert_for_multiple_entities.value, sp_sgn_cert_other.value)
+        allow(hub_config_api).to receive(:signing_certificates).with('entity 2').and_return(sp_sgn_cert_for_single_entity.value, sp_sgn_cert_other.value)
+        allow(hub_config_api).to receive(:signing_certificates).with('entity 3').and_return(sp_sgn_cert_for_multiple_entities.value)
+
+        cert_status_updater = CertStatusUpdater.new(hub_config_api)
+
+        expect(sp_sgn_cert_for_multiple_entities.in_use_at).to be(nil)
+        cert_status_updater.update_hub_usage_status_for_cert(sp_sgn_cert_for_multiple_entities)
+        expect(sp_sgn_cert_for_multiple_entities.in_use_at).to be(nil)
+      end
+
+      it "updates the cert's timestamp if a call to the Hub shows it is in use for all relevant entity IDs" do
+        hub_config_api = double('hub_config_api')
+        allow(hub_config_api).to receive(:signing_certificates).with('entity 1').and_return(sp_sgn_cert_for_multiple_entities.value, sp_sgn_cert_other.value)
+        allow(hub_config_api).to receive(:signing_certificates).with('entity 2').and_return(sp_sgn_cert_for_multiple_entities.value, sp_sgn_cert_other.value)
+        allow(hub_config_api).to receive(:signing_certificates).with('entity 3').and_return(sp_sgn_cert_for_multiple_entities.value)
+
+        cert_status_updater = CertStatusUpdater.new(hub_config_api)
+
+        expect(sp_sgn_cert_for_multiple_entities.in_use_at).to be(nil)
+        cert_status_updater.update_hub_usage_status_for_cert(sp_sgn_cert_for_multiple_entities)
+        expect(sp_sgn_cert_for_multiple_entities.in_use_at).not_to be(nil)
+      end
+    end
+  end
+end

--- a/spec/models/polling/cert_status_updater_spec.rb
+++ b/spec/models/polling/cert_status_updater_spec.rb
@@ -16,8 +16,10 @@ RSpec.describe CertStatusUpdater, type: :model do
   let(:service_3) { create(:service, entity_id: 'entity 3') }
   let(:sp_component_1) { create(:sp_component, services: [service_1]) }
   let(:sp_component_123) { create(:sp_component, services: [service_1, service_2, service_3]) }
+  let(:sp_component_0) { create(:sp_component, services: []) }
   let(:sp_enc_cert_for_single_entity) { create(:sp_encryption_certificate, component: sp_component_1, in_use_at: nil) }
   let(:sp_enc_cert_for_multiple_entities) { create(:sp_encryption_certificate, component: sp_component_123, in_use_at: nil) }
+  let(:sp_enc_cert_without_service) { create(:sp_encryption_certificate, component: sp_component_0, in_use_at: nil) }
   let(:sp_sgn_cert_for_single_entity) { create(:sp_signing_certificate, component: sp_component_1, in_use_at: nil) }
   let(:sp_sgn_cert_for_multiple_entities) { create(:sp_signing_certificate, component: sp_component_123, in_use_at: nil) }
   let(:sp_sgn_cert_other) { create(:sp_signing_certificate, in_use_at: nil) }
@@ -25,7 +27,7 @@ RSpec.describe CertStatusUpdater, type: :model do
   describe '#update_hub_usage_status_for_cert' do
     context 'When given an encryption cert belonging to an MSA component' do
       it "leaves the cert unchanged if a call to the Hub does not show it is in use" do
-        hub_config_api = double('hub_config_api')
+        hub_config_api = double(:hub_config_api)
         allow(hub_config_api).to receive(:encryption_certificate).and_return(msa_enc_cert_2.value)
 
         cert_status_updater = CertStatusUpdater.new(hub_config_api)
@@ -36,7 +38,7 @@ RSpec.describe CertStatusUpdater, type: :model do
       end
 
       it "updates the cert's timestamp if a call to the Hub shows it is in use" do
-        hub_config_api = double('hub_config_api')
+        hub_config_api = double(:hub_config_api)
         allow(hub_config_api).to receive(:encryption_certificate).and_return(msa_enc_cert_1.value)
 
         cert_status_updater = CertStatusUpdater.new(hub_config_api)
@@ -49,7 +51,7 @@ RSpec.describe CertStatusUpdater, type: :model do
 
     context 'When given a signing cert belonging to an MSA component' do
       it "leaves the cert unchanged if a call to the Hub does not show it is in use" do
-        hub_config_api = double('hub_config_api')
+        hub_config_api = double(:hub_config_api)
         allow(hub_config_api).to receive(:signing_certificates).and_return([msa_sgn_cert_2.value, msa_sgn_cert_3.value])
 
         cert_status_updater = CertStatusUpdater.new(hub_config_api)
@@ -60,7 +62,7 @@ RSpec.describe CertStatusUpdater, type: :model do
       end
 
       it "updates the cert's timestamp if a call to the Hub shows it is in use" do
-        hub_config_api = double('hub_config_api')
+        hub_config_api = double(:hub_config_api)
         allow(hub_config_api).to receive(:signing_certificates).and_return([msa_sgn_cert_1.value, msa_sgn_cert_2.value])
 
         cert_status_updater = CertStatusUpdater.new(hub_config_api)
@@ -73,7 +75,7 @@ RSpec.describe CertStatusUpdater, type: :model do
 
     context 'When given an encryption cert belonging to an SP component' do
       it "leaves the cert unchanged if a call to the Hub does not show it is in use for all relevant entity IDs" do
-        hub_config_api = double('hub_config_api')
+        hub_config_api = double(:hub_config_api)
         allow(hub_config_api).to receive(:encryption_certificate).with('entity 1').and_return(sp_enc_cert_for_multiple_entities.value)
         allow(hub_config_api).to receive(:encryption_certificate).with('entity 2').and_return(sp_enc_cert_for_single_entity.value)
         allow(hub_config_api).to receive(:encryption_certificate).with('entity 3').and_return(sp_enc_cert_for_multiple_entities.value)
@@ -86,7 +88,7 @@ RSpec.describe CertStatusUpdater, type: :model do
       end
 
       it "updates the cert's timestamp if a call to the Hub shows it is in use for all relevant entity IDs" do
-        hub_config_api = double('hub_config_api')
+        hub_config_api = double(:hub_config_api)
         allow(hub_config_api).to receive(:encryption_certificate).with('entity 1').and_return(sp_enc_cert_for_multiple_entities.value)
         allow(hub_config_api).to receive(:encryption_certificate).with('entity 2').and_return(sp_enc_cert_for_multiple_entities.value)
         allow(hub_config_api).to receive(:encryption_certificate).with('entity 3').and_return(sp_enc_cert_for_multiple_entities.value)
@@ -101,7 +103,7 @@ RSpec.describe CertStatusUpdater, type: :model do
 
     context 'When given a signing cert belonging to an SP component' do
       it "leaves the cert unchanged if a call to the Hub does not show it is in use for all relevant entity IDs" do
-        hub_config_api = double('hub_config_api')
+        hub_config_api = double(:hub_config_api)
         allow(hub_config_api).to receive(:signing_certificates).with('entity 1').and_return(sp_sgn_cert_for_multiple_entities.value, sp_sgn_cert_other.value)
         allow(hub_config_api).to receive(:signing_certificates).with('entity 2').and_return(sp_sgn_cert_for_single_entity.value, sp_sgn_cert_other.value)
         allow(hub_config_api).to receive(:signing_certificates).with('entity 3').and_return(sp_sgn_cert_for_multiple_entities.value)
@@ -114,7 +116,7 @@ RSpec.describe CertStatusUpdater, type: :model do
       end
 
       it "updates the cert's timestamp if a call to the Hub shows it is in use for all relevant entity IDs" do
-        hub_config_api = double('hub_config_api')
+        hub_config_api = double(:hub_config_api)
         allow(hub_config_api).to receive(:signing_certificates).with('entity 1').and_return(sp_sgn_cert_for_multiple_entities.value, sp_sgn_cert_other.value)
         allow(hub_config_api).to receive(:signing_certificates).with('entity 2').and_return(sp_sgn_cert_for_multiple_entities.value, sp_sgn_cert_other.value)
         allow(hub_config_api).to receive(:signing_certificates).with('entity 3').and_return(sp_sgn_cert_for_multiple_entities.value)
@@ -124,6 +126,17 @@ RSpec.describe CertStatusUpdater, type: :model do
         expect(sp_sgn_cert_for_multiple_entities.in_use_at).to be(nil)
         cert_status_updater.update_hub_usage_status_for_cert(sp_sgn_cert_for_multiple_entities)
         expect(sp_sgn_cert_for_multiple_entities.in_use_at).not_to be(nil)
+      end
+    end
+
+    context 'when given a cert belonging to an SP component with no services' do
+      it "performs no action" do
+        hub_config_api = double(:hub_config_api)
+        cert_status_updater = CertStatusUpdater.new(hub_config_api)
+
+        expect(sp_enc_cert_without_service.in_use_at).to be(nil)
+        cert_status_updater.update_hub_usage_status_for_cert(sp_enc_cert_without_service)
+        expect(sp_enc_cert_without_service.in_use_at).to be(nil)
       end
     end
   end


### PR DESCRIPTION
This module provides code which handles checking Hub for the current status of a particular certificate, and taking appropriate action based on the result.  If the given cert is included in the list of certs returned by Hub, then the in_use_at field on that cert will be set to a timestamp representing the moment by which we expect all Hub cert caches to have expired, and thus can trust that the cert is being used throughout all of Hub.

https://trello.com/c/psV0aeSY/780-update-certs-status-timestamp-based-on-result-from-hub