### PR TITLE
XsLYPuxh: Bug - failed to publish now renders correctly when necessary

### DIFF
--- a/app/controllers/user_journey_controller.rb
+++ b/app/controllers/user_journey_controller.rb
@@ -99,6 +99,8 @@ class UserJourneyController < ApplicationController
 
       if certicate_published && replaced_certicate_published
         render :confirmation
+      elsif @upload.certificate.signing? && certicate_published
+        render :confirmation
       else
         render :publish_failed
       end

--- a/spec/system/visit_user_journey_check_your_certificate_page_spec.rb
+++ b/spec/system/visit_user_journey_check_your_certificate_page_spec.rb
@@ -105,6 +105,18 @@ RSpec.describe 'Check your certificate page', type: :system do
       expect(current_path).to eql confirmation_path(vsp_signing_certificate.id)
     end
 
+    it 'unsuccessfully publishes certificate' do
+      stub_storage_client_service_error
+      visit upload_certificate_path(sp_signing_certificate.id)
+      fill_in 'certificate_value', with: sp_signing_certificate.value
+      click_button 'Continue'
+      expect(current_path).to eql check_your_certificate_path(sp_signing_certificate.id)
+      expect(page).to have_content 'Signing'
+      click_button 'Use this certificate'
+      expect(current_path).to eql confirmation_path(sp_signing_certificate.id)
+      expect(page).to have_content t('user_journey.confirmation.failed_to_publish_heading')
+    end
+
     it 'expect sp component, signing certificate and successfully goes to next page' do
       visit upload_certificate_path(sp_signing_certificate.id)
       fill_in 'certificate_value', with: sp_signing_certificate.value


### PR DESCRIPTION
The warning that publishing to S3 failed does not show on encryption certs. Fixed the logic which decides which views are being rendered.
We was only testing the encryption journey unsuccessful publish, created a test for signing