### PR TITLE
BUGFIX: Missing space between classes

### DIFF
--- a/app/views/shared/_user_component_certificates.html.erb
+++ b/app/views/shared/_user_component_certificates.html.erb
@@ -27,7 +27,7 @@
                     <% end %>
                   </td>
                   <td class="govuk-table__cell">
-                    <div class="app-certificate-tag <%= 'app-certificate-tag-deploying' if cert.deploying? %><%= 'app-certificate-tag-expiring' if cert.expires_soon? %>">
+                    <div class="app-certificate-tag <%= 'app-certificate-tag-deploying' if cert.deploying? %> <%= 'app-certificate-tag-expiring' if cert.expires_soon? %>">
                       <strong class="govuk-tag"><%= certificate_status(cert) %></strong>
                     </div>
                   </td>


### PR DESCRIPTION
The tags when the cert is expiring and deploying are not delimited by a space meaning
the resulting class is `app-certificate-tag-deployingapp-certificate-tag-expiring`

This scenario should rarely happen, but it should be correct regardless.

<img width="716" alt="image" src="https://user-images.githubusercontent.com/30629434/70035423-b6940900-15aa-11ea-83f9-faacbcf38fd9.png">
