### PR TITLE
9lg6cx1o initiate polling when a cert is added

### DIFF
--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -26,6 +26,12 @@ class Component < Aggregate
 
   scope :for_user, ->(user) { where(team_id: user.team) }
 
+  def self.all_pollable_certificates(environment)
+    msa_certificates = MsaComponent.all_components_for_metadata(environment).map(&:unexpired_certificates_not_in_use)
+    sp_certificates =  SpComponent.all_components_for_metadata(environment).where.not(services: { id: nil }).map(&:unexpired_certificates_not_in_use)
+    msa_certificates.concat(sp_certificates).flatten
+  end
+
   def self.to_service_metadata(event_id, environment, published_at = Time.now)
     service_providers = SpComponent.all_components_for_metadata(environment)
     {
@@ -59,14 +65,16 @@ class Component < Aggregate
     certs
   end
 
+  def unexpired_certificates_not_in_use
+    current_certificates.reject { |c| c.expired? || c.in_use_at.present? }
+  end
+
   def days_left
     sorted_certificates&.first&.days_left || NON_SORTING_SEED
   end
 
   def sorted_certificates
-    current_certificates.sort_by do |c|
-      c.expires_soon? ? c.days_left : NON_SORTING_SEED
-    end
+    current_certificates.sort_by { |c| c.expires_soon? ? c.days_left : NON_SORTING_SEED }
   end
 
   def previous_encryption_certificates

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -28,8 +28,8 @@ class Component < Aggregate
 
   def self.all_pollable_certificates(environment)
     msa_certificates = MsaComponent.all_components_for_metadata(environment).map(&:unexpired_certificates_not_in_use)
-    sp_certificates =  SpComponent.all_components_for_metadata(environment).where.not(services: { id: nil }).map(&:unexpired_certificates_not_in_use)
-    msa_certificates.concat(sp_certificates).flatten
+    sp_certificates = SpComponent.all_components_for_metadata(environment).where.not(services: { id: nil }).map(&:unexpired_certificates_not_in_use)
+    (msa_certificates + sp_certificates).flatten
   end
 
   def self.to_service_metadata(event_id, environment, published_at = Time.now)

--- a/app/models/concerns/hub_environment_concern.rb
+++ b/app/models/concerns/hub_environment_concern.rb
@@ -1,6 +1,11 @@
 module HubEnvironmentConcern
   extend ActiveSupport::Concern
 
+  HEALTHCHECK_ENDPOINT = '/service-status'.freeze
+  CERTIFICATES_ROUTE = '/config/certificates/'.freeze
+  CERTIFICATE_ENCRYPTION_ENDPOINT = "%{entity_id}/certs/encryption".freeze
+  CERTIFICATES_SIGNING_ENDPOINT = "%{entity_id}/certs/signing".freeze
+
   def hub_environment(environment, value)
     environment = environment
     value = value.to_s
@@ -8,5 +13,21 @@ module HubEnvironmentConcern
   rescue KeyError
     Rails.logger.error("Failed to find #{value} for #{environment}")
     "#{environment}-#{value}"
+  end
+
+  def encryption_cert_path(environment, entity_id)
+    { environment: environment, url: [hub_environment(environment, :hub_config_host), CERTIFICATES_ROUTE, CERTIFICATE_ENCRYPTION_ENDPOINT % { entity_id: CGI.escape(entity_id) }].join }
+  end
+
+  def signing_certs_path(environment, entity_id)
+    { environment: environment, url: [hub_environment(environment, :hub_config_host), CERTIFICATES_ROUTE, CERTIFICATES_SIGNING_ENDPOINT % { entity_id: CGI.escape(entity_id) }].join }
+  end
+
+  def healthcheck_path(environment)
+    { environment: environment, url: [hub_environment(environment, :hub_config_host), HEALTHCHECK_ENDPOINT].join }
+  end
+
+  def use_secure_header(environment)
+    hub_environment(environment, :secure_header) == 'true'
   end
 end

--- a/app/models/polling/dev_cert_status_updater.rb
+++ b/app/models/polling/dev_cert_status_updater.rb
@@ -1,0 +1,5 @@
+class DevCertStatusUpdater
+  def update_hub_usage_status_for_cert(_hub_config_api, certificate)
+    CertificateInUseEvent.create(certificate: certificate)
+  end
+end

--- a/app/models/polling/scheduler.rb
+++ b/app/models/polling/scheduler.rb
@@ -3,8 +3,8 @@ module Polling
   class Scheduler
     attr_reader :rufus_scheduler
     attr_reader :job
-    DEFAULT_TIMEOUT = '30.0s'.freeze
-    DEFAULT_NUMBER_POLLS = 30
+    DEFAULT_TIMEOUT = '100.0s'.freeze
+    DEFAULT_NUMBER_POLLS = 12
 
     def initialize(opts = { overlap: false, timeout: DEFAULT_TIMEOUT, times: DEFAULT_NUMBER_POLLS })
       @opts = opts

--- a/app/models/polling/worker.rb
+++ b/app/models/polling/worker.rb
@@ -1,19 +1,10 @@
 class Worker
   def after_commit(model)
-    poll(environment: model.environment)
-  end
-
-  def poll(
-    scheduler: Polling::Scheduler.new,
-    status_updater: CERT_STATUS_UPDATER,
-    hub_api: HUB_CONFIG_API,
-    environment:
-  )
-    certificates = Component.all_pollable_certificates(environment)
+    certificates = Component.all_pollable_certificates(model.environment)
     certificates.each { |certificate|
-      scheduler.mode(:every)
-               .perform(-> { status_updater.update_hub_usage_status_for_cert(hub_api, certificate) })
-               .until(scheduler.action_result&.certificate&.in_use_at.present?)
+      SCHEDULER.mode(:every)
+               .perform(-> { CERT_STATUS_UPDATER.update_hub_usage_status_for_cert(HUB_CONFIG_API, certificate) })
+               .until(SCHEDULER.action_result&.certificate&.in_use_at.present?)
     }
   end
 

--- a/app/models/polling/worker.rb
+++ b/app/models/polling/worker.rb
@@ -1,0 +1,23 @@
+class Worker
+  def after_commit(model)
+    poll(environment: model.environment)
+  end
+
+  def poll(
+    scheduler: Polling::Scheduler.new,
+    status_updater: CERT_STATUS_UPDATER,
+    hub_api: HUB_CONFIG_API,
+    environment:
+  )
+    certificates = Component.all_pollable_certificates(environment)
+    certificates.each { |certificate|
+      scheduler.mode(:every)
+               .perform(-> { status_updater.update_hub_usage_status_for_cert(hub_api, certificate) })
+               .until(scheduler.action_result&.certificate&.in_use_at.present?)
+    }
+  end
+
+  def self.poll
+    Worker.new
+  end
+end

--- a/app/models/publish_services_metadata_event.rb
+++ b/app/models/publish_services_metadata_event.rb
@@ -1,6 +1,7 @@
 require 'yaml'
 require 'digest/md5'
 require 'notify/notification'
+require 'polling/worker'
 
 class PublishServicesMetadataEvent < Event
   include HubEnvironmentConcern
@@ -10,6 +11,7 @@ class PublishServicesMetadataEvent < Event
   validates_presence_of :event_id
   before_create :populate_data_attributes
   before_create :upload
+  after_create_commit Worker.poll
 
   def populate_data_attributes
     @metadata = services_metadata

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -89,6 +89,9 @@ Rails.application.configure do
   config.after_initialize do
     require 'api/hub_config_api'
     HUB_CONFIG_API = HubConfigApi.new
+
+    require 'polling/dev_cert_status_updater'
+    CERT_STATUS_UPDATER = DevCertStatusUpdater.new
   end
 
   config.scheduler_polling_interval =  ENV.fetch('SCHEDULER_POLLING_INTERVAL','5s')

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -87,6 +87,9 @@ Rails.application.configure do
    end
 
   config.after_initialize do
+    require 'polling/scheduler'
+
+    SCHEDULER = Polling::Scheduler.new
     require 'api/hub_config_api'
     HUB_CONFIG_API = HubConfigApi.new
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -148,6 +148,9 @@ Rails.application.configure do
 
     require 'api/hub_config_api'
     HUB_CONFIG_API = HubConfigApi.new
+
+    require 'polling/cert_status_updater'
+    CERT_STATUS_UPDATER = CertStatusUpdater.new
   end
 
   config.scheduler_polling_interval =  ENV.fetch('SCHEDULER_POLLING_INTERVAL','5s')

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -153,6 +153,6 @@ Rails.application.configure do
     CERT_STATUS_UPDATER = CertStatusUpdater.new
   end
 
-  config.scheduler_polling_interval =  ENV.fetch('SCHEDULER_POLLING_INTERVAL','5s')
+  config.scheduler_polling_interval =  ENV.fetch('SCHEDULER_POLLING_INTERVAL','15s')
   config.authentication_header = ENV.fetch('SELF_SERVICE_AUTHENTICATION_HEADER', nil)
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -58,11 +58,14 @@ Rails.application.configure do
   config.cognito_aws_secret_access_key = ENV['COGNITO_AWS_SECRET_ACCESS_KEY']
   config.cognito_client_id = ENV['AWS_COGNITO_CLIENT_ID']
   config.cognito_user_pool_id = ENV['AWS_COGNITO_USER_POOL_ID']
-  config.scheduler_polling_interval =  ENV.fetch('SCHEDULER_POLLING_INTERVAL','5s')
+  config.scheduler_polling_interval =  ENV.fetch('SCHEDULER_POLLING_INTERVAL','0.5s')
   config.notify_key = 'test-11111111-1111-1111-1111-111111111111-11111111-1111-1111-1111-111111111111'
   config.app_url = 'www.test.com'
 
   config.after_initialize do
+    require 'polling/scheduler'
+    SCHEDULER = Polling::Scheduler.new
+
     require 'api/hub_config_api'
     HUB_CONFIG_API = HubConfigApi.new
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -65,5 +65,8 @@ Rails.application.configure do
   config.after_initialize do
     require 'api/hub_config_api'
     HUB_CONFIG_API = HubConfigApi.new
+
+    require 'polling/dev_cert_status_updater'
+    CERT_STATUS_UPDATER = DevCertStatusUpdater.new
   end
 end

--- a/lib/api/hub_config_api.rb
+++ b/lib/api/hub_config_api.rb
@@ -1,10 +1,6 @@
 class HubConfigApi
   include HubEnvironmentConcern
   require 'cgi'
-  HEALTHCHECK_ENDPOINT = '/service-status'.freeze
-  CERTIFICATES_ROUTE = '/config/certificates/'.freeze
-  CERTIFICATE_ENCRYPTION_ENDPOINT = "%{entity_id}/certs/encryption".freeze
-  CERTIFICATES_SIGNING_ENDPOINT = "%{entity_id}/certs/signing".freeze
 
   def healthcheck(environment)
     build_request(**healthcheck_path(environment))
@@ -32,25 +28,9 @@ class HubConfigApi
 
 private
 
-  def use_secure_header(environment)
-    hub_environment(environment, :secure_header) == 'true'
-  end
-
   def build_request(environment:, url:)
     return Faraday.get(url) unless use_secure_header(environment)
 
     Faraday.get(url) { |req| req.headers['X-Self-Service-Authentication'] = Rails.configuration.authentication_header }
-  end
-
-  def encryption_cert_path(environment, entity_id)
-    { environment: environment, url: [hub_environment(environment, :hub_config_host), CERTIFICATES_ROUTE, CERTIFICATE_ENCRYPTION_ENDPOINT % { entity_id: CGI.escape(entity_id) }].join }
-  end
-
-  def signing_certs_path(environment, entity_id)
-    { environment: environment, url: [hub_environment(environment, :hub_config_host), CERTIFICATES_ROUTE, CERTIFICATES_SIGNING_ENDPOINT % { entity_id: CGI.escape(entity_id) }].join }
-  end
-
-  def healthcheck_path(environment)
-    { environment: environment, url: [hub_environment(environment, :hub_config_host), HEALTHCHECK_ENDPOINT].join }
   end
 end

--- a/spec/models/certificate_expiry_reminder_spec.rb
+++ b/spec/models/certificate_expiry_reminder_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe CertificateExpiryReminder, type: :model do
         encryption_certificate_id: cert.id,
         admin_upload: true,
       )
-      
+
       certificate_expiry_reminder.run
 
       expected_expiry_date = (Time.now + expires_in_days.days).strftime("%d %B %Y")
@@ -140,7 +140,7 @@ RSpec.describe CertificateExpiryReminder, type: :model do
       stub_notify_response
 
       expires_in_days = 7
-      
+
       team = create(:team)
 
       component_vsp = create(:sp_component, vsp: true, environment: 'production', team_id: team.id)

--- a/spec/models/certificate_expiry_reminder_spec.rb
+++ b/spec/models/certificate_expiry_reminder_spec.rb
@@ -114,7 +114,6 @@ RSpec.describe CertificateExpiryReminder, type: :model do
         encryption_certificate_id: cert.id,
         admin_upload: true,
       )
-
       certificate_expiry_reminder.run
 
       expected_expiry_date = (Time.now + expires_in_days.days).strftime("%d %B %Y")
@@ -140,7 +139,6 @@ RSpec.describe CertificateExpiryReminder, type: :model do
       stub_notify_response
 
       expires_in_days = 7
-
       team = create(:team)
 
       component_vsp = create(:sp_component, vsp: true, environment: 'production', team_id: team.id)

--- a/spec/models/component_spec.rb
+++ b/spec/models/component_spec.rb
@@ -3,30 +3,10 @@ require 'rails_helper'
 RSpec.describe Component, type: :model do
   include StubHubConfigApiSupport
   context '#to_service_metadata' do
-
     before(:each) do
       SpComponent.destroy_all
       MsaComponent.destroy_all
     end
-
-    def hub_response_for_encryption(entity_id, certificate_value)
-      {
-        issuerId: entity_id,
-        certificate: certificate_value,
-        keyUse: 'Encryption',
-        federationEntityType: 'RP',
-      }.to_json
-    end
-
-    def hub_response_for_signing(entity_id, certificate_value)
-      [{
-        issuerId: entity_id,
-        certificate: certificate_value,
-        keyUse: 'Signing',
-        federationEntityType: 'RP',
-      }].to_json
-    end
-
     let(:published_at) { Time.now }
     let(:msa_component) { create(:msa_component) }
     let(:sp_component) { create(:sp_component) }
@@ -46,8 +26,6 @@ RSpec.describe Component, type: :model do
       )
     end
     let!(:upload_signing_certificate_event_3) do
-      stub_signing_certificates_hub_request(environment: sp_component.environment, entity_id: sp_service.entity_id)
-      .to_return(body: hub_response_for_signing(sp_service.entity_id, root.generate_encoded_cert(expires_in: 2.months)))
       create(:assign_sp_component_to_service_event, service: sp_service, sp_component_id: sp_component.id)
       create(:upload_certificate_event,
         usage: CERTIFICATE_USAGE::SIGNING,
@@ -56,8 +34,6 @@ RSpec.describe Component, type: :model do
       )
     end
     let!(:upload_signing_certificate_event_4) do
-      stub_signing_certificates_hub_request(environment: sp_component.environment, entity_id: sp_service.entity_id)
-      .to_return(body: hub_response_for_signing(sp_service.entity_id, root.generate_encoded_cert(expires_in: 2.months)))
       create(:assign_sp_component_to_service_event, service: sp_service, sp_component_id: sp_component.id)
       create(:upload_certificate_event,
         usage: CERTIFICATE_USAGE::SIGNING,
@@ -78,8 +54,6 @@ RSpec.describe Component, type: :model do
       event
     end
     let!(:upload_encryption_event_2) do
-      stub_encryption_certificate_hub_request(environment: sp_component.environment, entity_id: sp_service.entity_id)
-      .to_return(body: hub_response_for_encryption(sp_service.entity_id, root.generate_encoded_cert(expires_in: 3.months)))
       create(:assign_sp_component_to_service_event, service: sp_service, sp_component_id: sp_component.id)
       event = create(:upload_certificate_event,
         usage: CERTIFICATE_USAGE::ENCRYPTION,

--- a/spec/models/component_spec.rb
+++ b/spec/models/component_spec.rb
@@ -32,8 +32,6 @@ RSpec.describe Component, type: :model do
     let(:sp_component) { create(:sp_component) }
     let(:root) { PKI.new }
     let!(:upload_signing_certificate_event_1) do
-
-
       create(:upload_certificate_event,
         usage: CERTIFICATE_USAGE::SIGNING,
         value: root.generate_encoded_cert(expires_in: 6.months),
@@ -41,7 +39,6 @@ RSpec.describe Component, type: :model do
       )
     end
     let!(:upload_signing_certificate_event_2) do
-
       create(:upload_certificate_event,
         usage: CERTIFICATE_USAGE::SIGNING,
         value: root.generate_encoded_cert(expires_in: 6.months),
@@ -69,8 +66,6 @@ RSpec.describe Component, type: :model do
       )
     end
     let!(:upload_encryption_event_1) do
-
-
       event = create(:upload_certificate_event,
         usage: CERTIFICATE_USAGE::ENCRYPTION,
         value: root.generate_encoded_cert(expires_in: 6.months),
@@ -190,7 +185,6 @@ RSpec.describe Component, type: :model do
     let(:sp_component) { create(:sp_component) }
 
     def encryption_certificate(expires_in: 129.days, component: )
-
       @encryption_event = create(:upload_certificate_event,
         usage: CERTIFICATE_USAGE::ENCRYPTION,
         value: root.generate_encoded_cert(expires_in: expires_in),

--- a/spec/models/polling/scheduler_spec.rb
+++ b/spec/models/polling/scheduler_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Polling::Scheduler, type: :model do
   after :each do
     scheduler.rufus_scheduler.shutdown
   end
-  
+
   let(:greetings) { 'hello verify self service...' }
   let(:worker) {
    Class.new do
@@ -34,6 +34,12 @@ RSpec.describe Polling::Scheduler, type: :model do
     it 'does something when mode is bad' do
       expect(scheduler.mode(:ofather)).to eql scheduler
       expect(scheduler.perform(->{ worker.work })).not_to be scheduler
+    end
+
+    it 'uses default job frequency when polling on an action' do
+      expect(scheduler.mode(:every)).to eql scheduler
+      expect(scheduler.perform(->{ worker.work })).to be scheduler
+      expect(scheduler.job.frequency).to eq Rails.configuration.scheduler_polling_interval.chomp('s').to_f
     end
 
     it 'uses duration string to poll on a repeatable schedule' do

--- a/spec/models/polling/scheduler_spec.rb
+++ b/spec/models/polling/scheduler_spec.rb
@@ -2,6 +2,11 @@ require 'rails_helper'
 
 RSpec.describe Polling::Scheduler, type: :model do
   let(:scheduler) { Polling::Scheduler.new }
+
+  after :each do
+    scheduler.rufus_scheduler.shutdown
+  end
+  
   let(:greetings) { 'hello verify self service...' }
   let(:worker) {
    Class.new do

--- a/spec/models/upload_certificate_event_spec.rb
+++ b/spec/models/upload_certificate_event_spec.rb
@@ -37,92 +37,91 @@ RSpec.describe UploadCertificateEvent, type: :model do
         expect(event).to_not be_valid
         expect(event.errors[:certificate]).to eql [t('certificates.errors.invalid')]
       end
-  
+
       it 'must allow base64 encoded DER format x509 certificate' do
         cert = root.generate_encoded_cert(expires_in: 2.months)
-  
+
         event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert, component: msa_component)
         expect(event.certificate.value).to eql(cert)
         expect(event).to be_valid
         expect(event.errors[:certificate]).to be_empty
       end
-  
+
       it 'must allow PEM format x509 certificate and be stored as base64 encoded DER' do
         cert = root.generate_signed_cert(expires_in: 2.months)
-  
+
         event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert.to_pem, component: msa_component)
         expect(event.certificate.value).to eql(Base64.strict_encode64(cert.to_der))
         expect(event).to be_valid
         expect(event.errors[:certificate]).to be_empty
       end
-  
+
       it 'must not be expired' do
         cert = root.generate_encoded_cert(expires_in: -1.months)
-  
+
         event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert, component: msa_component)
         expect(event).to_not be_valid
         expect(event.errors[:certificate]).to eql [t('certificates.errors.expired')]
       end
-  
+
       it 'must not expire within 1 month' do
         cert = root.generate_encoded_cert(expires_in: 15.days)
-  
+
         event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert, component: msa_component)
         expect(event).to_not be_valid
         expect(event.errors[:certificate]).to eql [t('certificates.errors.expires_soon')]
       end
-  
+
       it 'must expire within 1 year' do
         cert = root.generate_encoded_cert(expires_in: 2.years)
-  
         event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert, component: msa_component)
         expect(event).to_not be_valid
         expect(event.errors[:certificate]).to eql [t('certificates.errors.valid_too_long')]
       end
-  
+
       it 'must be RSA' do
         cert = root.generate_signed_ec_cert(6.months)
-  
+
         event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert.to_pem, component: msa_component)
         expect(event).to_not be_valid
         expect(event.errors[:certificate]).to eql [t('certificates.errors.not_rsa')]
       end
-  
+
       it 'must accept sha-256' do
         cert = root.generate_signed_cert(expires_in: 6.months, digest: "SHA256")
-  
+
         event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert.to_pem, component: msa_component)
         expect(event).to be_valid
         expect(event.errors[:certificate]).to be_empty
       end
-  
+
       it 'must accept sha-512' do
         cert = root.generate_signed_cert(expires_in: 6.months, digest: "SHA512")
-  
+
         event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert.to_pem, component: msa_component)
         expect(event).to be_valid
         expect(event.errors[:certificate]).to be_empty
       end
-  
+
       it 'must not be sha-1' do
         cert = root.generate_signed_cert(expires_in: 6.months, digest: "SHA1")
-  
+
         event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert.to_pem, component: msa_component)
         expect(event).to_not be_valid
         expect(event.errors[:certificate]).to eql [t('certificates.errors.bad_algorithm')]
       end
-  
+
       it 'must not be sha-384' do
         cert = root.generate_signed_cert(expires_in: 6.months, digest: "SHA384")
-  
+
         event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert.to_pem, component: msa_component)
         expect(event).to_not be_valid
         expect(event.errors[:certificate]).to eql [t('certificates.errors.bad_algorithm')]
       end
-  
+
       it 'must be at least 2048 bits' do
         cert = root.generate_signed_rsa_cert_and_key(size: 1024)[0]
-  
+
         event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert.to_pem, component: msa_component)
         expect(event).to_not be_valid
         expect(event.errors[:certificate]).to eql [t('certificates.errors.small_key')]
@@ -145,92 +144,92 @@ RSpec.describe UploadCertificateEvent, type: :model do
         expect(event).to_not be_valid
         expect(event.errors[:certificate]).to eql [t('certificates.errors.invalid')]
       end
-  
+
       it 'must allow base64 encoded DER format x509 certificate' do
         cert = root.generate_encoded_cert(expires_in: 2.months)
-  
+
         event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert, component: msa_component, admin_upload: true)
         expect(event.certificate.value).to eql(cert)
         expect(event).to be_valid
         expect(event.errors[:certificate]).to be_empty
       end
-  
+
       it 'must allow PEM format x509 certificate and be stored as base64 encoded DER' do
         cert = root.generate_signed_cert(expires_in: 2.months)
-  
+
         event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert.to_pem, component: msa_component, admin_upload: true)
         expect(event.certificate.value).to eql(Base64.strict_encode64(cert.to_der))
         expect(event).to be_valid
         expect(event.errors[:certificate]).to be_empty
       end
-  
+
       it 'must allow expired' do
         cert = root.generate_encoded_cert(expires_in: -1.months)
-  
+
         event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert, component: msa_component, admin_upload: true)
         expect(event).to be_valid
         expect(event.errors[:certificate]).to be_empty
       end
-  
+
       it 'must allow expiring within in less than 30 days' do
         cert = root.generate_encoded_cert(expires_in: 15.days)
-  
+
         event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert, component: msa_component, admin_upload: true)
         expect(event).to be_valid
         expect(event.errors[:certificate]).to be_empty
       end
-  
+
       it 'must allow expiring in more than 1 year' do
         cert = root.generate_encoded_cert(expires_in: 2.years)
-  
+
         event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert, component: msa_component, admin_upload: true)
         expect(event).to be_valid
         expect(event.errors[:certificate]).to be_empty
       end
-  
+
       it 'must be RSA' do
         cert = root.generate_signed_ec_cert(6.months)
-  
+
         event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert.to_pem, component: msa_component, admin_upload: true)
         expect(event).to_not be_valid
         expect(event.errors[:certificate]).to eql [t('certificates.errors.not_rsa')]
       end
-  
+
       it 'must accept sha-256' do
         cert = root.generate_signed_cert(expires_in: 6.months, digest: "SHA256")
-  
+
         event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert.to_pem, component: msa_component, admin_upload: true)
         expect(event).to be_valid
         expect(event.errors[:certificate]).to be_empty
       end
-  
+
       it 'must accept sha-512' do
         cert = root.generate_signed_cert(expires_in: 6.months, digest: "SHA512")
-  
+
         event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert.to_pem, component: msa_component, admin_upload: true)
         expect(event).to be_valid
         expect(event.errors[:certificate]).to be_empty
       end
-  
+
       it 'must not be sha-1' do
         cert = root.generate_signed_cert(expires_in: 6.months, digest: "SHA1")
-  
+
         event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert.to_pem, component: msa_component, admin_upload: true)
         expect(event).to_not be_valid
         expect(event.errors[:certificate]).to eql [t('certificates.errors.bad_algorithm')]
       end
-  
+
       it 'must not be sha-384' do
         cert = root.generate_signed_cert(expires_in: 6.months, digest: "SHA384")
-  
+
         event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert.to_pem, component: msa_component, admin_upload: true)
         expect(event).to_not be_valid
         expect(event.errors[:certificate]).to eql [t('certificates.errors.bad_algorithm')]
       end
-  
+
       it 'must be at least 2048 bits' do
         cert = root.generate_signed_rsa_cert_and_key(size: 1024)[0]
-  
+
         event = UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: cert.to_pem, component: msa_component, admin_upload: true)
         expect(event).to_not be_valid
         expect(event.errors[:certificate]).to eql [t('certificates.errors.small_key')]

--- a/spec/support/notify_support.rb
+++ b/spec/support/notify_support.rb
@@ -1,4 +1,3 @@
-require 'json'
 module NotifySupport
   NOTIFY_ENDPOINT = "https://api.notifications.service.gov.uk/v2/notifications/email".freeze
 

--- a/spec/support/notify_support.rb
+++ b/spec/support/notify_support.rb
@@ -1,3 +1,4 @@
+require 'json'
 module NotifySupport
   NOTIFY_ENDPOINT = "https://api.notifications.service.gov.uk/v2/notifications/email".freeze
 

--- a/spec/support/stub_hub_config_api_support.rb
+++ b/spec/support/stub_hub_config_api_support.rb
@@ -22,4 +22,22 @@ module StubHubConfigApiSupport
 
     stub
   end
+
+  def hub_response_for_signing(entity_id:, value:)
+    [{
+      issuerId: entity_id,
+      certificate: value,
+      keyUse: 'Signing',
+      federationEntityType: 'RP',
+    }].to_json
+  end
+
+  def hub_response_for_encryption(entity_id:, value:)
+    {
+      issuerId: entity_id,
+      certificate: value,
+      keyUse: 'Signing',
+      federationEntityType: 'RP',
+    }.to_json
+  end
 end

--- a/spec/support/stub_hub_config_api_support.rb
+++ b/spec/support/stub_hub_config_api_support.rb
@@ -1,0 +1,25 @@
+module StubHubConfigApiSupport
+  include HubEnvironmentConcern
+  AUTHENTICATION_HEADER = { 'X-Self-Service-Authentication': Rails.configuration.authentication_header }.freeze
+
+  def stub_healthcheck_hub_request(environment:, secure_header: false)
+    stub = stub_request(:get, healthcheck_path(environment)[:url])
+    return stub.with(headers: AUTHENTICATION_HEADER) if secure_header
+
+    stub
+  end
+
+  def stub_encryption_certificate_hub_request(environment:, entity_id:, secure_header: false)
+    stub = stub_request(:get, encryption_cert_path(environment, entity_id)[:url])
+    return stub.with(headers: AUTHENTICATION_HEADER) if secure_header
+
+    stub
+  end
+
+  def stub_signing_certificates_hub_request(environment:, entity_id:, secure_header: false)
+    stub = stub_request(:get, signing_certs_path(environment, entity_id)[:url])
+    return stub.with(headers: AUTHENTICATION_HEADER) if secure_header
+
+    stub
+  end
+end


### PR DESCRIPTION
**[(part of [EPIC] Implement a way for self-service to know when the hub is using the new certificates](https://trello.com/c/HAgIQnnZ/773-epic-implement-a-way-for-self-service-to-know-when-the-hub-is-using-the-new-certificates)**

**Background:** In order to send out email notifications to the cert owner when a new cert is confirmed to be in use by Hub, the app will need to poll the Hub until it is confirmed that the cert is being used. Other cards ([Poll Hub to get status of new certs ](https://trello.com/c/HKYMG4ca/781-poll-hub-to-get-status-of-new-certs) and [Update cert's status timestamp based on result from Hub](https://trello.com/c/psV0aeSY/780-update-certs-status-timestamp-based-on-result-from-hub)) cover implementing the details of performing that polling, but we also need to actually **initiate it** when a new cert is added. This is what this PR covers

**Scope:** This card covers ensuring that after a new cert is added or replaced, a call is made to the class which handles polling. It also includes creating and injecting a suitably configured instance of that class into the place where it will need to be called from in different environments

**Acceptance criteria**

- The polling functionality is called when a new cert is added.  Or when publish event occurs
- The polling functionality behaves appropriately in different for development, testing and production e.g. In production we really want to be polling, in development we don't really care about polling so the in_use_at field is update by a DevCertStatusUpdater. In test environment, we want to be able to test that polling is trigger. So in PublishEvent Spec we turn it on for the duration of that test only.
   