### PR TITLE
BUGFIX: Incorrect serialization of user data

### DIFF
--- a/app/models/remote_authenticatable.rb
+++ b/app/models/remote_authenticatable.rb
@@ -75,8 +75,8 @@ module Devise
           resource.access_token = data['access_token']
           resource.roles = data['roles']
           resource.permissions = UserRolePermissions.new(data['roles'], data['email'])
-          resource.last_name = data['given_name']
-          resource.last_name = data['family_name']
+          resource.first_name = data['first_name']
+          resource.last_name = data['last_name']
           resource.session_start_time = data['session_start_time']
           resource.team = data['team']
           resource.cognito_groups = data['cognito_groups']&.split(',')


### PR DESCRIPTION
First name and last name have never been populated from the session correctly!
Always being nil as it was looking at the wrong elements.

This will fix other PRs which rely on first_name:
https://github.com/alphagov/verify-self-service/pull/330
https://github.com/alphagov/verify-self-service/pull/332