### PR TITLE
BAU: Fix failing healthchecks

### DIFF
--- a/app/models/concerns/hub_environment_concern.rb
+++ b/app/models/concerns/hub_environment_concern.rb
@@ -2,8 +2,8 @@ module HubEnvironmentConcern
   extend ActiveSupport::Concern
 
   def hub_environment(environment, value)
-    environment = environment.to_sym
-    value = value.to_sym
+    environment = environment
+    value = value.to_s
     Rails.configuration.hub_environments.fetch(environment)[value]
   rescue KeyError
     Rails.logger.error("Failed to find #{value} for #{environment}")

--- a/app/models/healthcheck/storage_check.rb
+++ b/app/models/healthcheck/storage_check.rb
@@ -7,7 +7,7 @@ module Healthcheck
     def status
       Rails.configuration.hub_environments.values.each do |hub_environment|
         begin
-          unless healthcheck_file_exists?(hub_environment[:bucket])
+          unless healthcheck_file_exists?(hub_environment['bucket'])
             SelfService.service(:storage_client).put_object(
               bucket: hub_environment[:bucket],
               key: FILES::HEALTHCHECK,
@@ -17,7 +17,7 @@ module Healthcheck
             )
           end
         rescue Aws::S3::Errors::ServiceError
-          raise StandardError.new("Error connecting to #{hub_environment[:bucket]} bucket")
+          raise StandardError.new("Error connecting to #{hub_environment['bucket']} bucket")
         end
       end
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -60,13 +60,13 @@ Rails.application.configure do
 
   config.aws_region = ENV['AWS_REGION']
 
-  config.hub_environments = {
-    'development': {
-      'bucket': 'development-bucket',
-      'hub_config_host': 'http://localhost:50240',
-      'secure_header': 'false'
+  config.hub_environments = JSON.parse("{
+    \"development\": {
+      \"bucket\": \"development-bucket\",
+      \"hub_config_host\": \"http://localhost:50240\",
+      \"secure_header\": \"false\"
     }
-  }
+  }")
 
   config.cognito_aws_access_key_id = ENV['COGNITO_AWS_ACCESS_KEY_ID']
   config.cognito_aws_secret_access_key = ENV['COGNITO_AWS_SECRET_ACCESS_KEY']

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,12 +45,14 @@ Rails.application.configure do
 
   config.aws_region = ENV['AWS_REGION']
 
-  config.hub_environments = {
-    'production': {'bucket': 'production-bucket', 'hub_config_host': 'http://config-service.test', 'secure_header': 'false'},
-    'integration': {'bucket': 'integration-bucket', 'hub_config_host': 'http://config-service.test', 'secure_header': 'true'},
-    'staging': {'bucket': 'staging-bucket', 'hub_config_host': 'http://config-service.test', 'secure_header': 'false'},
-    'test': {'bucket': 'test-bucket', 'hub_config_host': 'http://config-service.test', 'secure_header': 'false'}
-  }
+  config.hub_environments = JSON.parse("{
+    \"production\": {\"bucket\": \"production-bucket\", \"hub_config_host\": \"http://config-service.test\", \"secure_header\": \"false\"},
+    \"integration\": {\"bucket\": \"integration-bucket\", \"hub_config_host\": \"http://config-service.test\", \"secure_header\": \"true\"},
+    \"staging\": {\"bucket\": \"staging-bucket\", \"hub_config_host\": \"http://config-service.test\", \"secure_header\": \"false\"},
+    \"test\": {\"bucket\": \"test-bucket\", \"hub_config_host\": \"http://config-service.test\", \"secure_header\": \"false\"}
+  }")
+
+  config.authentication_header = 'secure-header-value'
 
   config.cognito_aws_access_key_id = ENV['COGNITO_AWS_ACCESS_KEY_ID']
   config.cognito_aws_secret_access_key = ENV['COGNITO_AWS_SECRET_ACCESS_KEY']


### PR DESCRIPTION
We can't currently deploy as the healthchecks are failing. This is due to a change in data
structure of the hub_environments. This aligns the dev, test and production
format to be the same to avoid this in future.

We were also missing the authentication_header config on test.rb