### PR TITLE
o8P0uBic: Send reminder email for expiring certs

### DIFF
--- a/app/models/certificate_expiry_reminder.rb
+++ b/app/models/certificate_expiry_reminder.rb
@@ -56,7 +56,7 @@ module CertificateExpiryReminder
       recipients = team_recipients(team.team_alias)
       certificates = certs.sort_by { |cert| [cert.component.environment, cert.component_type] }.reverse
       certificates_list = certificates.map do |cert|
-        "#{component_name(cert)} (#{cert.component.environment}): #{cert.usage} certificate - expires on #{cert.x509.not_after}"
+        "#{cert.component.display_long_name} (#{cert.component.environment}): #{cert.usage} certificate - expires on #{cert.x509.not_after}"
       end
       Rails.logger.info("Sending a #{days}-day reminder email to #{team.name} team (#{recipients.count} recipients, #{certificates_list.count} certificates)")
       Rails.logger.error("No recipients found for #{team.name}!") if recipients.empty?
@@ -73,16 +73,6 @@ module CertificateExpiryReminder
     def team_recipients(team_alias)
       users = get_users_in_group(group_name: team_alias)
       users.map { |user| user.attributes.find { |att| att.name == 'email' }.value }
-    end
-
-    def component_name(cert)
-      if cert.component_type == COMPONENT_TYPE::MSA
-        "Matching Service Adapter"
-      elsif cert.component.vsp
-        "Verify Service Provider"
-      else
-        "Service Provider"
-      end
     end
   end
 end

--- a/app/models/certificate_expiry_reminder.rb
+++ b/app/models/certificate_expiry_reminder.rb
@@ -1,0 +1,73 @@
+require 'notify/notification'
+require 'auth/authentication_backend'
+
+module CertificateExpiryReminder
+  class Check
+    include Notification
+    include AuthenticationBackend
+
+    REMIND_DAYS_LEFT = [30, 7, 3].freeze
+
+    def run
+      Rails.logger.info("Looking for expiring certs which are enabled...")
+      certificates = expiring_certs
+      Rails.logger.info("Found #{certificates.count} expiring certs.")
+      if certificates.any?
+        send_notifications(group_by_team(certificates))
+      end
+    end
+
+  private
+
+    def expiring_certs
+      Certificate.where('enabled = ?', true).select { |c| REMIND_DAYS_LEFT.include?(c.days_left) && !c.component.nil? }
+    end
+
+    def group_by_team(certificates)
+      certificates.group_by { |c| c.component.team_id }
+    end
+
+    def send_notifications(team_certificates)
+      team_certificates.each do |team_id, certificates|
+        team = Team.find_by_id(team_id)
+        certs_by_days_left = certificates.group_by(&:days_left)
+        certs_by_days_left.each do |days, certs|
+          send_reminder(team, certs, days)
+        end
+      end
+    end
+
+    def send_reminder(team, certs, days)
+      recipients = team_recipients(team.team_alias)
+      certificates = certs.sort_by { |cert| [cert.component.environment, cert.component_type] }.reverse
+      certificates_list = certificates.map do |cert|
+        "#{component_name(cert)} (#{cert.component.environment}): #{cert.usage} certificate - expires on #{cert.x509.not_after}"
+      end
+      Rails.logger.info("Sending a #{days}-day reminder email to #{team.name} team (#{recipients.count} recipients, #{certificates_list.count} certificates)")
+      Rails.logger.error("No recipients found for #{team.name}!") if recipients.empty?
+      recipients.each do |email|
+        send_reminder_email(
+          email_address: email,
+          team_name: team.name,
+          days_left: days,
+          certificates: certificates_list,
+        )
+      end
+    end
+
+    def team_recipients(team_alias)
+      users = get_users_in_group(group_name: team_alias)
+      users.map { |user| user.attributes.find { |att| att.name == 'email' }.value }
+    end
+
+    def component_name(cert)
+      if cert.component_type == COMPONENT_TYPE::MSA
+        "Matching Service Adapter"
+      elsif cert.component.vsp
+        "Verify Service Provider"
+      else
+        "Service Provider"
+      end
+    end
+  end
+end

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -95,6 +95,10 @@ class Component < Aggregate
     I18n.t("user_journey.component_name.#{type}")
   end
 
+  def display_long_name
+    I18n.t("user_journey.component_long_name.#{type}")
+  end
+
 private
 
   def unexpired_encryption_certificate

--- a/lib/notify/notification.rb
+++ b/lib/notify/notification.rb
@@ -4,8 +4,7 @@ module Notification
   INVITE_TEMPLATE = "afdb4827-0f71-4588-b35d-80bd514f5bdb".freeze
   REMINDER_TEMPLATE = "bbc34127-7fca-4d78-a95b-703da58e15ce".freeze
 
-  REMINDER_TEMPLATE_STANDARD_SUBJECT = "Your GOV.UK Verify certificates will expire on %s".freeze
-  REMINDER_TEMPLATE_URGENT_SUBJECT = "Urgent: your GOV.UK Verify certificates will expire in %d days".freeze
+  REMINDER_TEMPLATE_SUBJECT = "your GOV.UK Verify certificates will expire on %s".freeze
 
   def mail_client
     Notifications::Client.new(Rails.configuration.notify_key)
@@ -27,7 +26,7 @@ module Notification
 
   def send_reminder_email(email_address:, team_name:, days_left:, certificates:)
     expiry_date = (Time.now + days_left.days).strftime("%d %B %Y")
-    subject = days_left == 3 ? REMINDER_TEMPLATE_URGENT_SUBJECT % days_left : REMINDER_TEMPLATE_STANDARD_SUBJECT % expiry_date
+    subject = days_left == 3 ? "Urgent: #{REMINDER_TEMPLATE_SUBJECT}" % expiry_date : (REMINDER_TEMPLATE_SUBJECT % expiry_date).sub(/^./, &:upcase)
     mail_client.send_email(
       email_address: email_address,
       template_id: REMINDER_TEMPLATE,
@@ -35,6 +34,7 @@ module Notification
         subject: subject,
         team: team_name,
         no_of_certs: certificates.count,
+        multiple: certificates.count > 1 ? 'yes' : 'no',
         expire_on: expiry_date,
         certificates: certificates,
         url: url,

--- a/lib/tasks/check_expiring_certs.rake
+++ b/lib/tasks/check_expiring_certs.rake
@@ -1,6 +1,6 @@
 desc 'Email users if their certs are due to expire soon'
-task 'send_cert_expiry_reminder_emails' do
-  # Placeholder to test scheduler
-  # Sending expiry emails will be implemented in future
-  puts "Hello World!"
+task 'send_cert_expiry_reminder_emails' => :environment do
+  Rails.logger.info("Scheduled rake task started")
+  CertificateExpiryReminder::Check.new().run
+  Rails.logger.info("Scheduled rake task ended")
 end

--- a/spec/models/certificate_expiry_reminder_spec.rb
+++ b/spec/models/certificate_expiry_reminder_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe CertificateExpiryReminder, type: :model do
           subject: "Your GOV.UK Verify certificates will expire on #{expected_expiry_date}",
           team: cert.component.team.name,
           no_of_certs: 1,
+          multiple: 'no',
           expire_on: expected_expiry_date,
           certificates: ["Verify Service Provider (staging): encryption certificate - expires on #{cert.x509.not_after}"],
           url: "http://www.test.com"
@@ -83,6 +84,7 @@ RSpec.describe CertificateExpiryReminder, type: :model do
           subject: "Your GOV.UK Verify certificates will expire on #{expected_expiry_date}",
           team: cert.component.team.name,
           no_of_certs: 1,
+          multiple: 'no',
           expire_on: expected_expiry_date,
           certificates: ["Verify Service Provider (staging): encryption certificate - expires on #{cert.x509.not_after}"],
           url: "http://www.test.com"
@@ -110,6 +112,7 @@ RSpec.describe CertificateExpiryReminder, type: :model do
           subject: "Your GOV.UK Verify certificates will expire on #{expected_expiry_date}",
           team: cert.component.team.name,
           no_of_certs: 1,
+          multiple: 'no',
           expire_on: expected_expiry_date,
           certificates: ["Verify Service Provider (staging): encryption certificate - expires on #{cert.x509.not_after}"],
           url: "http://www.test.com"
@@ -146,6 +149,7 @@ RSpec.describe CertificateExpiryReminder, type: :model do
           subject: "Your GOV.UK Verify certificates will expire on #{expected_expiry_date}",
           team: component_vsp.team.name,
           no_of_certs: 4,
+          multiple: 'yes',
           expire_on: expected_expiry_date,
           certificates: [
             "Verify Service Provider (production): signing certificate - expires on #{vsp_cert_two.x509.not_after}",
@@ -175,9 +179,10 @@ RSpec.describe CertificateExpiryReminder, type: :model do
         email_address: email,
         template_id: "bbc34127-7fca-4d78-a95b-703da58e15ce",
         personalisation: {
-          subject: "Urgent: your GOV.UK Verify certificates will expire in #{expires_in_days} days",
+          subject: "Urgent: your GOV.UK Verify certificates will expire on #{expected_expiry_date}",
           team: cert.component.team.name,
           no_of_certs: 1,
+          multiple: 'no',
           expire_on: expected_expiry_date,
           certificates: ["Verify Service Provider (staging): encryption certificate - expires on #{cert.x509.not_after}"],
           url: "http://www.test.com"
@@ -205,6 +210,7 @@ RSpec.describe CertificateExpiryReminder, type: :model do
           subject: "Your GOV.UK Verify certificates will expire on #{expected_expiry_date}",
           team: cert.component.team.name,
           no_of_certs: 1,
+          multiple: 'no',
           expire_on: expected_expiry_date,
           certificates: ["Verify Service Provider (staging): encryption certificate - expires on #{cert.x509.not_after}"],
           url: "http://www.test.com"
@@ -232,6 +238,7 @@ RSpec.describe CertificateExpiryReminder, type: :model do
           subject: "Your GOV.UK Verify certificates will expire on #{expected_expiry_date}",
           team: cert.component.team.name,
           no_of_certs: 1,
+          multiple: 'no',
           expire_on: expected_expiry_date,
           certificates: ["Verify Service Provider (staging): encryption certificate - expires on #{cert.x509.not_after}"],
           url: "http://www.test.com"
@@ -261,6 +268,7 @@ RSpec.describe CertificateExpiryReminder, type: :model do
           subject: "Your GOV.UK Verify certificates will expire on #{expected_expiry_date}",
           team: cert.component.team.name,
           no_of_certs: 1,
+          multiple: 'no',
           expire_on: expected_expiry_date,
           certificates: ["Verify Service Provider (staging): encryption certificate - expires on #{cert.x509.not_after}"],
           url: "http://www.test.com"
@@ -288,6 +296,7 @@ RSpec.describe CertificateExpiryReminder, type: :model do
           subject: "Your GOV.UK Verify certificates will expire on #{expected_expiry_date}",
           team: cert.component.team.name,
           no_of_certs: 1,
+          multiple: 'no',
           expire_on: expected_expiry_date,
           certificates: ["Verify Service Provider (staging): encryption certificate - expires on #{cert.x509.not_after}"],
           url: "http://www.test.com"

--- a/spec/models/certificate_expiry_reminder_spec.rb
+++ b/spec/models/certificate_expiry_reminder_spec.rb
@@ -1,0 +1,248 @@
+require 'rails_helper'
+
+RSpec.describe CertificateExpiryReminder, type: :model do
+  include CognitoSupport
+
+  let(:certificate_expiry_reminder) { subject::Check.new() }
+  let(:email) { 'test@test.com' }
+  let(:cognito_users) {
+    { users: [
+        { username: '0000',
+         attributes: [{name: "given_name", value: "Cherry"},
+                      {name: "family_name", value: "One"},
+                      {name: "email", value: email},
+                      {name: "custom:roles", value: "certmgr"}
+         ]}
+    ]}
+  }
+  let(:many_cognito_users) {
+    { users: [
+        { username: '0000',
+         attributes: [{name: "given_name", value: "Cherry"},
+                      {name: "family_name", value: "One"},
+                      {name: "email", value: email},
+                      {name: "custom:roles", value: "certmgr"}
+        ]},
+        { username: '0001',
+          attributes: [{name: "given_name", value: "Cherry"},
+                       {name: "family_name", value: "Two"},
+                       {name: "email", value: email},
+                       {name: "custom:roles", value: "certmgr"}
+        ]},
+        { username: '0002',
+            attributes: [{name: "given_name", value: "Cherry"},
+                         {name: "family_name", value: "Three"},
+                         {name: "email", value: email},
+                         {name: "custom:roles", value: "certmgr"}
+        ]}
+    ]}
+  }
+  let(:notify_endpoint) { 'https://api.notifications.service.gov.uk/v2/notifications/email' }
+
+  context 'sends reminder emails' do
+    it 'when certificate is expiring in 30 days' do
+      stub_cognito_response(method: :list_users_in_group, payload: cognito_users)
+      stub_request(:post, notify_endpoint).to_return(body: '{}')
+
+      expires_in_days = 30
+      cert = create(:vsp_encryption_certificate, value: PKI.new.generate_encoded_cert(expires_in: expires_in_days.days))
+      certificate_expiry_reminder.run
+
+      expected_expiry_date = (Time.now + expires_in_days.days).strftime("%d %B %Y")
+      expected_call = {
+        email_address: email,
+        template_id: "bbc34127-7fca-4d78-a95b-703da58e15ce",
+        personalisation: {
+          subject: "Your GOV.UK Verify certificates will expire on #{expected_expiry_date}",
+          team: cert.component.team.name,
+          no_of_certs: 1,
+          expire_on: expected_expiry_date,
+          certificates: ["Verify Service Provider (staging): encryption certificate - expires on #{cert.x509.not_after}"],
+          url: "http://www.test.com"
+        }
+      }
+
+      expect(a_request(:post, notify_endpoint).
+        with(body: expected_call.to_json)).
+        to have_been_made.once
+    end
+
+    it 'when certificate is expiring in 7 days' do
+      stub_cognito_response(method: :list_users_in_group, payload: cognito_users)
+      stub_request(:post, notify_endpoint).to_return(body: '{}')
+
+      expires_in_days = 7
+      cert = create(:vsp_encryption_certificate, value: PKI.new.generate_encoded_cert(expires_in: expires_in_days.days))
+      certificate_expiry_reminder.run
+
+      expected_expiry_date = (Time.now + expires_in_days.days).strftime("%d %B %Y")
+      expected_call = {
+        email_address: email,
+        template_id: "bbc34127-7fca-4d78-a95b-703da58e15ce",
+        personalisation: {
+          subject: "Your GOV.UK Verify certificates will expire on #{expected_expiry_date}",
+          team: cert.component.team.name,
+          no_of_certs: 1,
+          expire_on: expected_expiry_date,
+          certificates: ["Verify Service Provider (staging): encryption certificate - expires on #{cert.x509.not_after}"],
+          url: "http://www.test.com"
+        }
+      }
+
+      expect(a_request(:post, notify_endpoint).
+        with(body: expected_call.to_json)).
+        to have_been_made.once
+    end
+
+    it 'when certificate is expiring in 7 days and team have many members' do
+      stub_cognito_response(method: :list_users_in_group, payload: many_cognito_users)
+      stub_request(:post, notify_endpoint).to_return(body: '{}')
+
+      expires_in_days = 7
+      cert = create(:vsp_encryption_certificate, value: PKI.new.generate_encoded_cert(expires_in: expires_in_days.days))
+      certificate_expiry_reminder.run
+
+      expected_expiry_date = (Time.now + expires_in_days.days).strftime("%d %B %Y")
+      expected_call = {
+        email_address: email,
+        template_id: "bbc34127-7fca-4d78-a95b-703da58e15ce",
+        personalisation: {
+          subject: "Your GOV.UK Verify certificates will expire on #{expected_expiry_date}",
+          team: cert.component.team.name,
+          no_of_certs: 1,
+          expire_on: expected_expiry_date,
+          certificates: ["Verify Service Provider (staging): encryption certificate - expires on #{cert.x509.not_after}"],
+          url: "http://www.test.com"
+        }
+      }
+
+      expect(a_request(:post, notify_endpoint).
+        with(body: expected_call.to_json)).
+        to have_been_made.times(3)
+    end
+
+    it 'when certificate is expiring in 7 days and team have many members and many certs' do
+      stub_cognito_response(method: :list_users_in_group, payload: cognito_users)
+      stub_request(:post, notify_endpoint).to_return(body: '{}')
+
+      expires_in_days = 7
+      
+      team = create(:team)
+
+      component_vsp = create(:sp_component, vsp: true, environment: 'production', team_id: team.id)
+      vsp_cert_one = create(:vsp_encryption_certificate, value: PKI.new.generate_encoded_cert(expires_in: expires_in_days.days), component: component_vsp)
+      vsp_cert_two = create(:vsp_signing_certificate, value: PKI.new.generate_encoded_cert(expires_in: expires_in_days.days), component: component_vsp)
+
+      component_msa = create(:msa_component, environment: 'integration', team_id: team.id)
+      msa_cert_one = create(:msa_encryption_certificate, value: PKI.new.generate_encoded_cert(expires_in: expires_in_days.days), component: component_msa)
+      msa_cert_two = create(:msa_signing_certificate, value: PKI.new.generate_encoded_cert(expires_in: expires_in_days.days), component: component_msa)
+      certificate_expiry_reminder.run
+
+      expected_expiry_date = (Time.now + expires_in_days.days).strftime("%d %B %Y")
+      expected_call = {
+        email_address: email,
+        template_id: "bbc34127-7fca-4d78-a95b-703da58e15ce",
+        personalisation: {
+          subject: "Your GOV.UK Verify certificates will expire on #{expected_expiry_date}",
+          team: component_vsp.team.name,
+          no_of_certs: 4,
+          expire_on: expected_expiry_date,
+          certificates: [
+            "Verify Service Provider (production): signing certificate - expires on #{vsp_cert_two.x509.not_after}",
+            "Verify Service Provider (production): encryption certificate - expires on #{vsp_cert_one.x509.not_after}",
+            "Matching Service Adapter (integration): signing certificate - expires on #{msa_cert_two.x509.not_after}",
+            "Matching Service Adapter (integration): encryption certificate - expires on #{msa_cert_one.x509.not_after}"
+          ],
+          url: "http://www.test.com"
+        }
+      }
+
+      expect(a_request(:post, notify_endpoint).
+        with(body: expected_call.to_json)).
+        to have_been_made.once
+    end
+
+    it 'when certificate is expiring in 3 days' do
+      stub_cognito_response(method: :list_users_in_group, payload: cognito_users)
+      stub_request(:post, notify_endpoint).to_return(body: '{}')
+
+      expires_in_days = 3
+      cert = create(:vsp_encryption_certificate, value: PKI.new.generate_encoded_cert(expires_in: expires_in_days.days))
+      certificate_expiry_reminder.run
+
+      expected_expiry_date = (Time.now + expires_in_days.days).strftime("%d %B %Y")
+      expected_call = {
+        email_address: email,
+        template_id: "bbc34127-7fca-4d78-a95b-703da58e15ce",
+        personalisation: {
+          subject: "Urgent: your GOV.UK Verify certificates will expire in #{expires_in_days} days",
+          team: cert.component.team.name,
+          no_of_certs: 1,
+          expire_on: expected_expiry_date,
+          certificates: ["Verify Service Provider (staging): encryption certificate - expires on #{cert.x509.not_after}"],
+          url: "http://www.test.com"
+        }
+      }
+
+      expect(a_request(:post, notify_endpoint).
+        with(body: expected_call.to_json)).
+        to have_been_made.once
+    end
+  end
+
+  context 'does not send reminder emails' do
+    it 'when no certificate is expiring' do
+      stub_cognito_response(method: :list_users_in_group, payload: cognito_users)
+      stub_request(:post, notify_endpoint).to_return(body: '{}')
+
+      expires_in_days = 180
+      cert = create(:vsp_encryption_certificate, value: PKI.new.generate_encoded_cert(expires_in: expires_in_days.days))
+      certificate_expiry_reminder.run
+
+      expected_expiry_date = (Time.now + expires_in_days.days).strftime("%d %B %Y")
+      expected_call = {
+        email_address: email,
+        template_id: "bbc34127-7fca-4d78-a95b-703da58e15ce",
+        personalisation: {
+          subject: "Your GOV.UK Verify certificates will expire on #{expected_expiry_date}",
+          team: cert.component.team.name,
+          no_of_certs: 1,
+          expire_on: expected_expiry_date,
+          certificates: ["Verify Service Provider (staging): encryption certificate - expires on #{cert.x509.not_after}"],
+          url: "http://www.test.com"
+        }
+      }
+
+      expect(a_request(:post, notify_endpoint).
+        with(body: expected_call.to_json)).
+        not_to have_been_made
+    end
+
+    it 'when a certificate is expiring in 22 days' do
+      stub_cognito_response(method: :list_users_in_group, payload: cognito_users)
+      stub_request(:post, notify_endpoint).to_return(body: '{}')
+
+      expires_in_days = 22
+      cert = create(:vsp_encryption_certificate, value: PKI.new.generate_encoded_cert(expires_in: expires_in_days.days))
+      certificate_expiry_reminder.run
+
+      expected_expiry_date = (Time.now + expires_in_days.days).strftime("%d %B %Y")
+      expected_call = {
+        email_address: email,
+        template_id: "bbc34127-7fca-4d78-a95b-703da58e15ce",
+        personalisation: {
+          subject: "Your GOV.UK Verify certificates will expire on #{expected_expiry_date}",
+          team: cert.component.team.name,
+          no_of_certs: 1,
+          expire_on: expected_expiry_date,
+          certificates: ["Verify Service Provider (staging): encryption certificate - expires on #{cert.x509.not_after}"],
+          url: "http://www.test.com"
+        }
+      }
+
+      expect(a_request(:post, notify_endpoint).
+        with(body: expected_call.to_json)).
+        not_to have_been_made
+    end
+  end
+end


### PR DESCRIPTION
When a cert is expiring in 30, 7 or 3 days, an email notification is sent
to the team's members.
The module with the logic is going to be triggered daily using the rake task.