### PR TITLE
BAU: Enable admins to override expiry restrictions on encryption certificates

### DIFF
--- a/app/controllers/certificates_controller.rb
+++ b/app/controllers/certificates_controller.rb
@@ -20,6 +20,7 @@ class CertificatesController < ApplicationController
         replace_event = ReplaceEncryptionCertificateEvent.create(
           component: component,
           encryption_certificate_id: @upload.certificate.id,
+          admin_upload: true,
         )
         check_metadata_published(replace_event.id)
       end
@@ -72,6 +73,7 @@ class CertificatesController < ApplicationController
     event = ReplaceEncryptionCertificateEvent.create(
       component: component,
       encryption_certificate_id: certificate.id,
+      admin_upload: true,
     )
     unless event.valid?
       error_message = event.errors.full_messages

--- a/app/models/replace_encryption_certificate_event.rb
+++ b/app/models/replace_encryption_certificate_event.rb
@@ -1,6 +1,6 @@
 class ReplaceEncryptionCertificateEvent < AggregatedEvent
   belongs_to_aggregate :component
-  data_attributes :encryption_certificate_id
+  data_attributes :encryption_certificate_id, :admin_upload
   validates :value, presence: true, certificate: true
   after_save TriggerMetadataEventCallback.publish
 


### PR DESCRIPTION
Previously, we've added the ability for admins to override the certificate validation for
expiry. This also adds it for encryption certificate.

Previous PR: https://github.com/alphagov/verify-self-service/pull/315