### PR TITLE
4Twxnq3H: Send a notification email when user changes their MFA

### DIFF
--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -77,6 +77,7 @@ class ProfileController < ApplicationController
     @form = MfaEnrolmentForm.new(params[:mfa_enrolment_form] || {})
     if @form.valid?
       verify_code_for_mfa(access_token: current_user.access_token, code: @form.totp_code)
+      send_changed_mfa_email(email_address: current_user.email, first_name: current_user.first_name)
       flash[:sucess] = t('profile.mfa_success')
       redirect_to profile_path
     else

--- a/lib/notify/notification.rb
+++ b/lib/notify/notification.rb
@@ -4,6 +4,7 @@ module Notification
   INVITE_TEMPLATE = "afdb4827-0f71-4588-b35d-80bd514f5bdb".freeze
   REMINDER_TEMPLATE = "bbc34127-7fca-4d78-a95b-703da58e15ce".freeze
   CHANGED_NAME_TEMPLATE = "c6880583-6f8e-4820-bb2e-98125e355f72".freeze
+  CHANGED_MFA_TEMPLATE = "029b2f45-72f2-4386-8149-71bf57ba86d1".freeze
 
   REMINDER_TEMPLATE_SUBJECT = "your GOV.UK Verify certificates will expire on %s".freeze
 
@@ -51,6 +52,18 @@ module Notification
       template_id: CHANGED_NAME_TEMPLATE,
       personalisation: {
         new_name: new_name,
+      },
+     )
+  rescue Notifications::Client::RequestError => e
+    Rails.logger.error(e.to_s)
+  end
+
+  def send_changed_mfa_email(email_address:, first_name:)
+    mail_client.send_email(
+      email_address: email_address,
+      template_id: CHANGED_MFA_TEMPLATE,
+      personalisation: {
+        first_name: first_name,
       },
      )
   rescue Notifications::Client::RequestError => e

--- a/spec/controllers/profile_controller_spec.rb
+++ b/spec/controllers/profile_controller_spec.rb
@@ -88,11 +88,20 @@ RSpec.describe ProfileController, type: :controller do
       expect(subject).to render_template(:show_change_mfa)
     end
 
-    it 'redirects to the profile page on success' do
+    it 'redirects to the profile page on success and sends email' do
       usermgr_stub_auth
+      stub_notify_response
+      expected_email_body = {
+        email_address: @user.email,
+        template_id: "029b2f45-72f2-4386-8149-71bf57ba86d1",
+        personalisation: {
+          first_name: @user.first_name,
+        }
+      }
       post :change_mfa, params: { mfa_enrolment_form: { 'totp_code': '123456' } }
       expect(response).to have_http_status(:redirect)
       expect(subject).to redirect_to(profile_path)
+      expect(stub_notify_request(expected_email_body)).to have_been_made.once
     end
 
     it 'renders the page again on code mismatch' do


### PR DESCRIPTION
When user chooses to change their MFA, an email is sent.