### PR TITLE
Updated test to account for inclusion of notify

### DIFF
--- a/spec/system/visit_change_password_spec.rb
+++ b/spec/system/visit_change_password_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'ChangePassword', type: :system do
+  include NotifySupport
   before(:each) do
     login_gds_user
   end
@@ -20,7 +21,15 @@ RSpec.describe 'ChangePassword', type: :system do
   end
 
   it 'submits the form correctly without error' do 
-    stub_cognito_response(method: :change_password,payload: {})
+    stub_cognito_response(method: :change_password, payload: {})
+    stub_notify_response
+    expected_body = {
+      email_address: "test.test@digital.cabinet-office.gov.uk",
+      template_id: "16557e1a-767f-42d9-a8d6-7f35ca57f0dd",
+      personalisation: {
+        first_name: "John",
+      }
+    }
     visit profile_change_password_path
     fill_in 'change_password_form[old_password]', with: '12345678'
     fill_in 'change_password_form[password]', with: "87654321"
@@ -28,5 +37,6 @@ RSpec.describe 'ChangePassword', type: :system do
     click_button 'Change password'
     expect(current_path).to eql profile_path
     expect(page).to have_content t('password.password_changed')
+    expect(stub_notify_request(expected_body)).to have_been_made.once
   end
 end


### PR DESCRIPTION
This PR https://github.com/alphagov/verify-self-service/pull/323 broke the pipeline 
<img width="580" alt="Screen Shot 2019-12-16 at 19 10 38" src="https://user-images.githubusercontent.com/41922771/70935312-d0682e00-2037-11ea-8afe-be06892077ae.png">

I've updated the test included in that PR to fix this. 
