### PR TITLE
69ughKnj: Out-of-hours notification

### DIFF
--- a/app/models/publish_services_metadata_event.rb
+++ b/app/models/publish_services_metadata_event.rb
@@ -1,8 +1,10 @@
 require 'yaml'
 require 'digest/md5'
+require 'notify/notification'
 
 class PublishServicesMetadataEvent < Event
   include HubEnvironmentConcern
+  include Notification
   attr_reader :metadata
   data_attributes :event_id, :services_metadata, :environment
   validates_presence_of :event_id
@@ -22,6 +24,7 @@ class PublishServicesMetadataEvent < Event
       server_side_encryption: 'AES256',
       acl: 'bucket-owner-full-control',
     )
+    out_of_hours_notification if environment == 'production'
   rescue Aws::S3::Errors::ServiceError
     Rails.logger.error("Failed to publish config metadata for event #{event_id}")
     raise ActiveRecord::Rollback
@@ -31,5 +34,18 @@ private
 
   def services_metadata
     Component.to_service_metadata(event_id, environment)
+  end
+
+  def out_of_hours_notification
+    if out_of_hours?
+      event = Event.find_by_id(event_id)
+      team = Team.find_by_id(current_user.team)
+      send_out_of_hours_rotation_email(event_type: event.type, user: current_user, team: team)
+    end
+  end
+
+  def out_of_hours?
+    Time.zone = 'London'
+    Time.zone.now.on_weekend? || !Time.zone.now.hour.between?(8, 17)
   end
 end

--- a/lib/notify/notification.rb
+++ b/lib/notify/notification.rb
@@ -7,6 +7,7 @@ module Notification
   CHANGED_MFA_TEMPLATE = "029b2f45-72f2-4386-8149-71bf57ba86d1".freeze
   CHANGED_PASSWORD_TEMPLATE = "16557e1a-767f-42d9-a8d6-7f35ca57f0dd".freeze
   ADMIN_RESET_USER_PASSWORD_TEMPLATE = "335cc196-0260-493a-9fc7-7440a7110e7e".freeze
+  OUT_OF_HOURS_ROTATION_TEMPLATE = "0cab7f14-c616-4541-8a73-55bf26b93479".freeze
 
   REMINDER_TEMPLATE_SUBJECT = "your GOV.UK Verify certificates will expire on %s".freeze
 
@@ -91,6 +92,21 @@ module Notification
       personalisation: {
         first_name: first_name,
         reset_url: "[#{url}#{reset_password_path}](#{reset_url})",
+      },
+     )
+  rescue Notifications::Client::RequestError => e
+    Rails.logger.error(e.message)
+  end
+
+  def send_out_of_hours_rotation_email(event_type:, user:, team:)
+    mail_client.send_email(
+      email_address: 'idasupport@digital.cabinet-office.gov.uk',
+      template_id: OUT_OF_HOURS_ROTATION_TEMPLATE,
+      personalisation: {
+        event_type: event_type,
+        user_name: user.full_name,
+        user_email: user.email,
+        user_team: team.name,
       },
      )
   rescue Notifications::Client::RequestError => e


### PR DESCRIPTION
As part of our protection, we want to be notified of any out-of-hours activity which
could introduce a change to the production environment.
This change adds an additional logic to the production publish event which checks whether
it's out-of-hours (6PM-8AM and weekends) and sends an email if it is.

Email template:
<img width="721" alt="image" src="https://user-images.githubusercontent.com/30629434/71359665-2cc1d500-2585-11ea-97c6-fd89c640128a.png">
