### PR TITLE
BAU: Change the way we build URLs

### DIFF
--- a/app/models/healthcheck/hub_check.rb
+++ b/app/models/healthcheck/hub_check.rb
@@ -10,7 +10,10 @@ module Healthcheck
       Rails.configuration.hub_environments.keys.each do |environment|
         response = HUB_CONFIG_API.healthcheck(environment)
 
-        return UNAVAILABLE unless response.status == 200
+        unless response.success?
+          Rails.logger.error("Error connecting to #{environment} (#{response.env.url}) - status: #{response.status}, body: #{response.body}")
+          return UNAVAILABLE
+        end
       end
       OK
     end

--- a/lib/api/hub_config_api.rb
+++ b/lib/api/hub_config_api.rb
@@ -1,7 +1,7 @@
 class HubConfigApi
   include HubEnvironmentConcern
   require 'cgi'
-  HEALTHCHECK_ENDPOINT = 'service-status'.freeze
+  HEALTHCHECK_ENDPOINT = '/service-status'.freeze
   CERTIFICATES_ROUTE = '/config/certificates/'.freeze
   CERTIFICATE_ENCRYPTION_ENDPOINT = "%{entity_id}/certs/encryption".freeze
   CERTIFICATES_SIGNING_ENDPOINT = "%{entity_id}/certs/signing".freeze
@@ -12,7 +12,7 @@ class HubConfigApi
 
   def encryption_certificate(environment, entity_id)
     response = build_request(**encryption_cert_path(environment, entity_id))
-    if response.status == 200
+    if response.success?
       JSON.parse(response.body)['certificate']
     else
       Rails.logger.error("Error getting encryption certificate for entity_id: #{entity_id}! (Code: #{response.status})")
@@ -22,7 +22,7 @@ class HubConfigApi
 
   def signing_certificates(environment, entity_id)
     response = build_request(**signing_certs_path(environment, entity_id))
-    if response.status == 200
+    if response.success?
       JSON.parse(response.body).map { |c| c['certificate'] }
     else
       Rails.logger.error("Error getting signing certificates for entity_id: #{entity_id}! (Code: #{response.status})")
@@ -43,14 +43,14 @@ private
   end
 
   def encryption_cert_path(environment, entity_id)
-    { environment: environment, url: URI.join(hub_environment(environment, :hub_config_host), CERTIFICATES_ROUTE, CERTIFICATE_ENCRYPTION_ENDPOINT % { entity_id: CGI.escape(entity_id) }).to_s }
+    { environment: environment, url: [hub_environment(environment, :hub_config_host), CERTIFICATES_ROUTE, CERTIFICATE_ENCRYPTION_ENDPOINT % { entity_id: CGI.escape(entity_id) }].join }
   end
 
   def signing_certs_path(environment, entity_id)
-    { environment: environment, url: URI.join(hub_environment(environment, :hub_config_host), CERTIFICATES_ROUTE, CERTIFICATES_SIGNING_ENDPOINT % { entity_id: CGI.escape(entity_id) }).to_s }
+    { environment: environment, url: [hub_environment(environment, :hub_config_host), CERTIFICATES_ROUTE, CERTIFICATES_SIGNING_ENDPOINT % { entity_id: CGI.escape(entity_id) }].join }
   end
 
   def healthcheck_path(environment)
-    { environment: environment, url: URI.join(hub_environment(environment, :hub_config_host), HEALTHCHECK_ENDPOINT).to_s }
+    { environment: environment, url: [hub_environment(environment, :hub_config_host), HEALTHCHECK_ENDPOINT].join }
   end
 end


### PR DESCRIPTION
The URI.join method works differently than I assumed. The integration hub URL
is not a root so `URI.join('http://www.test.com/abc/def', '/service-status')`
becomes `http://www.test.com/service-status` which is incorrect. By switching to standard join should resolve it.

Also refactored the hub healthcheck to provide more useful information when it fails. And started using the the `success?` method from Faraday.