### PR TITLE
WtjPds2P: Send a notification email when admin resets a users password

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -140,6 +140,7 @@ class UsersController < ApplicationController
       @user = as_team_member(cognito_user: get_user(user_id: params[:user_id]))
       admin_reset_user_password(username: @user.email)
       ResetUserPasswordEvent.create(data: { username: @user.email, user_id: params[:user_id], name: @user.full_name })
+      send_admin_changed_user_password_email(email_address: @user.email, first_name: @user.first_name, reset_url: force_user_reset_password_path(email: @user.email, reset_by_admin: true))
     rescue AuthenticationBackend::AuthenticationBackendException
       flash[:errors] = t('users.reset_user_password.errors.generic_error')
     end

--- a/app/views/password/_password_recovery_form.erb
+++ b/app/views/password/_password_recovery_form.erb
@@ -13,6 +13,11 @@
     <% end %>
     <div class="govuk-form-group">
       <%= f.label :code, class: "govuk-label" %>
+      <% if params[:reset_by_admin].present? %>
+        <span id="admin-reset-password-code-hint" class="govuk-hint">
+          <%= t('password.check_inbox_hint') %>
+        </span>
+      <% end %>
       <%= f.text_field :code, class: "govuk-input govuk-input--width-10" %>
     </div>
     <div class="govuk-form-group">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -205,12 +205,13 @@ en:
     reset_password_heading: Set your new password
     password_changed: Password changed successfully
     reset_password_legend: You can reset your password by entering the code you have received via email.
+    admin_reset_password_legend: An admin user has reset your password.
     current_password_lbl: Current password
     new_password_lbl: New password
-    admin_reset_password_legend: An admin user has reset your password. You can change your password by entering the code you have received via email.
     confirm_password_lbl: Confirm new password
     change_password_btn: Change password
     password_recovered: Your password has now been changed. Please login with your new password
+    check_inbox_hint: You should have received this via email - please check your inbox
     errors:
       email_missing: Your e-mail address is missing
       old_password_mismatch: Your old password does not match the one we have on record

--- a/lib/notify/notification.rb
+++ b/lib/notify/notification.rb
@@ -6,6 +6,7 @@ module Notification
   CHANGED_NAME_TEMPLATE = "c6880583-6f8e-4820-bb2e-98125e355f72".freeze
   CHANGED_MFA_TEMPLATE = "029b2f45-72f2-4386-8149-71bf57ba86d1".freeze
   CHANGED_PASSWORD_TEMPLATE = "16557e1a-767f-42d9-a8d6-7f35ca57f0dd".freeze
+  ADMIN_RESET_USER_PASSWORD_TEMPLATE = "335cc196-0260-493a-9fc7-7440a7110e7e".freeze
 
   REMINDER_TEMPLATE_SUBJECT = "your GOV.UK Verify certificates will expire on %s".freeze
 
@@ -77,6 +78,19 @@ module Notification
       template_id: CHANGED_PASSWORD_TEMPLATE,
       personalisation: {
         first_name: first_name,
+      },
+     )
+  rescue Notifications::Client::RequestError => e
+    Rails.logger.error(e.message)
+  end
+
+  def send_admin_changed_user_password_email(email_address:, first_name:, reset_url:)
+    mail_client.send_email(
+      email_address: email_address,
+      template_id: ADMIN_RESET_USER_PASSWORD_TEMPLATE,
+      personalisation: {
+        first_name: first_name,
+        reset_url: "[#{url}#{reset_password_path}](#{reset_url})",
       },
      )
   rescue Notifications::Client::RequestError => e


### PR DESCRIPTION
Send a notification email when user has their password reset by an admin as per https://docs.google.com/document/d/1CYF-K3hKIdrryaTvc52CZtl80kbwAoJnWYoiFxkL9RU/edit#heading=h.lduypbyjzs1t

An email is sent when an admin resets a users password.
Amend an existing test to show the email functionality working.
Change content on the reset password page

The email that is sent to the user:
<img width="1064" alt="Screenshot 2019-12-17 at 14 41 29" src="https://user-images.githubusercontent.com/24409958/71005316-5e492500-20db-11ea-8e43-db7669d116b4.png">

The changed content on reset password page:
<img width="1440" alt="Screenshot 2019-12-16 at 15 10 11" src="https://user-images.githubusercontent.com/24409958/70917962-2e841980-2016-11ea-9a9a-3f7d8adc3fb6.png">
