### PR TITLE
Hkymg4ca generic scheduler polling functionality

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ gem 'jwt'
 gem 'pundit'
 gem 'request_store'
 gem 'rqrcode'
+gem 'rufus-scheduler'
 
 gem 'notifications-ruby-client'
 gem 'email_validator'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,8 @@ GEM
     email_validator (2.0.1)
       activemodel
     erubi (1.9.0)
+    et-orbi (1.2.2)
+      tzinfo
     execjs (2.7.0)
     factory_bot (5.1.1)
       activesupport (>= 4.2.0)
@@ -125,6 +127,9 @@ GEM
     faraday (0.17.0)
       multipart-post (>= 1.2, < 3)
     ffi (1.11.1)
+    fugit (1.3.3)
+      et-orbi (~> 1.1, >= 1.1.8)
+      raabro (~> 1.1)
     geckodriver-helper (0.24.0)
       archive-zip (~> 0.7)
     globalid (0.4.2)
@@ -185,6 +190,7 @@ GEM
     puma (3.12.1)
     pundit (2.1.0)
       activesupport (>= 3.0.0)
+    raabro (1.1.6)
     rack (2.0.7)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -268,6 +274,8 @@ GEM
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
     rubyzip (2.0.0)
+    rufus-scheduler (3.6.0)
+      fugit (~> 1.1, >= 1.1.6)
     safe_yaml (1.0.5)
     sassc (2.2.1)
       ffi (~> 1.9)
@@ -353,6 +361,7 @@ DEPENDENCIES
   rspec-rails (>= 4.0.0.beta2)
   rubocop
   rubocop-rails
+  rufus-scheduler
   sassc-rails
   selenium-webdriver
   sentry-raven

--- a/app/models/polling/scheduler.rb
+++ b/app/models/polling/scheduler.rb
@@ -1,0 +1,46 @@
+require 'rufus-scheduler'
+module Polling
+  class Scheduler
+    attr_reader :rufus_scheduler
+    attr_reader :job
+    DEFAULT_TIMEOUT = '30.0s'.freeze
+    DEFAULT_NUMBER_POLLS = 30
+
+    def initialize(opts = { overlap: false, timeout: DEFAULT_TIMEOUT, times: DEFAULT_NUMBER_POLLS })
+      @opts = opts
+      @rufus_scheduler ||= Rufus::Scheduler.new
+      @rufus_scheduler.stderr = StringIO.new
+    end
+
+    def mode(mode, time = Rails.configuration.scheduler_polling_interval)
+    # @mode is any of kind of rufus-scheduler job i.e in, at, every, interval and cron jobs
+      @mode = mode
+      @time = time
+      self
+    end
+
+    def perform(action = -> {})
+      @job = @rufus_scheduler.method("schedule_#{@mode}")
+                            .call(@time, **@opts, &action)
+      self
+    rescue NameError => e
+      Rails.logger.error("#{e}, Expected symbol or string for scheduler i.e in, at, every, interval or cron")
+    end
+
+    def action_result
+      @job.handler.call
+    end
+
+    def until(test)
+      stop if test
+    end
+
+    def stop
+      @rufus_scheduler.stop
+    end
+
+    def stderr
+      @rufus_scheduler.stderr
+    end
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -81,6 +81,8 @@ Rails.application.configure do
    end
 
   config.hub_config_host = ENV.fetch('HUB_CONFIG_HOST', 'http://localhost:50240')
+  config.scheduler_polling_interval =  ENV.fetch('SCHEDULER_POLLING_INTERVAL','5s')
+
   config.after_initialize do
     require 'api/hub_config_api'
     HUB_CONFIG_API = HubConfigApi.new

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -148,8 +148,11 @@ Rails.application.configure do
   end
 
   config.hub_config_host = ENV.fetch('HUB_CONFIG_HOST')
+
   config.after_initialize do
     require 'api/hub_config_api'
     HUB_CONFIG_API = HubConfigApi.new
   end
+
+  config.scheduler_polling_interval =  ENV.fetch('SCHEDULER_POLLING_INTERVAL','5s')
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -51,13 +51,13 @@ Rails.application.configure do
     'staging': 'staging-bucket',
     'test': 'test-bucket'
   }
-
   config.cognito_aws_access_key_id = ENV['COGNITO_AWS_ACCESS_KEY_ID']
   config.cognito_aws_secret_access_key = ENV['COGNITO_AWS_SECRET_ACCESS_KEY']
   config.cognito_client_id = ENV['AWS_COGNITO_CLIENT_ID']
   config.cognito_user_pool_id = ENV['AWS_COGNITO_USER_POOL_ID']
 
   config.hub_config_host = 'http://config-service.test'
+  config.scheduler_polling_interval =  ENV.fetch('SCHEDULER_POLLING_INTERVAL','5s')
 
   config.after_initialize do
     require 'api/hub_config_api'

--- a/spec/models/polling/scheduler_spec.rb
+++ b/spec/models/polling/scheduler_spec.rb
@@ -1,0 +1,181 @@
+require 'rails_helper'
+
+RSpec.describe Polling::Scheduler, type: :model do
+  let(:scheduler) { Polling::Scheduler.new }
+  let(:greetings) { 'hello verify self service...' }
+  let(:worker) {
+   Class.new do
+      def work
+      end
+   end.new
+  }
+  let(:display) {
+    Class.new do
+      def name(name)
+        "my name is #{name}"
+      end
+    end.new
+  }
+  context 'is polling (every)' do
+    it 'creates a new scheduler' do
+      expect(scheduler).not_to be_nil
+    end
+
+    it 'has chainable methods' do
+      expect(scheduler.mode(:every)).to eql scheduler
+      expect(scheduler.perform(->{ worker.work })).to be scheduler
+    end
+
+    it 'does something when mode is bad' do
+      expect(scheduler.mode(:ofather)).to eql scheduler
+      expect(scheduler.perform(->{ worker.work })).not_to be scheduler
+    end
+
+    it 'uses duration string to poll on a repeatable schedule' do
+      scheduler.mode(:every, '1h')
+              .perform(->{ display.name('Fido dido')})
+      job = scheduler.job
+
+      expect(job.class).to eql(Rufus::Scheduler::EveryJob)
+      expect(job).to be_scheduled
+      expect(job.frequency).to eq(3600.0)
+      expect(scheduler.action_result).to eql display.name('Fido dido')
+    end
+
+    it 'polls when there is an action but until test is not given' do
+      scheduler.mode(:every, '2m')
+              .perform(->{ greetings })
+
+      job = scheduler.job
+      expect(job).to be_scheduled
+      expect(job.frequency).to eq(120)
+      expect(scheduler.action_result).to eql greetings
+    end
+
+    it 'does not poll when there is an action but until test is true' do
+      scheduler.mode(:every, '2m')
+               .perform(->{ 'hello verify self service...' })
+               .until(scheduler.action_result.present?)
+
+      job = scheduler.job
+
+      expect(job).not_to be_scheduled
+      expect(scheduler.action_result).to eql greetings
+    end
+
+    it 'can display errors when timeout is specified' do
+      scheduler = Polling::Scheduler.new(timeout: '0.5s')
+      scheduler.mode(:every, '1s')
+               .perform(-> {
+                 sleep 0.9
+                })
+
+        sleep(2)
+        expect(scheduler.stderr.string).to match(/Rufus::Scheduler::TimeoutError/)
+    end
+
+    it 'can display errors when timeout is specified' do
+      scheduler = Polling::Scheduler.new(timeout: '0.5s')
+      scheduler.mode(:every, '1s')
+               .perform(-> {
+                 sleep 0.9
+                })
+
+        sleep(2)
+        expect(scheduler.stderr.string).to match(/Rufus::Scheduler::TimeoutError/)
+    end
+
+    context 'stops using last:/last_in/:last_at/times: options' do
+      it 'uses a time instance to unschedule job at a particular time' do
+        counter = 0
+        t = Time.now + 2.seconds
+        tt = nil
+        scheduler = Polling::Scheduler.new(last: t)
+        job = scheduler.mode(:every, '0.5s')
+                .perform(-> {
+                  display.name('Fido dido')
+                  counter += 1
+                  tt = Time.now}
+                  )
+                  .job
+        sleep 3
+
+        expect(job.last_at.to_f).to eql(t.to_f)
+        expect([3, 4]).to include(counter)
+        expect(scheduler.rufus_scheduler.jobs).not_to include(job)
+        expect(scheduler.job).not_to be_scheduled
+      end
+
+      it 'uses a duration string to unschedule job after a particular duration' do
+        t = Time.now
+        scheduler = Polling::Scheduler.new(last_in: '2s')
+        job = scheduler.mode(:every, '0.5s')
+                      .perform
+                      .job
+
+        expect(job.last_at).to be >= t + 2.seconds
+        expect(job.last_at).to be < t + 2.5.seconds
+      end
+
+      it 'uses no of times to unschedule job' do
+        counter = 0
+        scheduler = Polling::Scheduler.new(times: 3)
+        job = scheduler.mode(:every, '0.5s')
+                        .perform(-> { counter += 1 })
+                        .job
+
+        expect(job).to be_scheduled
+        sleep(2.6)
+
+        expect(counter).to eq(3)
+        expect(job).not_to be_scheduled
+      end
+    end
+  end
+
+  it 'can create and use multiple scheduler instances' do
+    scheduler.mode(:every, '2m')
+    .perform(->{ greetings })
+
+    job = scheduler.job
+    expect(job).to be_scheduled
+    expect(job.frequency).to eq(120)
+    expect(scheduler.action_result).to eql greetings
+
+    scheduler_one = Polling::Scheduler.new
+    scheduler_one.mode(:every, '2m')
+    .perform(->{ 'hello verify self service...' })
+    .until(scheduler_one.action_result.present?)
+
+    job_one = scheduler_one.job
+
+    expect(job_one).not_to be_scheduled
+    expect(scheduler_one.action_result).to eql greetings
+
+    scheduler_two = Polling::Scheduler.new
+    scheduler_two.mode(:every, '1h')
+    .perform(->{ display.name('Fido dido')})
+    job_two = scheduler_two.job
+
+    expect(job_two.class).to eql(Rufus::Scheduler::EveryJob)
+    expect(job_two).to be_scheduled
+    expect(job_two.frequency).to eq(3600.0)
+    expect(scheduler_two.action_result).to eql display.name('Fido dido')
+  end
+
+  context 'is scheduling (in)' do
+    it 'creates an in job schedule' do
+      expect(scheduler.mode(:in)).to eql scheduler
+      expect(scheduler.perform(->{ worker.work })).to be scheduler
+    end
+    it 'uses duration string to schedule an action' do
+      job = scheduler.mode(:in, '1h')
+                     .perform(->{ display.name('Fido dido')})
+                     .job
+
+      expect(job.class).to eql(Rufus::Scheduler::InJob)
+      expect(job).to be_scheduled
+      expect(scheduler.action_result).to eql display.name('Fido dido')
+    end
+  end
+end


### PR DESCRIPTION
    **HKYMG4ca: generic polling functionality**
Is the first of more PR to come for [Poll Hub to get status of new certs](https://trello.com/c/HKYMG4ca/781-poll-hub-to-get-status-of-new-certs). It add the rufus-scheduler gem and a class to wrap around **rufus-scheduler**. It can be used for
    **polling action** or can be used to **schedule an action** to occur at some
    later point.
      - it accepts a mode
          i.e mode('every') for polling
              mode('in') for running a later point
      -  a perform which requires a lambda
      -  until is the condition which must evaluate to true for it.
      ```
         scheduler.mode(:every, '2m')
                 .perform(->{ 'hello verify self service...' })
                 .until(scheduler.action_result.present?)
      ```