### PR TITLE
bau to remove flaky redundant test

### DIFF
--- a/spec/models/component_spec.rb
+++ b/spec/models/component_spec.rb
@@ -379,4 +379,3 @@ RSpec.describe Component, type: :model do
   end
 end
 
-

--- a/spec/models/new_team_event_spec.rb
+++ b/spec/models/new_team_event_spec.rb
@@ -9,12 +9,7 @@ RSpec.describe NewTeamEvent, type: :model do
       team_event = create(:new_team_event, name: 'The O Father')
       expect(team_event).to be_valid
       expect(team_event).to be_persisted
-    end
-
-    it 'has team event' do
-      stub_cognito_response(method: :create_group)
-      team_event = create(:new_team_event, name: 'J Snoop')
-      expect(team_event).to eq NewTeamEvent.last
+      expect(team_event).to eq NewTeamEvent.find_by_id(team_event.id)
     end
   end
 


### PR DESCRIPTION
removed 'has team event' test because it is redundant and implied in valid and persisted test