### PR TITLE
gbOCPRmz: Make usernames/emails case insensitive

### DIFF
--- a/app/models/forgotten_password_form.rb
+++ b/app/models/forgotten_password_form.rb
@@ -6,7 +6,7 @@ class ForgottenPasswordForm
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
 
   def initialize(params = {})
-    @email = params[:email]
+    @email = params[:email]&.downcase
   end
 
   def to_h

--- a/app/models/password_recovery_form.rb
+++ b/app/models/password_recovery_form.rb
@@ -11,7 +11,7 @@ class PasswordRecoveryForm
 
   def initialize(params = {})
     @code = params[:code]
-    @email = params[:email]
+    @email = params[:email]&.downcase
     @password = params[:password]
     @password_confirmation = params[:password_confirmation]
   end

--- a/app/models/sign_in_form.rb
+++ b/app/models/sign_in_form.rb
@@ -7,7 +7,7 @@ class SignInForm
   validates :password, length: { minimum: 8 }
 
   def initialize(params)
-    @email = params[:email]
+    @email = params[:email]&.downcase
     @password = params[:password]
   end
 end

--- a/app/models/update_user_email_form.rb
+++ b/app/models/update_user_email_form.rb
@@ -6,6 +6,6 @@ class UpdateUserEmailForm
   validates :email, email: true
 
   def initialize(params = {})
-    @email = params[:email]
+    @email = params[:email]&.downcase
   end
 end

--- a/lib/auth/authentication_backend.rb
+++ b/lib/auth/authentication_backend.rb
@@ -127,6 +127,7 @@ module AuthenticationBackend
   end
 
   def add_user(email:, given_name:, family_name:, roles:, temporary_password:)
+    email&.downcase!
     client.admin_create_user(
       temporary_password: temporary_password,
       message_action: 'SUPPRESS',
@@ -213,6 +214,7 @@ module AuthenticationBackend
   end
 
   def update_user_email(user_id:, email:)
+    email&.downcase!
     client.admin_update_user_attributes(
       user_pool_id: user_pool_id,
       username: user_id,


### PR DESCRIPTION
Currently, the emails used as usernames are case sensitive. This adds a downcase method on
models when we're handling emails.
I did consider putting to the API calls cognito only, but we often store the email
in the session for further processing (MFA enrolment) which would create
discrepencies.
Open to other suggestions.