### PR TITLE
bau: refactor confirmation logic

### DIFF
--- a/app/controllers/user_journey_controller.rb
+++ b/app/controllers/user_journey_controller.rb
@@ -75,45 +75,44 @@ class UserJourneyController < ApplicationController
   end
 
   def confirm
-    if @certificate.component.enabled_signing_certificates.count >= 2
+    if @certificate.signing? && @certificate.component.enabled_signing_certificates.count >= 2
       flash[:error] = I18n.t('user_journey.errors.multi_submission')
       redirect_to root_path
+    elsif upload.invalid?
+      Rails.logger.info(upload.errors.full_messages.join(', '))
+      render :upload_certificate
+    elsif upload.certificate.signing? && uploaded_certificate_published?
+      render :confirmation
+    elsif upload.certificate.encryption? && uploaded_certificate_published?
+      render_replaced_encryption_certificate_confirmation
     else
-      new_certificate_value = params[:certificate][:new_certificate]
-      @upload = UploadCertificateEvent.create(
-        usage: @certificate.usage,
-        value: new_certificate_value,
-        component_id: @certificate.component_id,
-        component_type: @certificate.component_type,
-      )
-
-      if @upload.valid?
-        component = klass_component(@upload.component_type).find_by_id(@upload.component_id)
-        if @upload.certificate.encryption?
-          replace = ReplaceEncryptionCertificateEvent.create(
-            component: component,
-            encryption_certificate_id: @upload.certificate.id,
-          )
-          replaced_certicate_published = check_metadata_published_user_journey(replace.id)
-        end
-
-        certicate_published = check_metadata_published_user_journey(@upload.id)
-
-        if certicate_published && replaced_certicate_published
-          render :confirmation
-        elsif @upload.certificate.signing? && certicate_published
-          render :confirmation
-        else
-          render :publish_failed
-        end
-      else
-        Rails.logger.info(@upload.errors.full_messages.join(', '))
-        render :upload_certificate
-      end
+      render :publish_failed
     end
   end
 
 private
+
+  def uploaded_certificate_published?
+    @uploaded_certificate_published ||= check_metadata_published_user_journey(upload.id)
+  end
+
+  def render_replaced_encryption_certificate_confirmation
+    component = klass_component(upload.component_type).find_by_id(upload.component_id)
+    replace = ReplaceEncryptionCertificateEvent.create(
+      component: component,
+      encryption_certificate_id: upload.certificate.id,
+    )
+    render :confirmation if check_metadata_published_user_journey(replace.id)
+  end
+
+  def upload
+    @upload ||= UploadCertificateEvent.create(
+      usage: @certificate.usage,
+      value: params[:certificate][:new_certificate],
+      component_id: @certificate.component_id,
+      component_type: @certificate.component_type,
+    )
+  end
 
   def find_certificate
     @certificate = Certificate.find_by_id(params[:certificate_id])


### PR DESCRIPTION
user journey confirmation logic is a little difficult to follow
this is an attempt to make easier to follow the logic by

- redirecting when more than 2 signing certificates
- render upload errors if there are any?
- render confirmation for published encryption certificate
- render confirmation for published signed certificate
- else render failed publish template