### PR TITLE
9lg6cx1o using secure header and removing hub_environment_legacy

### DIFF
--- a/app/controllers/msa_components_controller.rb
+++ b/app/controllers/msa_components_controller.rb
@@ -7,13 +7,13 @@ class MsaComponentsController < ApplicationController
 
   def new
     @component = NewMsaComponentEvent.new
-    @hub_environments_legacy = Rails.configuration.hub_environments_legacy.keys
+    @hub_environments = Rails.configuration.hub_environments.keys
     @teams = Team.all
   end
 
   def edit
     @component = MsaComponent.find(params[:id])
-    @hub_environments_legacy = Rails.configuration.hub_environments_legacy.keys
+    @hub_environments = Rails.configuration.hub_environments.keys
     @teams = Team.all
   end
 
@@ -24,7 +24,7 @@ class MsaComponentsController < ApplicationController
 
   def create
     @component = NewMsaComponentEvent.create(component_params)
-    @hub_environments_legacy = Rails.configuration.hub_environments_legacy.keys
+    @hub_environments = Rails.configuration.hub_environments.keys
     if @component.valid?
       redirect_to admin_path
     else
@@ -44,7 +44,7 @@ class MsaComponentsController < ApplicationController
     else
       Rails.logger.info(@event.errors.full_messages)
       @teams = Team.all
-      @hub_environments_legacy = Rails.configuration.hub_environments_legacy.keys
+      @hub_environments = Rails.configuration.hub_environments.keys
 
       render :edit
     end

--- a/app/controllers/sp_components_controller.rb
+++ b/app/controllers/sp_components_controller.rb
@@ -7,7 +7,7 @@ class SpComponentsController < ApplicationController
 
   def new
     @component = NewSpComponentEvent.new
-    @hub_environments_legacy = Rails.configuration.hub_environments_legacy.keys
+    @hub_environments = Rails.configuration.hub_environments.keys
     @teams = Team.all
   end
 
@@ -18,13 +18,13 @@ class SpComponentsController < ApplicationController
 
   def edit
     @component = SpComponent.find(params[:id])
-    @hub_environments_legacy = Rails.configuration.hub_environments_legacy.keys
+    @hub_environments = Rails.configuration.hub_environments.keys
     @teams = Team.all
   end
 
   def create
     @component = NewSpComponentEvent.create(component_params)
-    @hub_environments_legacy = Rails.configuration.hub_environments_legacy.keys
+    @hub_environments = Rails.configuration.hub_environments.keys
     if @component.valid?
       redirect_to admin_path
     else
@@ -44,7 +44,7 @@ class SpComponentsController < ApplicationController
     else
       Rails.logger.info(@event.errors.full_messages)
       @teams = Team.all
-      @hub_environments_legacy = Rails.configuration.hub_environments_legacy.keys
+      @hub_environments = Rails.configuration.hub_environments.keys
 
       render :edit
     end

--- a/app/models/change_component_event.rb
+++ b/app/models/change_component_event.rb
@@ -47,6 +47,6 @@ private
   end
 
   def environment_present_and_valid?(environment)
-    Rails.configuration.hub_environments_legacy.keys.include?(environment)
+    Rails.configuration.hub_environments.keys.include?(environment)
   end
 end

--- a/app/models/concerns/hub_environment_concern.rb
+++ b/app/models/concerns/hub_environment_concern.rb
@@ -1,0 +1,12 @@
+module HubEnvironmentConcern
+  extend ActiveSupport::Concern
+
+  def hub_environment(environment, value)
+    environment = environment.to_sym
+    value = value.to_sym
+    Rails.configuration.hub_environments.fetch(environment)[value]
+  rescue KeyError
+    Rails.logger.error("Failed to find #{value} for #{environment}")
+    "#{environment}-#{value}"
+  end
+end

--- a/app/models/healthcheck/hub_check.rb
+++ b/app/models/healthcheck/hub_check.rb
@@ -7,9 +7,12 @@ module Healthcheck
     end
 
     def status
-      response = HUB_CONFIG_API.healthcheck
+      Rails.configuration.hub_environments.keys.each do |environment|
+        response = HUB_CONFIG_API.healthcheck(environment)
 
-      return OK if response.status == 200
+        return UNAVAILABLE unless response.status == 200
+      end
+      OK
     end
   end
 end

--- a/app/models/healthcheck/storage_check.rb
+++ b/app/models/healthcheck/storage_check.rb
@@ -5,11 +5,11 @@ module Healthcheck
     end
 
     def status
-      Rails.configuration.hub_environments_legacy.values.each do |bucket|
+      Rails.configuration.hub_environments_legacy.values.each do |hub_environment|
         begin
-          unless healthcheck_file_exists?(bucket)
+          unless healthcheck_file_exists?(hub_environment[:bucket])
             SelfService.service(:storage_client).put_object(
-              bucket: bucket,
+              bucket: hub_environment[:bucket],
               key: FILES::HEALTHCHECK,
               body: '',
               server_side_encryption: 'AES256',
@@ -17,7 +17,7 @@ module Healthcheck
             )
           end
         rescue Aws::S3::Errors::ServiceError
-          raise StandardError.new("Error connecting to #{bucket} bucket")
+          raise StandardError.new("Error connecting to #{hub_environment[:bucket]} bucket")
         end
       end
 

--- a/app/models/healthcheck/storage_check.rb
+++ b/app/models/healthcheck/storage_check.rb
@@ -5,7 +5,7 @@ module Healthcheck
     end
 
     def status
-      Rails.configuration.hub_environments_legacy.values.each do |hub_environment|
+      Rails.configuration.hub_environments.values.each do |hub_environment|
         begin
           unless healthcheck_file_exists?(hub_environment[:bucket])
             SelfService.service(:storage_client).put_object(

--- a/app/models/new_msa_component_event.rb
+++ b/app/models/new_msa_component_event.rb
@@ -6,7 +6,7 @@ class NewMsaComponentEvent < AggregatedEvent
   validates_presence_of :name, message: I18n.t('events.errors.missing_name')
   validates_presence_of :team_id, message: I18n.t('components.errors.invalid_team')
   validates_presence_of :environment,
-                        in: Rails.configuration.hub_environments_legacy.keys,
+                        in: Rails.configuration.hub_environments.keys,
                         message: I18n.t('components.errors.invalid_environment')
 
   def build_msa_component

--- a/app/models/new_sp_component_event.rb
+++ b/app/models/new_sp_component_event.rb
@@ -6,7 +6,7 @@ class NewSpComponentEvent < AggregatedEvent
   validates_presence_of :name, message: I18n.t('events.errors.missing_name')
   validates_presence_of :team_id, message: I18n.t('components.errors.invalid_team')
   validates_presence_of :environment,
-                        in: Rails.configuration.hub_environments_legacy.keys,
+                        in: Rails.configuration.hub_environments.keys,
                         message: I18n.t('components.errors.invalid_environment')
   validates_inclusion_of :component_type,
                          in: [COMPONENT_TYPE::SP, COMPONENT_TYPE::VSP],

--- a/app/models/polling/cert_status_updater.rb
+++ b/app/models/polling/cert_status_updater.rb
@@ -1,10 +1,6 @@
 class CertStatusUpdater
-  def initialize(hub_config_api)
-    @hub_config_api = hub_config_api
-  end
-
-  def update_hub_usage_status_for_cert(certificate_to_check)
-    outcomes = entity_ids_for(certificate_to_check).map { |entity_id| cert_is_in_use_for_entity_id?(entity_id, certificate_to_check) }
+  def update_hub_usage_status_for_cert(hub_config_api, certificate_to_check)
+    outcomes = entity_ids_for(certificate_to_check).map { |entity_id| cert_is_in_use_for_entity_id?(hub_config_api, entity_id, certificate_to_check) }
 
     if outcomes.present? && outcomes.all?
       update_cert_status_for(certificate_to_check)
@@ -21,16 +17,16 @@ private
     end
   end
 
-  def cert_is_in_use_for_entity_id?(entity_id, certificate_to_check)
-    certs_in_use = get_certs_from_hub(entity_id, certificate_to_check.encryption?)
+  def cert_is_in_use_for_entity_id?(hub_config_api, entity_id, certificate_to_check)
+    certs_in_use = get_certs_from_hub(hub_config_api, entity_id, certificate_to_check)
     certs_in_use.include?(certificate_to_check.value)
   end
 
-  def get_certs_from_hub(entity_id, is_for_encryption)
-    if is_for_encryption
-      Array.wrap(@hub_config_api.encryption_certificate(entity_id))
+  def get_certs_from_hub(hub_config_api, entity_id, certificate)
+    if certificate.encryption?
+      Array.wrap(hub_config_api.encryption_certificate(certificate.component.environment, entity_id))
     else
-      Array.wrap(@hub_config_api.signing_certificates(entity_id))
+      Array.wrap(hub_config_api.signing_certificates(certificate.component.environment, entity_id))
     end
   end
 

--- a/app/models/publish_services_metadata_event.rb
+++ b/app/models/publish_services_metadata_event.rb
@@ -33,7 +33,7 @@ private
   end
 
   def hub_environment_bucket
-    Rails.configuration.hub_environments_legacy.fetch(environment)
+    Rails.configuration.hub_environments.fetch(environment)[:bucket]
   rescue KeyError
     Rails.logger.error("Failed to find bucket for #{environment}")
     "#{environment}-bucket"

--- a/app/views/admin/_publish.erb
+++ b/app/views/admin/_publish.erb
@@ -1,4 +1,4 @@
-<% Rails.configuration.hub_environments_legacy.keys.each do |environment| %>
+<% Rails.configuration.hub_environments.keys.each do |environment| %>
   <%= link_to "Publish to #{environment}", publish_metadata_path(environment), class: 'govuk-button' %>
 <% end %>
 

--- a/app/views/shared/_component_environments.erb
+++ b/app/views/shared/_component_environments.erb
@@ -1,7 +1,7 @@
 <div class="govuk-form-group <%= 'govuk-form-group--error' if @component.errors.key?(:environment) %>">
   <h3 class="govuk-heading-m"><%= t 'components.environment' %></h3>
   <div class="govuk-radios">
-    <% @hub_environments_legacy.each do |hub_environment| %>
+    <% @hub_environments.each do |hub_environment| %>
       <div class="govuk-radios__item">
         <%= f.radio_button :environment, hub_environment, class: 'govuk-radios__input'  %>
         <%= f.label :environment, hub_environment.capitalize, class: 'govuk-label govuk-radios__label' %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -63,8 +63,8 @@ Rails.application.configure do
   config.hub_environments = {
     'development': {
       'bucket': 'development-bucket',
-      'url': 'http://config-service.dev',
-      'secure_header': 'false'
+      'hub-config-host': 'http://localhost:50240',
+      'secure-header': 'false'
     }
   }
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -63,8 +63,8 @@ Rails.application.configure do
   config.hub_environments = {
     'development': {
       'bucket': 'development-bucket',
-      'hub-config-host': 'http://localhost:50240',
-      'secure-header': 'false'
+      'hub_config_host': 'http://localhost:50240',
+      'secure_header': 'false'
     }
   }
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -86,15 +86,12 @@ Rails.application.configure do
      IntegrityChecker.new
    end
 
-  config.hub_config_host = ENV.fetch('HUB_CONFIG_HOST', 'http://localhost:50240')
-  config.scheduler_polling_interval =  ENV.fetch('SCHEDULER_POLLING_INTERVAL','5s')
-
   config.after_initialize do
     require 'api/hub_config_api'
     HUB_CONFIG_API = HubConfigApi.new
   end
 
+  config.scheduler_polling_interval =  ENV.fetch('SCHEDULER_POLLING_INTERVAL','5s')
   config.notify_key = ENV.fetch('NOTIFY_KEY', 'test-11111111-1111-1111-1111-111111111111-11111111-1111-1111-1111-111111111111')
-
   config.app_url = ENV.fetch('APP_URL', 'localhost:3000')
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -60,13 +60,11 @@ Rails.application.configure do
 
   config.aws_region = ENV['AWS_REGION']
 
-  config.hub_environments_legacy = { 'development': 'development-bucket' }
-
   config.hub_environments = {
     'development': {
       'bucket': 'development-bucket',
-      'hub-config-host': 'http://config-service.dev',
-      'secure-header': 'false'
+      'url': 'http://config-service.dev',
+      'secure_header': 'false'
     }
   }
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -123,7 +123,7 @@ Rails.application.configure do
 
   config.aws_region = ENV.fetch('AWS_REGION')
 
-  config.hub_environments_legacy = JSON.parse(ENV.fetch('HUB_ENVIRONMENTS_LEGACY'))
+  config.hub_environments = JSON.parse(ENV.fetch('HUB_ENVIRONMENTS'))
 
   config.cognito_client_id = ENV.fetch('AWS_COGNITO_CLIENT_ID')
   config.cognito_user_pool_id = ENV.fetch('AWS_COGNITO_USER_POOL_ID')
@@ -145,14 +145,11 @@ Rails.application.configure do
 
     require 'data/integrity_checker'
     IntegrityChecker.new unless ENV['DISABLE_INTEGRITY_CHECKER'].present?
-  end
 
-  config.hub_config_host = ENV.fetch('HUB_CONFIG_HOST')
-
-  config.after_initialize do
     require 'api/hub_config_api'
     HUB_CONFIG_API = HubConfigApi.new
   end
 
   config.scheduler_polling_interval =  ENV.fetch('SCHEDULER_POLLING_INTERVAL','5s')
+  config.authentication_header = ENV.fetch('SELF_SERVICE_AUTHENTICATION_HEADER', nil)
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -46,10 +46,10 @@ Rails.application.configure do
   config.aws_region = ENV['AWS_REGION']
 
   config.hub_environments = {
-    'production': {'bucket': 'production-bucket', 'hub-config-host': 'http://config-service.test', 'secure-header': 'false'},
-    'integration': {'bucket': 'integration-bucket', 'hub-config-host': 'http://config-service.test', 'secure-header': 'true'},
-    'staging': {'bucket': 'staging-bucket', 'hub-config-host': 'http://config-service.test', 'secure-header': 'false'},
-    'test': {'bucket': 'test-bucket', 'hub-config-host': 'http://config-service.test', 'secure-header': 'false'}
+    'production': {'bucket': 'production-bucket', 'hub_config_host': 'http://config-service.test', 'secure_header': 'false'},
+    'integration': {'bucket': 'integration-bucket', 'hub_config_host': 'http://config-service.test', 'secure_header': 'true'},
+    'staging': {'bucket': 'staging-bucket', 'hub_config_host': 'http://config-service.test', 'secure_header': 'false'},
+    'test': {'bucket': 'test-bucket', 'hub_config_host': 'http://config-service.test', 'secure_header': 'false'}
   }
 
   config.cognito_aws_access_key_id = ENV['COGNITO_AWS_ACCESS_KEY_ID']

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,17 +45,10 @@ Rails.application.configure do
 
   config.aws_region = ENV['AWS_REGION']
 
-  config.hub_environments_legacy = {
-    'production': 'production-bucket',
-    'integration': 'integration-bucket',
-    'staging': 'staging-bucket',
-    'test': 'test-bucket'
-  }
-
   config.hub_environments = {
-    'production': {'bucket': 'production-bucket', 'hub-config-host': 'http://config-service.production', 'secure-header': 'false'},
-    'integration': {'bucket': 'integration-bucket', 'hub-config-host': 'http://config-service.integration', 'secure-header': 'true'},
-    'staging': {'bucket': 'staging-bucket', 'hub-config-host': 'http://config-service.staging', 'secure-header': 'false'},
+    'production': {'bucket': 'production-bucket', 'hub-config-host': 'http://config-service.test', 'secure-header': 'false'},
+    'integration': {'bucket': 'integration-bucket', 'hub-config-host': 'http://config-service.test', 'secure-header': 'true'},
+    'staging': {'bucket': 'staging-bucket', 'hub-config-host': 'http://config-service.test', 'secure-header': 'false'},
     'test': {'bucket': 'test-bucket', 'hub-config-host': 'http://config-service.test', 'secure-header': 'false'}
   }
 
@@ -64,13 +57,11 @@ Rails.application.configure do
   config.cognito_client_id = ENV['AWS_COGNITO_CLIENT_ID']
   config.cognito_user_pool_id = ENV['AWS_COGNITO_USER_POOL_ID']
   config.scheduler_polling_interval =  ENV.fetch('SCHEDULER_POLLING_INTERVAL','5s')
+  config.notify_key = 'test-11111111-1111-1111-1111-111111111111-11111111-1111-1111-1111-111111111111'
+  config.app_url = 'www.test.com'
 
   config.after_initialize do
     require 'api/hub_config_api'
-    HUB_CONFIG_API = HubConfigApi.new(environment: :test)
+    HUB_CONFIG_API = HubConfigApi.new
   end
-
-  config.notify_key = 'test-11111111-1111-1111-1111-111111111111-11111111-1111-1111-1111-111111111111'
-
-  config.app_url = 'www.test.com'
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -69,7 +69,7 @@ Rails.application.configure do
 
   config.after_initialize do
     require 'api/hub_config_api'
-    HUB_CONFIG_API = HubConfigApi.new
+    HUB_CONFIG_API = HubConfigApi.new(environment: :test)
   end
 
   config.notify_key = 'test-11111111-1111-1111-1111-111111111111-11111111-1111-1111-1111-111111111111'

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -63,8 +63,6 @@ Rails.application.configure do
   config.cognito_aws_secret_access_key = ENV['COGNITO_AWS_SECRET_ACCESS_KEY']
   config.cognito_client_id = ENV['AWS_COGNITO_CLIENT_ID']
   config.cognito_user_pool_id = ENV['AWS_COGNITO_USER_POOL_ID']
-
-  config.hub_config_host = 'http://config-service.test'
   config.scheduler_polling_interval =  ENV.fetch('SCHEDULER_POLLING_INTERVAL','5s')
 
   config.after_initialize do

--- a/lib/api/hub_config_api.rb
+++ b/lib/api/hub_config_api.rb
@@ -1,20 +1,23 @@
 class HubConfigApi
   require 'cgi'
-
-  HUB_HOST = Rails.configuration.hub_config_host
   HEALTHCHECK_ENDPOINT = 'service-status'.freeze
   CERTIFICATES_ROUTE = '/config/certificates/'.freeze
   CERTIFICATE_ENCRYPTION_ENDPOINT = "%{entity_id}/certs/encryption".freeze
   CERTIFICATES_SIGNING_ENDPOINT = "%{entity_id}/certs/signing".freeze
 
-  def initialize; end
+  def initialize(environment: :test)
+    @environment = environment
+    @header = hub_environment(:'secure-header') == 'true'
+    @hub_host = hub_environment(:'hub-config-host')
+    @service_authentication_header = ENV['SELF_SERVICE_AUTHENTICATION_HEADER']
+  end
 
   def healthcheck
-    Faraday.get healthcheck_path
+    build_request(healthcheck_path)
   end
 
   def encryption_certificate(entity_id)
-    response = Faraday.get encryption_cert_path(entity_id)
+    response = build_request(encryption_cert_path(entity_id))
     if response.status == 200
       JSON.parse(response.body)['certificate']
     else
@@ -24,7 +27,7 @@ class HubConfigApi
   end
 
   def signing_certificates(entity_id)
-    response = Faraday.get signing_certs_path(entity_id)
+    response = build_request(signing_certs_path(entity_id))
     if response.status == 200
       JSON.parse(response.body).map { |c| c['certificate'] }
     else
@@ -35,15 +38,28 @@ class HubConfigApi
 
 private
 
+  def build_request(url)
+    return Faraday.get(url) unless @header
+
+    Faraday.get(url) { |req| req.headers['X-Self-Service-Authentication'] = @service_authentication_header }
+  end
+
   def encryption_cert_path(entity_id)
-    URI.join(HUB_HOST, CERTIFICATES_ROUTE, CERTIFICATE_ENCRYPTION_ENDPOINT % { entity_id: CGI.escape(entity_id) }).to_s
+    URI.join(@hub_host, CERTIFICATES_ROUTE, CERTIFICATE_ENCRYPTION_ENDPOINT % { entity_id: CGI.escape(entity_id) }).to_s
   end
 
   def signing_certs_path(entity_id)
-    URI.join(HUB_HOST, CERTIFICATES_ROUTE, CERTIFICATES_SIGNING_ENDPOINT % { entity_id: CGI.escape(entity_id) }).to_s
+    URI.join(@hub_host, CERTIFICATES_ROUTE, CERTIFICATES_SIGNING_ENDPOINT % { entity_id: CGI.escape(entity_id) }).to_s
   end
 
   def healthcheck_path
-    URI.join(HUB_HOST, HEALTHCHECK_ENDPOINT).to_s
+    URI.join(@hub_host, HEALTHCHECK_ENDPOINT).to_s
+  end
+
+  def hub_environment(value)
+    Rails.configuration.hub_environments.fetch(@environment)[value]
+  rescue KeyError
+    Rails.logger.error("Failed to find #{value} for #{@environment}")
+    "#{environment}-#{value}"
   end
 end

--- a/lib/api/hub_config_api.rb
+++ b/lib/api/hub_config_api.rb
@@ -33,7 +33,7 @@ class HubConfigApi
 private
 
   def use_secure_header(environment)
-    hub_environment(environment, :'secure-header') == 'true'
+    hub_environment(environment, :secure_header) == 'true'
   end
 
   def build_request(environment:, url:)
@@ -43,14 +43,14 @@ private
   end
 
   def encryption_cert_path(environment, entity_id)
-    { environment: environment, url: URI.join(hub_environment(environment, :'hub-config-host'), CERTIFICATES_ROUTE, CERTIFICATE_ENCRYPTION_ENDPOINT % { entity_id: CGI.escape(entity_id) }).to_s }
+    { environment: environment, url: URI.join(hub_environment(environment, :hub_config_host), CERTIFICATES_ROUTE, CERTIFICATE_ENCRYPTION_ENDPOINT % { entity_id: CGI.escape(entity_id) }).to_s }
   end
 
   def signing_certs_path(environment, entity_id)
-    { environment: environment, url: URI.join(hub_environment(environment, :'hub-config-host'), CERTIFICATES_ROUTE, CERTIFICATES_SIGNING_ENDPOINT % { entity_id: CGI.escape(entity_id) }).to_s }
+    { environment: environment, url: URI.join(hub_environment(environment, :hub_config_host), CERTIFICATES_ROUTE, CERTIFICATES_SIGNING_ENDPOINT % { entity_id: CGI.escape(entity_id) }).to_s }
   end
 
   def healthcheck_path(environment)
-    { environment: environment, url: URI.join(hub_environment(environment, :'hub-config-host'), HEALTHCHECK_ENDPOINT).to_s }
+    { environment: environment, url: URI.join(hub_environment(environment, :hub_config_host), HEALTHCHECK_ENDPOINT).to_s }
   end
 end

--- a/lib/api/hub_config_api.rb
+++ b/lib/api/hub_config_api.rb
@@ -33,7 +33,7 @@ class HubConfigApi
 private
 
   def use_secure_header(environment)
-    hub_environment(environment, 'secure-header') == 'true' && environment == 'integration'
+    hub_environment(environment, :'secure-header') == 'true'
   end
 
   def build_request(environment:, url:)
@@ -43,14 +43,14 @@ private
   end
 
   def encryption_cert_path(environment, entity_id)
-    { environment: environment, url: URI.join(hub_environment(environment, 'hub-config-host'), CERTIFICATES_ROUTE, CERTIFICATE_ENCRYPTION_ENDPOINT % { entity_id: CGI.escape(entity_id) }).to_s }
+    { environment: environment, url: URI.join(hub_environment(environment, :'hub-config-host'), CERTIFICATES_ROUTE, CERTIFICATE_ENCRYPTION_ENDPOINT % { entity_id: CGI.escape(entity_id) }).to_s }
   end
 
   def signing_certs_path(environment, entity_id)
-    { environment: environment, url: URI.join(hub_environment(environment, 'hub-config-host'), CERTIFICATES_ROUTE, CERTIFICATES_SIGNING_ENDPOINT % { entity_id: CGI.escape(entity_id) }).to_s }
+    { environment: environment, url: URI.join(hub_environment(environment, :'hub-config-host'), CERTIFICATES_ROUTE, CERTIFICATES_SIGNING_ENDPOINT % { entity_id: CGI.escape(entity_id) }).to_s }
   end
 
   def healthcheck_path(environment)
-    { environment: environment, url: URI.join(hub_environment(environment, 'hub-config-host'), HEALTHCHECK_ENDPOINT).to_s }
+    { environment: environment, url: URI.join(hub_environment(environment, :'hub-config-host'), HEALTHCHECK_ENDPOINT).to_s }
   end
 end

--- a/spec/lib/api/hub_config_api_spec.rb
+++ b/spec/lib/api/hub_config_api_spec.rb
@@ -9,7 +9,7 @@ describe HubConfigApi do
   let(:encryption_certificate) { 'base64-x509-encryption-cert' }
   let(:signing_certificate_one) { 'base64-x509-signing-cert-one' }
   let(:signing_certificate_two) { 'base64-x509-encryption-cert-two' }
-  let(:hub_response_for_encryption) { 
+  let(:hub_response_for_encryption) {
     {
       issuerId: entity_id,
       certificate: encryption_certificate,
@@ -18,7 +18,7 @@ describe HubConfigApi do
     }
   }
 
-  let(:hub_response_for_signing) { 
+  let(:hub_response_for_signing) {
     [
       {
         issuerId: entity_id,
@@ -29,7 +29,7 @@ describe HubConfigApi do
     ]
   }
 
-  let(:hub_response_for_signing_when_dual_running) { 
+  let(:hub_response_for_signing_when_dual_running) {
     [
       {
         issuerId: entity_id,
@@ -79,7 +79,7 @@ describe HubConfigApi do
     it 'should return nil and log error if certificate not found' do
       stub_request(:get, "http://config-service.test:80/config/certificates/#{CGI.escape(wrong_entity_id)}/certs/encryption")
         .to_return(status: 404, body: "{\"code\":404,\"message\":\"'#{wrong_entity_id}' - No data is configured for this entity.\"}")
-      
+
       expect(Rails.logger).to receive(:error).with("Error getting encryption certificate for entity_id: #{wrong_entity_id}! (Code: 404)")
 
       response = hub_config_api.encryption_certificate(wrong_entity_id)
@@ -116,6 +116,48 @@ describe HubConfigApi do
       response = hub_config_api.signing_certificates(wrong_entity_id)
 
       expect(response).to eq([])
+    end
+  end
+
+  describe 'authentication headers required' do
+    let(:authentication_header) { 'a-very-secure-header required here'}
+    before(:each) do
+      Rails.configuration.hub_environments.merge!({'test': {'bucket': 'test-bucket', 'hub-config-host': 'http://config-service.test', 'secure-header': 'true'}})
+      ENV['SELF_SERVICE_AUTHENTICATION_HEADER'] = authentication_header
+    end
+    it 'should return service-status from healtheck' do
+      stub_request(:get, 'http://config-service.test:80/service-status')
+        .with(headers: {'X-Self-Service-Authentication': authentication_header })
+        .to_return(status: 200)
+
+      response = hub_config_api.healthcheck
+
+      expect(response.status).to eq(200)
+    end
+    it 'should return service-status from healtheck' do
+      stub_request(:get, 'http://config-service.test:80/service-status')
+        .to_return(status: 200)
+
+      response = hub_config_api.healthcheck
+      expect(response.status).to eq(200)
+    end
+    it 'should return the encryption certificate' do
+      stub_request(:get, "http://config-service.test:80/config/certificates/#{CGI.escape(entity_id)}/certs/encryption")
+      .with(headers: {'X-Self-Service-Authentication': authentication_header })
+        .to_return(body: hub_response_for_encryption.to_json)
+
+      response = hub_config_api.encryption_certificate(entity_id)
+
+      expect(response).to eq(encryption_certificate)
+    end
+    it 'should return an array of signing certs with two certs when dual-running' do
+      stub_request(:get, "http://config-service.test:80/config/certificates/#{CGI.escape(entity_id)}/certs/signing")
+      .with(headers: {'X-Self-Service-Authentication': authentication_header })
+        .to_return(body: hub_response_for_signing_when_dual_running.to_json)
+
+      response = hub_config_api.signing_certificates(entity_id)
+
+      expect(response).to eq([signing_certificate_one, signing_certificate_two])
     end
   end
 end

--- a/spec/lib/api/hub_config_api_spec.rb
+++ b/spec/lib/api/hub_config_api_spec.rb
@@ -122,7 +122,7 @@ describe HubConfigApi do
   end
 
   describe 'authentication headers used when configured' do
-    let(:authentication_header) { 'a-very-secure-header required here'}
+    let(:authentication_header) { 'a-very-secure_header required here'}
     let(:hub_config_api) { HubConfigApi.new }
     let(:environment) {'integration'}
     before(:each) do

--- a/spec/lib/api/hub_config_api_spec.rb
+++ b/spec/lib/api/hub_config_api_spec.rb
@@ -121,7 +121,7 @@ describe HubConfigApi do
     end
   end
 
-  describe 'authentication headers required in integration' do
+  describe 'authentication headers used when configured' do
     let(:authentication_header) { 'a-very-secure-header required here'}
     let(:hub_config_api) { HubConfigApi.new }
     let(:environment) {'integration'}

--- a/spec/lib/api/hub_config_api_spec.rb
+++ b/spec/lib/api/hub_config_api_spec.rb
@@ -1,9 +1,11 @@
 require 'spec_helper'
 require 'rails_helper'
 require 'cgi'
+require 'api/hub_config_api'
 
 describe HubConfigApi do
   let(:hub_config_api) { HubConfigApi.new }
+  let(:environment) {'test'}
   let(:entity_id) { 'http://www.test-rp.gov.uk/SAML2/MD' }
   let(:wrong_entity_id) { 'wrong-entity-id' }
   let(:encryption_certificate) { 'base64-x509-encryption-cert' }
@@ -51,7 +53,7 @@ describe HubConfigApi do
       stub_request(:get, 'http://config-service.test:80/service-status')
         .to_return(status: 200)
 
-      response = hub_config_api.healthcheck
+      response = hub_config_api.healthcheck(environment)
 
       expect(response.status).to eq(200)
     end
@@ -60,7 +62,7 @@ describe HubConfigApi do
       stub_request(:get, 'http://config-service.test:80/service-status')
         .to_return(status: 502)
 
-      response = hub_config_api.healthcheck
+      response = hub_config_api.healthcheck(environment)
 
       expect(response.status).to eq(502)
     end
@@ -71,7 +73,7 @@ describe HubConfigApi do
       stub_request(:get, "http://config-service.test:80/config/certificates/#{CGI.escape(entity_id)}/certs/encryption")
         .to_return(body: hub_response_for_encryption.to_json)
 
-      response = hub_config_api.encryption_certificate(entity_id)
+      response = hub_config_api.encryption_certificate(environment, entity_id)
 
       expect(response).to eq(encryption_certificate)
     end
@@ -82,7 +84,7 @@ describe HubConfigApi do
 
       expect(Rails.logger).to receive(:error).with("Error getting encryption certificate for entity_id: #{wrong_entity_id}! (Code: 404)")
 
-      response = hub_config_api.encryption_certificate(wrong_entity_id)
+      response = hub_config_api.encryption_certificate(environment, wrong_entity_id)
 
       expect(response).to be nil
     end
@@ -93,7 +95,7 @@ describe HubConfigApi do
       stub_request(:get, "http://config-service.test:80/config/certificates/#{CGI.escape(entity_id)}/certs/signing")
         .to_return(body: hub_response_for_signing.to_json)
 
-      response = hub_config_api.signing_certificates(entity_id)
+      response = hub_config_api.signing_certificates(environment, entity_id)
 
       expect(response).to eq([signing_certificate_one])
     end
@@ -102,7 +104,7 @@ describe HubConfigApi do
       stub_request(:get, "http://config-service.test:80/config/certificates/#{CGI.escape(entity_id)}/certs/signing")
         .to_return(body: hub_response_for_signing_when_dual_running.to_json)
 
-      response = hub_config_api.signing_certificates(entity_id)
+      response = hub_config_api.signing_certificates(environment, entity_id)
 
       expect(response).to eq([signing_certificate_one, signing_certificate_two])
     end
@@ -113,49 +115,43 @@ describe HubConfigApi do
 
       expect(Rails.logger).to receive(:error).with("Error getting signing certificates for entity_id: #{wrong_entity_id}! (Code: 404)")
 
-      response = hub_config_api.signing_certificates(wrong_entity_id)
+      response = hub_config_api.signing_certificates(environment, wrong_entity_id)
 
       expect(response).to eq([])
     end
   end
 
-  describe 'authentication headers required' do
+  describe 'authentication headers required in integration' do
     let(:authentication_header) { 'a-very-secure-header required here'}
+    let(:hub_config_api) { HubConfigApi.new }
+    let(:environment) {'integration'}
     before(:each) do
-      Rails.configuration.hub_environments.merge!({'test': {'bucket': 'test-bucket', 'hub-config-host': 'http://config-service.test', 'secure-header': 'true'}})
-      ENV['SELF_SERVICE_AUTHENTICATION_HEADER'] = authentication_header
+      Rails.configuration.authentication_header = authentication_header
     end
     it 'should return service-status from healtheck' do
       stub_request(:get, 'http://config-service.test:80/service-status')
         .with(headers: {'X-Self-Service-Authentication': authentication_header })
         .to_return(status: 200)
 
-      response = hub_config_api.healthcheck
+      response = hub_config_api.healthcheck(environment)
 
-      expect(response.status).to eq(200)
-    end
-    it 'should return service-status from healtheck' do
-      stub_request(:get, 'http://config-service.test:80/service-status')
-        .to_return(status: 200)
-
-      response = hub_config_api.healthcheck
       expect(response.status).to eq(200)
     end
     it 'should return the encryption certificate' do
       stub_request(:get, "http://config-service.test:80/config/certificates/#{CGI.escape(entity_id)}/certs/encryption")
-      .with(headers: {'X-Self-Service-Authentication': authentication_header })
+        .with(headers: {'X-Self-Service-Authentication': authentication_header })
         .to_return(body: hub_response_for_encryption.to_json)
 
-      response = hub_config_api.encryption_certificate(entity_id)
+      response = hub_config_api.encryption_certificate(environment, entity_id)
 
       expect(response).to eq(encryption_certificate)
     end
     it 'should return an array of signing certs with two certs when dual-running' do
       stub_request(:get, "http://config-service.test:80/config/certificates/#{CGI.escape(entity_id)}/certs/signing")
-      .with(headers: {'X-Self-Service-Authentication': authentication_header })
+        .with(headers: {'X-Self-Service-Authentication': authentication_header })
         .to_return(body: hub_response_for_signing_when_dual_running.to_json)
 
-      response = hub_config_api.signing_certificates(entity_id)
+      response = hub_config_api.signing_certificates(environment, entity_id)
 
       expect(response).to eq([signing_certificate_one, signing_certificate_two])
     end

--- a/spec/models/polling/cert_status_updater_spec.rb
+++ b/spec/models/polling/cert_status_updater_spec.rb
@@ -4,13 +4,13 @@ require 'polling/cert_status_updater'
 RSpec.describe CertStatusUpdater, type: :model do
 
   let(:root) { PKI.new }
-
+  let(:hub_config_api) { HubConfigApi.new }
+  let(:cert_status_updater) { CertStatusUpdater.new }
   let(:msa_enc_cert_1) { create(:msa_encryption_certificate, in_use_at: nil) }
   let(:msa_enc_cert_2) { create(:msa_encryption_certificate, in_use_at: nil) }
   let(:msa_sgn_cert_1) { create(:msa_signing_certificate, in_use_at: nil) }
   let(:msa_sgn_cert_2) { create(:msa_signing_certificate, in_use_at: nil) }
   let(:msa_sgn_cert_3) { create(:msa_signing_certificate, in_use_at: nil) }
-
   let(:service_1) { create(:service, entity_id: 'entity 1') }
   let(:service_2) { create(:service, entity_id: 'entity 2') }
   let(:service_3) { create(:service, entity_id: 'entity 3') }
@@ -27,115 +27,89 @@ RSpec.describe CertStatusUpdater, type: :model do
   describe '#update_hub_usage_status_for_cert' do
     context 'When given an encryption cert belonging to an MSA component' do
       it "leaves the cert unchanged if a call to the Hub does not show it is in use" do
-        hub_config_api = double(:hub_config_api)
         allow(hub_config_api).to receive(:encryption_certificate).and_return(msa_enc_cert_2.value)
 
-        cert_status_updater = CertStatusUpdater.new(hub_config_api)
-
         expect(msa_enc_cert_1.in_use_at).to be(nil)
-        cert_status_updater.update_hub_usage_status_for_cert(msa_enc_cert_1)
+        cert_status_updater.update_hub_usage_status_for_cert(hub_config_api, msa_enc_cert_1)
         expect(msa_enc_cert_1.in_use_at).to be(nil)
       end
 
       it "updates the cert's timestamp if a call to the Hub shows it is in use" do
-        hub_config_api = double(:hub_config_api)
         allow(hub_config_api).to receive(:encryption_certificate).and_return(msa_enc_cert_1.value)
 
-        cert_status_updater = CertStatusUpdater.new(hub_config_api)
-
         expect(msa_enc_cert_1.in_use_at).to be(nil)
-        cert_status_updater.update_hub_usage_status_for_cert(msa_enc_cert_1)
+        cert_status_updater.update_hub_usage_status_for_cert(hub_config_api, msa_enc_cert_1)
         expect(msa_enc_cert_1.in_use_at).not_to be(nil)
       end
     end
 
     context 'When given a signing cert belonging to an MSA component' do
       it "leaves the cert unchanged if a call to the Hub does not show it is in use" do
-        hub_config_api = double(:hub_config_api)
         allow(hub_config_api).to receive(:signing_certificates).and_return([msa_sgn_cert_2.value, msa_sgn_cert_3.value])
 
-        cert_status_updater = CertStatusUpdater.new(hub_config_api)
-
         expect(msa_sgn_cert_1.in_use_at).to be(nil)
-        cert_status_updater.update_hub_usage_status_for_cert(msa_sgn_cert_1)
+        cert_status_updater.update_hub_usage_status_for_cert(hub_config_api, msa_sgn_cert_1)
         expect(msa_sgn_cert_1.in_use_at).to be(nil)
       end
 
       it "updates the cert's timestamp if a call to the Hub shows it is in use" do
-        hub_config_api = double(:hub_config_api)
         allow(hub_config_api).to receive(:signing_certificates).and_return([msa_sgn_cert_1.value, msa_sgn_cert_2.value])
 
-        cert_status_updater = CertStatusUpdater.new(hub_config_api)
-
         expect(msa_sgn_cert_1.in_use_at).to be(nil)
-        cert_status_updater.update_hub_usage_status_for_cert(msa_sgn_cert_1)
+        cert_status_updater.update_hub_usage_status_for_cert(hub_config_api, msa_sgn_cert_1)
         expect(msa_sgn_cert_1.in_use_at).not_to be(nil)
       end
     end
 
     context 'When given an encryption cert belonging to an SP component' do
       it "leaves the cert unchanged if a call to the Hub does not show it is in use for all relevant entity IDs" do
-        hub_config_api = double(:hub_config_api)
-        allow(hub_config_api).to receive(:encryption_certificate).with('entity 1').and_return(sp_enc_cert_for_multiple_entities.value)
-        allow(hub_config_api).to receive(:encryption_certificate).with('entity 2').and_return(sp_enc_cert_for_single_entity.value)
-        allow(hub_config_api).to receive(:encryption_certificate).with('entity 3').and_return(sp_enc_cert_for_multiple_entities.value)
-
-        cert_status_updater = CertStatusUpdater.new(hub_config_api)
+        allow(hub_config_api).to receive(:encryption_certificate).with(sp_enc_cert_for_multiple_entities.component.environment, service_1.entity_id).and_return(sp_enc_cert_for_multiple_entities.value)
+        allow(hub_config_api).to receive(:encryption_certificate).with(sp_enc_cert_for_multiple_entities.component.environment, service_2.entity_id).and_return(sp_enc_cert_for_single_entity.value)
+        allow(hub_config_api).to receive(:encryption_certificate).with(sp_enc_cert_for_multiple_entities.component.environment, service_3.entity_id).and_return(sp_enc_cert_for_multiple_entities.value)
 
         expect(sp_enc_cert_for_multiple_entities.in_use_at).to be(nil)
-        cert_status_updater.update_hub_usage_status_for_cert(sp_enc_cert_for_multiple_entities)
+        cert_status_updater.update_hub_usage_status_for_cert(hub_config_api, sp_enc_cert_for_multiple_entities)
         expect(sp_enc_cert_for_multiple_entities.in_use_at).to be(nil)
       end
 
       it "updates the cert's timestamp if a call to the Hub shows it is in use for all relevant entity IDs" do
-        hub_config_api = double(:hub_config_api)
-        allow(hub_config_api).to receive(:encryption_certificate).with('entity 1').and_return(sp_enc_cert_for_multiple_entities.value)
-        allow(hub_config_api).to receive(:encryption_certificate).with('entity 2').and_return(sp_enc_cert_for_multiple_entities.value)
-        allow(hub_config_api).to receive(:encryption_certificate).with('entity 3').and_return(sp_enc_cert_for_multiple_entities.value)
-
-        cert_status_updater = CertStatusUpdater.new(hub_config_api)
+        allow(hub_config_api).to receive(:encryption_certificate).with(sp_enc_cert_for_multiple_entities.component.environment, service_1.entity_id).and_return(sp_enc_cert_for_multiple_entities.value)
+        allow(hub_config_api).to receive(:encryption_certificate).with(sp_enc_cert_for_multiple_entities.component.environment, service_2.entity_id).and_return(sp_enc_cert_for_multiple_entities.value)
+        allow(hub_config_api).to receive(:encryption_certificate).with(sp_enc_cert_for_multiple_entities.component.environment, service_3.entity_id).and_return(sp_enc_cert_for_multiple_entities.value)
 
         expect(sp_enc_cert_for_multiple_entities.in_use_at).to be(nil)
-        cert_status_updater.update_hub_usage_status_for_cert(sp_enc_cert_for_multiple_entities)
+        cert_status_updater.update_hub_usage_status_for_cert(hub_config_api, sp_enc_cert_for_multiple_entities)
         expect(sp_enc_cert_for_multiple_entities.in_use_at).not_to be(nil)
       end
     end
 
     context 'When given a signing cert belonging to an SP component' do
       it "leaves the cert unchanged if a call to the Hub does not show it is in use for all relevant entity IDs" do
-        hub_config_api = double(:hub_config_api)
-        allow(hub_config_api).to receive(:signing_certificates).with('entity 1').and_return(sp_sgn_cert_for_multiple_entities.value, sp_sgn_cert_other.value)
-        allow(hub_config_api).to receive(:signing_certificates).with('entity 2').and_return(sp_sgn_cert_for_single_entity.value, sp_sgn_cert_other.value)
-        allow(hub_config_api).to receive(:signing_certificates).with('entity 3').and_return(sp_sgn_cert_for_multiple_entities.value)
-
-        cert_status_updater = CertStatusUpdater.new(hub_config_api)
+        allow(hub_config_api).to receive(:signing_certificates).with(sp_sgn_cert_for_multiple_entities.component.environment, service_1.entity_id).and_return(sp_sgn_cert_for_multiple_entities.value, sp_sgn_cert_other.value)
+        allow(hub_config_api).to receive(:signing_certificates).with(sp_sgn_cert_for_multiple_entities.component.environment, service_2.entity_id).and_return(sp_sgn_cert_for_single_entity.value, sp_sgn_cert_other.value)
+        allow(hub_config_api).to receive(:signing_certificates).with(sp_sgn_cert_for_multiple_entities.component.environment, service_3.entity_id).and_return(sp_sgn_cert_for_multiple_entities.value)
 
         expect(sp_sgn_cert_for_multiple_entities.in_use_at).to be(nil)
-        cert_status_updater.update_hub_usage_status_for_cert(sp_sgn_cert_for_multiple_entities)
+        cert_status_updater.update_hub_usage_status_for_cert(hub_config_api, sp_sgn_cert_for_multiple_entities)
         expect(sp_sgn_cert_for_multiple_entities.in_use_at).to be(nil)
       end
 
       it "updates the cert's timestamp if a call to the Hub shows it is in use for all relevant entity IDs" do
-        hub_config_api = double(:hub_config_api)
-        allow(hub_config_api).to receive(:signing_certificates).with('entity 1').and_return(sp_sgn_cert_for_multiple_entities.value, sp_sgn_cert_other.value)
-        allow(hub_config_api).to receive(:signing_certificates).with('entity 2').and_return(sp_sgn_cert_for_multiple_entities.value, sp_sgn_cert_other.value)
-        allow(hub_config_api).to receive(:signing_certificates).with('entity 3').and_return(sp_sgn_cert_for_multiple_entities.value)
-
-        cert_status_updater = CertStatusUpdater.new(hub_config_api)
+        allow(hub_config_api).to receive(:signing_certificates).with(sp_sgn_cert_for_multiple_entities.component.environment, service_1.entity_id).and_return(sp_sgn_cert_for_multiple_entities.value, sp_sgn_cert_other.value)
+        allow(hub_config_api).to receive(:signing_certificates).with(sp_sgn_cert_for_multiple_entities.component.environment, service_2.entity_id).and_return(sp_sgn_cert_for_multiple_entities.value, sp_sgn_cert_other.value)
+        allow(hub_config_api).to receive(:signing_certificates).with(sp_sgn_cert_for_multiple_entities.component.environment, service_3.entity_id).and_return(sp_sgn_cert_for_multiple_entities.value)
 
         expect(sp_sgn_cert_for_multiple_entities.in_use_at).to be(nil)
-        cert_status_updater.update_hub_usage_status_for_cert(sp_sgn_cert_for_multiple_entities)
+        cert_status_updater.update_hub_usage_status_for_cert(hub_config_api, sp_sgn_cert_for_multiple_entities)
         expect(sp_sgn_cert_for_multiple_entities.in_use_at).not_to be(nil)
       end
     end
 
     context 'when given a cert belonging to an SP component with no services' do
       it "performs no action" do
-        hub_config_api = double(:hub_config_api)
-        cert_status_updater = CertStatusUpdater.new(hub_config_api)
 
         expect(sp_enc_cert_without_service.in_use_at).to be(nil)
-        cert_status_updater.update_hub_usage_status_for_cert(sp_enc_cert_without_service)
+        cert_status_updater.update_hub_usage_status_for_cert(hub_config_api, sp_enc_cert_without_service)
         expect(sp_enc_cert_without_service.in_use_at).to be(nil)
       end
     end


### PR DESCRIPTION
This PR uses the new structure of hub_environment that has secure-header for integration.
It also removes hub_environment_legacy