### PR TITLE
aU8jrM6b: Send a notification email when user changes their name 

### DIFF
--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -1,7 +1,10 @@
+require 'notify/notification'
+
 class ProfileController < ApplicationController
   layout "two_thirds_layout", except: :show
   include AuthenticationBackend
   include MfaQrHelper
+  include Notification
 
   def show
     if Rails.env.development?
@@ -95,6 +98,7 @@ class ProfileController < ApplicationController
     if @form.valid?
       update_user_name(access_token: current_user.access_token, given_name: @form.first_name, family_name: @form.last_name)
       UpdateUserNameEvent.create(data: { first_name: @form.first_name, last_name: @form.last_name })
+      send_changed_name_email(email_address: current_user.email, new_name: @form.first_name + ' ' + @form.last_name)
       redirect_to profile_path
     else
       @user = current_user

--- a/lib/notify/notification.rb
+++ b/lib/notify/notification.rb
@@ -3,6 +3,7 @@ require 'notifications/client'
 module Notification
   INVITE_TEMPLATE = "afdb4827-0f71-4588-b35d-80bd514f5bdb".freeze
   REMINDER_TEMPLATE = "bbc34127-7fca-4d78-a95b-703da58e15ce".freeze
+  CHANGED_NAME_TEMPLATE = "c6880583-6f8e-4820-bb2e-98125e355f72".freeze
 
   REMINDER_TEMPLATE_SUBJECT = "your GOV.UK Verify certificates will expire on %s".freeze
 
@@ -38,6 +39,18 @@ module Notification
         expire_on: expiry_date,
         certificates: certificates,
         url: url,
+      },
+     )
+  rescue Notifications::Client::RequestError => e
+    Rails.logger.error(e.to_s)
+  end
+
+  def send_changed_name_email(email_address:, new_name:)
+    mail_client.send_email(
+      email_address: email_address,
+      template_id: CHANGED_NAME_TEMPLATE,
+      personalisation: {
+        new_name: new_name,
       },
      )
   rescue Notifications::Client::RequestError => e

--- a/spec/support/notify_support.rb
+++ b/spec/support/notify_support.rb
@@ -1,0 +1,12 @@
+module NotifySupport
+  NOTIFY_ENDPOINT = "https://api.notifications.service.gov.uk/v2/notifications/email".freeze
+
+  def stub_notify_response
+    stub_request(:post, NOTIFY_ENDPOINT)
+      .to_return(status: 200, body: "{}", headers: {})
+  end
+
+  def stub_notify_request(body)
+    a_request(:post, NOTIFY_ENDPOINT).with(body: body.to_json)
+  end
+end


### PR DESCRIPTION
An email is sent when a user changes their name.

Also, introduced a new helper for Notify to make testing easier.

Review a commit by commit, the second one is just refactoring to use the new helper methods.