### PR TITLE
3pavjdif: BUG duplicate records being submitted

### DIFF
--- a/app/controllers/user_journey_controller.rb
+++ b/app/controllers/user_journey_controller.rb
@@ -75,8 +75,8 @@ class UserJourneyController < ApplicationController
   end
 
   def confirm
-    if @certificate.component.enabled_signing_certificates.length >= 2
-      flash[:error] = 'You have already uploaded two signing certificates'
+    if @certificate.component.enabled_signing_certificates.count >= 2
+      flash[:error] = I18n.t('user_journey.errors.multi_submission')
       redirect_to root_path
     else
       new_certificate_value = params[:certificate][:new_certificate]

--- a/app/models/upload_certificate_event.rb
+++ b/app/models/upload_certificate_event.rb
@@ -11,6 +11,7 @@ class UploadCertificateEvent < AggregatedEvent
   validates :value, presence: true, certificate: true
   validate :certificate_is_new, on: :create
   validate :component_is_persisted
+  validate :upload_max_2_signing_certificates
 
   validates_inclusion_of :usage, in: [CERTIFICATE_USAGE::SIGNING, CERTIFICATE_USAGE::ENCRYPTION]
 
@@ -54,5 +55,12 @@ private
 
   def component_is_persisted
     errors.add(:component, I18n.t('components.errors.must_exist')) unless component&.persisted?
+  end
+
+  def upload_max_2_signing_certificates
+    return if self.usage == CERTIFICATE_USAGE::ENCRYPTION
+    return if component.enabled_signing_certificates.count <= 2
+
+    errors.add(:certificate, I18n.t('certificates.errors.cannot_publish'))
   end
 end

--- a/app/models/upload_certificate_event.rb
+++ b/app/models/upload_certificate_event.rb
@@ -11,7 +11,7 @@ class UploadCertificateEvent < AggregatedEvent
   validates :value, presence: true, certificate: true
   validate :certificate_is_new, on: :create
   validate :component_is_persisted
-  validate :upload_max_2_signing_certificates
+  validate :upload_max_2_signing_certificates, on: :create
 
   validates_inclusion_of :usage, in: [CERTIFICATE_USAGE::SIGNING, CERTIFICATE_USAGE::ENCRYPTION]
 
@@ -59,7 +59,7 @@ private
 
   def upload_max_2_signing_certificates
     return if self.usage == CERTIFICATE_USAGE::ENCRYPTION
-    return if component.enabled_signing_certificates.count <= 2
+    return if component.enabled_signing_certificates.count < 2
 
     errors.add(:certificate, I18n.t('certificates.errors.cannot_publish'))
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -339,6 +339,7 @@ en:
   user_journey:
     errors:
       select_option: Must select an option
+      multi_submission: You have already uploaded two signing certificates
     title: Dashboard
     component_long_name:
       MSA: Matching Service Adapter

--- a/spec/controllers/user_journey_controller_spec.rb
+++ b/spec/controllers/user_journey_controller_spec.rb
@@ -175,6 +175,19 @@ RSpec.describe UserJourneyController, type: :controller do
       expect(subject).to render_template(:check_your_certificate)
     end
 
+    it 'renders index page when more than 2 signing certificates are trying to be submitted' do
+      signing_cert_primary = create(:msa_signing_certificate, component: msa_component)
+      signing_cert_secondary = create(:msa_signing_certificate, component: msa_component)
+      certmgr_stub_auth(team)
+      post :submit,
+          params: params.merge({
+            'upload-certificate': 'string',
+            certificate: { value: signing_cert_secondary.value, component: msa_component }
+          })
+      expect(response).to have_http_status(:success)
+      expect(subject).to render_template(root_path)
+    end
+
     it 'renders upload certificate page when cert file uploaded' do
       certmgr_stub_auth(team)
       post :submit,

--- a/spec/controllers/user_journey_controller_spec.rb
+++ b/spec/controllers/user_journey_controller_spec.rb
@@ -178,6 +178,7 @@ RSpec.describe UserJourneyController, type: :controller do
     it 'renders index page when more than 2 signing certificates are trying to be submitted' do
       signing_cert_primary = create(:msa_signing_certificate, component: msa_component)
       signing_cert_secondary = create(:msa_signing_certificate, component: msa_component)
+      expect(msa_component.enabled_signing_certificates.count).to eq(2)
       certmgr_stub_auth(team)
       post :submit,
           params: params.merge({
@@ -185,6 +186,7 @@ RSpec.describe UserJourneyController, type: :controller do
             certificate: { value: signing_cert_secondary.value, component: msa_component }
           })
       expect(response).to have_http_status(:success)
+      expect(msa_component.enabled_signing_certificates.count).to eq(2)
       expect(subject).to render_template(root_path)
     end
 

--- a/spec/models/upload_certificate_event_spec.rb
+++ b/spec/models/upload_certificate_event_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe UploadCertificateEvent, type: :model do
       it 'component ends up with 2 certs if an UploadCertificatesEvents is invalid' do
         valid_event1 = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: good_cert_value, component: msa_component)
         valid_event2 = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: good_cert_value, component: msa_component)
-        invalid_event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: "", component: msa_component)
+        invalid_event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: good_cert_value, component: msa_component)
         expect(valid_event1).to be_valid
         expect(valid_event2).to be_valid
         expect(invalid_event).to_not be_valid

--- a/spec/system/user_visits_events_page_spec.rb
+++ b/spec/system/user_visits_events_page_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'the events page', type: :system do
 
   it 'is paginated' do
     55.times.each do
-      UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: root.generate_encoded_cert(expires_in: 2.months), component: component)
+      UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::ENCRYPTION, value: root.generate_encoded_cert(expires_in: 2.months), component: component)
     end
 
     visit admin_events_path

--- a/spec/system/user_visits_events_page_spec.rb
+++ b/spec/system/user_visits_events_page_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'the events page', type: :system do
 
     UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: good_cert_1, component: component)
     UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: good_cert_2, component: component)
-    UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: good_cert_3, component: component)
+    UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::ENCRYPTION, value: good_cert_3, component: component)
 
     visit admin_events_path
     expect(page).to have_content good_cert_1

--- a/spec/system/visit_user_journey_check_your_certificate_page_spec.rb
+++ b/spec/system/visit_user_journey_check_your_certificate_page_spec.rb
@@ -127,5 +127,16 @@ RSpec.describe 'Check your certificate page', type: :system do
       click_button 'Use this certificate'
       expect(current_path).to eql confirmation_path(sp_signing_certificate.id)
     end
+
+    it 'renders index page when user tries to submit more than 2 signing certificates' do
+      second_sp_signing_certificate = create(:sp_signing_certificate, component: sp_signing_certificate.component)
+      visit upload_certificate_path(sp_signing_certificate.id)
+      fill_in 'certificate_value', with: sp_signing_certificate.value
+      click_button 'Continue'
+      expect(current_path).to eql check_your_certificate_path(sp_signing_certificate.id)
+      click_button 'Use this certificate'
+      expect(current_path).to eql root_path
+      expect(page).to have_content 'You have already uploaded two signing certificates'
+    end
   end
 end


### PR DESCRIPTION
When the user clicks back in the browser it goes to the form page again where if the user clicks the submit button again, it creates a new record in the database.

Added validation in the controller to stop multiple signing certs being added
Add extra validation on the UploadCertificateEvent itself to reinforce the functionality that a user cannot upload more than two signing certs
Fix broken tests - we are now calling the component on validation so it is required in tests