### PR TITLE
mb664GkE+GmBNuF4o: Fix expiring certs labels

### DIFF
--- a/app/assets/stylesheets/_components.scss
+++ b/app/assets/stylesheets/_components.scss
@@ -5,6 +5,12 @@
 .app-certificate-tag-expiring .govuk-tag {
   background-color: $warning-colour;
 }
+
+.app-certificate-tag-expired .govuk-tag {
+  color: govuk-colour("white");
+  background-color: govuk-colour("black");
+}
+
 .app-certificate-tag-deploying .govuk-tag {
   border: 2px solid govuk-colour("dark-grey");
   background-color: govuk-colour("white");

--- a/app/helpers/user_journey_helper.rb
+++ b/app/helpers/user_journey_helper.rb
@@ -18,12 +18,32 @@ module UserJourneyHelper
   def certificate_status(certificate)
     if certificate.nil?
       "MISSING"
+    elsif certificate.expired?
+      "EXPIRED"
     elsif certificate.expires_soon?
-      "EXPIRES IN #{certificate.days_left} DAYS"
+      expiry_label(certificate)
     elsif certificate.deploying?
       "DEPLOYING"
     else
       "IN USE"
+    end
+  end
+
+  def certificate_status_tag_class(certificate)
+    return 'app-certificate-tag-deploying' if certificate.deploying?
+    return 'app-certificate-tag-expired' if certificate.expired?
+    return 'app-certificate-tag-expiring' if certificate.expires_soon?
+  end
+
+  def expiry_label(certificate)
+    if certificate.days_left > 1
+      "EXPIRES IN #{certificate.days_left.to_i} DAYS"
+    elsif certificate.days_left == 1 && certificate.hours_left > 23
+      "EXPIRES IN #{certificate.days_left.to_i} DAY"
+    elsif certificate.hours_left > 1 && certificate.minutes_left > 59
+      "EXPIRES IN #{certificate.hours_left} HOURS"
+    else
+      "EXPIRES IN #{certificate.minutes_left} MINUTES"
     end
   end
 

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -32,6 +32,14 @@ class Certificate < Aggregate
     (x509.not_after.to_date - Time.now.to_date).to_i
   end
 
+  def hours_left
+    ((x509.not_after.to_time - Time.now) / (60 * 60)).to_i
+  end
+
+  def minutes_left
+    ((x509.not_after.to_time - Time.now) / 60).to_i
+  end
+
   def expired?
     x509.not_after < Time.now
   end

--- a/app/views/shared/_user_component_certificates.html.erb
+++ b/app/views/shared/_user_component_certificates.html.erb
@@ -27,7 +27,7 @@
                     <% end %>
                   </td>
                   <td class="govuk-table__cell">
-                    <div class="app-certificate-tag <%= 'app-certificate-tag-deploying' if cert.deploying? %> <%= 'app-certificate-tag-expiring' if cert.expires_soon? %>">
+                    <div class="app-certificate-tag <%= certificate_status_tag_class(cert) %>">
                       <strong class="govuk-tag"><%= certificate_status(cert) %></strong>
                     </div>
                   </td>
@@ -37,7 +37,7 @@
               <tr class="govuk-table__row" id="<%= cert.id %>">
                 <td class="govuk-table__cell"><%= link_to t('user_journey.encryption_certificate'), view_certificate_path(cert.id) %></td>
                 <td class="govuk-table__cell">
-                  <div class="app-certificate-tag <%= 'app-certificate-tag-expiring' if cert.expires_soon? %> <%= 'app-certificate-tag-deploying' if cert.deploying? %>">
+                  <div class="app-certificate-tag <%= certificate_status_tag_class(cert) %>">
                     <strong class="govuk-tag"><%= certificate_status(cert) %></strong>
                   </div>
                 </td>

--- a/spec/system/visit_index_page_spec.rb
+++ b/spec/system/visit_index_page_spec.rb
@@ -93,6 +93,27 @@ RSpec.describe 'IndexPage', type: :system do
     expect(table_row_content).to have_content 'EXPIRES IN 29 DAYS'
   end
 
+  it 'shows certificate expiry tag in hours if certificate expires under 1 day' do
+    expiring_certificate = create(:msa_signing_certificate, value: PKI.new.generate_encoded_cert(expires_in: 22.hours))
+    visit root_path
+    table_row_content = page.find("##{expiring_certificate.id}")
+    expect(table_row_content).to have_content 'EXPIRES IN 21 HOURS'
+  end
+
+  it 'shows certificate expiry tag in minutes if certificate expires under 1 hour' do
+    expiring_certificate = create(:msa_signing_certificate, value: PKI.new.generate_encoded_cert(expires_in: 55.minutes))
+    visit root_path
+    table_row_content = page.find("##{expiring_certificate.id}")
+    expect(table_row_content).to have_content 'EXPIRES IN 54 MINUTES'
+  end
+
+  it 'shows certificate expiry tag as expired if certificate expired' do
+    expiring_certificate = create(:msa_signing_certificate, value: PKI.new.generate_encoded_cert(expires_in: -30.minutes))
+    visit root_path
+    table_row_content = page.find("##{expiring_certificate.id}")
+    expect(table_row_content).to have_content 'EXPIRED'
+  end
+
   it 'shows deploying tag if certificate is being deployed' do
     cert_id = msa_signing_certificate.id
     visit root_path


### PR DESCRIPTION
When certs were expiring the tags were not correct, as there was a rounding going on
so certs expiring in 11 hours showed as "EXPIRES IN 1 DAYS" and under 11 hours
showed as "EXPIRES IN 0 DAYS".
Similar with expired certs which showed "EXPIRES IN -2 DAYS" if expired 2 days ago.

This PR adds more granular metrics for hours and minutes and pluralize accordingly.

Also extracted the logic for selecting the right class for the label to the helper.

**Before:**
<img width="743" alt="image" src="https://user-images.githubusercontent.com/30629434/71195746-7ad59080-2286-11ea-9296-e4e8e04310f7.png">

**After:**
<img width="738" alt="image" src="https://user-images.githubusercontent.com/30629434/71195759-7f9a4480-2286-11ea-8eb0-07dd7168fb01.png">
