### PR TITLE
RK8WfX73: Fix the logic for finding expiring certs 

### DIFF
--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -99,6 +99,10 @@ class Component < Aggregate
     I18n.t("user_journey.component_long_name.#{type}")
   end
 
+  def active_cert?(certificate)
+    current_certificates.include?(certificate)
+  end
+
 private
 
   def unexpired_encryption_certificate

--- a/spec/system/visit_invite_user_spec.rb
+++ b/spec/system/visit_invite_user_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'InviteToTeam', type: :system do
+  include NotifySupport
   before(:each) do
     login_gds_user
   end
@@ -12,6 +13,7 @@ RSpec.describe 'InviteToTeam', type: :system do
 
   it 'submits the form correctly without error' do
     stub_cognito_response(method: :admin_create_user, payload: { user: { username:'test@test.test' } })
+    stub_notify_response
     visit invite_to_team_path(Team.first.id)
     fill_in 'invite_user_form_email', with: 'test@test.com'
     fill_in 'invite_user_form_first_name', with: "test"

--- a/spec/system/visit_mfa_preferences_spec.rb
+++ b/spec/system/visit_mfa_preferences_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'MFA Preferences page', type: :system do
+  include NotifySupport
   before(:each) do
     login_user
   end
@@ -21,6 +22,7 @@ RSpec.describe 'MFA Preferences page', type: :system do
       secret_code = 'OC7YQ4VYEVRWQGIKSXV25B3MZUV355I5XUKKM4P7KGTO72OTXXUQ'
       stub_cognito_response(method: :associate_software_token, payload: { secret_code: secret_code })
       stub_cognito_response(method: :verify_software_token, payload: { status: "SUCCESS" })
+      stub_notify_response
       visit profile_update_mfa_get_code_path
       expect(current_path).to eql profile_update_mfa_get_code_path
       expect(page).to have_content secret_code

--- a/spec/system/visit_profile_update_user_name_spec.rb
+++ b/spec/system/visit_profile_update_user_name_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Update user name page', type: :system do
+  include NotifySupport
   before(:each) do
     login_user
     stub_cognito_response(method: :update_user_attributes, payload: {})  
@@ -14,6 +15,7 @@ RSpec.describe 'Update user name page', type: :system do
     end
 
     it 'successfully changes user name' do
+      stub_notify_response
       visit update_user_name_path
       fill_in 'update_user_name_form[first_name]', with: 'Joe'
       fill_in 'update_user_name_form[last_name]', with: 'Bloggs' 


### PR DESCRIPTION
The current logic for finding expiring certs is flawed. It works under the assumption
that certs are in use when their 'enabled' attribute is set to true.
It's the case for signing certs. However, encryption certs are behaving differently.
Encryption certs are replaced since there is one-to-one relationship
from a component perspective.

This change adds a new method on the component to check whether a given cert
is active/used by the component. This method is then used to find the certs which
are expiring and teams should be notified about.
I admit this is not the most performant solution, but should not present any
challenges for a long time. The alternative approach would be to start changing the
'enabled' attribute on the encryption certs, which adds quite a lot of complexity.

Also, in the second commit adding Notify stubs to stop real calls during testing. 