### PR TITLE
EPJNPyyX: Content changes to admin reset password flow

### DIFF
--- a/app/controllers/password_controller.rb
+++ b/app/controllers/password_controller.rb
@@ -6,7 +6,7 @@ class PasswordController < ApplicationController
   skip_before_action :authenticate_user!, except: %w[password_form update_password]
   skip_before_action :set_user, except: %w[password_form update_password]
 
-  layout 'two_thirds_layout', only: :password_form
+  layout 'two_thirds_layout'
 
   def password_form
     @password_form = ChangePasswordForm.new
@@ -44,7 +44,7 @@ class PasswordController < ApplicationController
   def force_user_reset_password
     session[:email] = params[:email]
     request_password_reset(params)
-    redirect_to reset_password_path
+    redirect_to reset_password_path(reset_by_admin: params[:reset_by_admin])
   end
 
   def send_code

--- a/app/controllers/user_journey_controller.rb
+++ b/app/controllers/user_journey_controller.rb
@@ -86,7 +86,6 @@ class UserJourneyController < ApplicationController
 
     if @upload.valid?
       component = klass_component(@upload.component_type).find_by_id(@upload.component_id)
-
       if @upload.certificate.encryption?
         replace = ReplaceEncryptionCertificateEvent.create(
           component: component,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -80,7 +80,8 @@
     <div class="govuk-width-container">
       <%= yield(:banner) %>
       <main class="govuk-main-wrapper app-decrease-wrapper-padding" id="main-content" role="main">
-        <% if flash.present? && (flash.keys & %w[error errors notice success warn alert]).size > 0 %>
+
+        <% if flash.present? && (flash.keys & %w[error errors notice success warn alert]).size > 0 && !flash.select{|k,v| !v.blank?}.empty? %>
           <div class="govuk-warning-text">
             <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
             <strong class="govuk-warning-text__text">

--- a/app/views/password/_password_recovery_form.erb
+++ b/app/views/password/_password_recovery_form.erb
@@ -3,7 +3,7 @@
 <%= form_for @form, url: reset_password_path do |f| %>
   <fieldset class="govuk-fieldset" aria-describedby="changed-password-hint">
     <span id="changed-password-hint" class="govuk-hint">
-      <%= t 'password.reset_password_legend' %>
+      <%= params[:reset_by_admin].present? ? t('password.admin_reset_password_legend') : t('password.reset_password_legend') %>
     </span>
     <% if session[:email].nil? %>
       <div class="govuk-form-group">

--- a/app/views/users/show_reset_user_password.html.erb
+++ b/app/views/users/show_reset_user_password.html.erb
@@ -4,5 +4,7 @@
 
 <h1 class="govuk-heading-l"><%= t('users.reset_user_password.heading', name: @user.full_name) %></h1>
 
+<p><%= t('users.reset_user_password.description', name: @user.full_name ) %></p>
+
 <%= link_to t('users.reset_user_password.confirm'), reset_user_password_path, method: :post, class: 'govuk-button govuk-button--warning', data: { module: "govuk-button" } %>
 

--- a/config/initializers/remote_authenticatable.rb
+++ b/config/initializers/remote_authenticatable.rb
@@ -36,7 +36,7 @@ module Devise
           rescue AuthenticationBackend::PasswordResetRequiredException => error
             Rails.logger.error error
             clean_up_session
-            return redirect!(Rails.application.routes.url_helpers.force_user_reset_password_path(email: params[:user][:email]))
+            return redirect!(Rails.application.routes.url_helpers.force_user_reset_password_path(email: params[:user][:email], reset_by_admin: true))
           rescue StandardError => error
             Rails.logger.error error
             clean_up_session

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -14,7 +14,7 @@ en:
       last_attempt: "You have one more attempt before your account is locked."
       not_found_in_database: "Invalid %{authentication_keys} or password."
       timeout: "Your session expired. Sign in to continue."
-      unauthenticated: "Sign in to continue"
+      unauthenticated: ""
       unconfirmed: "Confirm your email address to continue"
       unknown_cognito_error: "Something went wrong in our backend. Try again later."
       unknown_cognito_response: "Something went wrong in our backend. Try again later."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,8 +85,9 @@ en:
       errors:
         generic_error: Error occurred while updating name. Please try again.
     reset_user_password:
-      title: Reset user password
+      title: Reset user's password
       heading: Are you sure you want to reset the password for %{name}?
+      description: Next time %{name} tries to sign in they will receive an email with a code to create a new password
       confirm: Confirm
       errors:
         generic_error: Something went wrong when resetting the user's password, please try again
@@ -192,12 +193,13 @@ en:
     title_reset: Set up a new password
     forgot_link: Forgotten your password?
     forgot_password_legend: Enter your e-mail address below and we'll send you an e-mail with a code you can use to change your password.
-    your_email_lbl: "Your e-mail address:"
+    your_email_lbl: "E-mail address"
     request_reset: Send code
     change_password_heading: Change your password
     reset_password_heading: Set your new password
     password_changed: Password changed successfully
     reset_password_legend: You can reset your password by entering the code you have received via email.
+    admin_reset_password_legend: An admin user has reset your password. You can change your password by entering the code you have received via email.
     current_password_lbl: Current password
     new_password_lbl: New password
     confirm_password_lbl: Confirm new password

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,9 +63,9 @@ Rails.application.routes.draw do
   post '/profile/update-mfa', to: 'profile#change_mfa', as: :update_mfa_post
   get 'forgot-password', to: 'password#forgot_form'
   post 'forgot-password', to: 'password#send_code'
-  get 'reset-password', to: 'password#user_code'
-  post 'reset-password', to: 'password#process_code'
-  get 'reset-user-password/:email', constraints: { email: /[^\/]+/}, to: 'password#force_user_reset_password', as: :force_user_reset_password
+  get 'reset-password(/:reset_by_admin)', to: 'password#user_code', as: :reset_password
+  post 'reset-password(/:reset_by_admin)', to: 'password#process_code'
+  get 'reset-user-password/:email(/:reset_by_admin)', constraints: { email: /[^\/]+/}, to: 'password#force_user_reset_password', as: :force_user_reset_password
 
   get 'profile', to: 'profile#show'
   post 'profile/switch-client', to: 'profile#switch_client'

--- a/spec/controllers/session_controller_spec.rb
+++ b/spec/controllers/session_controller_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe SessionsController, type: :controller do
     @request.env['devise.mapping'] = Devise.mappings[:user]
     post :create, params: { user: { email: username, password: 'validpass' } }
     expect(response).to have_http_status(:redirect)
-    expect(subject).to redirect_to(force_user_reset_password_path(username))
+    expect(subject).to redirect_to(force_user_reset_password_path(username, true))
   end
 
   def setup_stub

--- a/spec/system/visit_sign_in_spec.rb
+++ b/spec/system/visit_sign_in_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe 'Sign in', type: :system do
     stub_cognito_response(method: :initiate_auth, payload: 'PasswordResetRequiredException')
     user = FactoryBot.create(:user_manager_user)
     sign_in(user.email, user.password)
-    expect(current_path).to eql reset_password_path
+    expect(current_path).to eql reset_password_path(reset_by_admin: true)
     expect(page).to have_content t('password.reset_password_heading')
   end
 end


### PR DESCRIPTION
The password controller now uses the column two thirds
Fix form label to just be Email
Remove sign in to continue as its self explanatory
Added a small description to reset user password page:
<img width="1440" alt="Screen Shot 2019-12-02 at 10 34 14" src="https://user-images.githubusercontent.com/24409958/69954207-b33d4680-14f2-11ea-8e75-7d6dba3997ac.png">

Added specialised text to reset password flow when admin reset a users password:
<img width="1440" alt="Screen Shot 2019-12-02 at 10 59 44" src="https://user-images.githubusercontent.com/24409958/69954308-e4b61200-14f2-11ea-8cbf-52d75ee29a2d.png">
