### PR TITLE
9lg6CX1O: changed structure of hub_enviroments

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -62,6 +62,14 @@ Rails.application.configure do
 
   config.hub_environments_legacy = { 'development': 'development-bucket' }
 
+  config.hub_environments = {
+    'development': {
+      'bucket': 'development-bucket',
+      'hub-config-host': 'http://config-service.dev',
+      'secure-header': 'false'
+    }
+  }
+
   config.cognito_aws_access_key_id = ENV['COGNITO_AWS_ACCESS_KEY_ID']
   config.cognito_aws_secret_access_key = ENV['COGNITO_AWS_SECRET_ACCESS_KEY']
   config.cognito_client_id = ENV['AWS_COGNITO_CLIENT_ID']

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -52,6 +52,13 @@ Rails.application.configure do
     'test': 'test-bucket'
   }
 
+  config.hub_environments = {
+    'production': {'bucket': 'production-bucket', 'hub-config-host': 'http://config-service.production', 'secure-header': 'false'},
+    'integration': {'bucket': 'integration-bucket', 'hub-config-host': 'http://config-service.integration', 'secure-header': 'true'},
+    'staging': {'bucket': 'staging-bucket', 'hub-config-host': 'http://config-service.staging', 'secure-header': 'false'},
+    'test': {'bucket': 'test-bucket', 'hub-config-host': 'http://config-service.test', 'secure-header': 'false'}
+  }
+
   config.cognito_aws_access_key_id = ENV['COGNITO_AWS_ACCESS_KEY_ID']
   config.cognito_aws_secret_access_key = ENV['COGNITO_AWS_SECRET_ACCESS_KEY']
   config.cognito_client_id = ENV['AWS_COGNITO_CLIENT_ID']


### PR DESCRIPTION
So that it can accomodate hub urls(hub-config-host) for different environment
and secure headers for integration

Co-authored-by: Rosa Fox <rosa.fox@digital.cabinet-office.gov.uk>