### PR TITLE
Email templates for when cert is ready

### DIFF
--- a/lib/notify/cert_status_notifications.rb
+++ b/lib/notify/cert_status_notifications.rb
@@ -1,0 +1,91 @@
+module CertStatusNotifications
+  MSA_SIGNING_TEMPLATE = 'db78c8a3-54c5-443a-ba93-b64c21799b4c'.freeze
+  MSA_SIGNING_NO_DEADLINE_TEMPLATE = 'ib86fd33c-59c1-4ea4-b643-4a88756c21eb'.freeze
+  MSA_VSP_DUAL_RUNNING_SP_ENCRYPTION_TEMPLATE = '3514d7ae-367f-428e-96d5-4eab3e09eeed'.freeze
+  SP_ENCRYPTION_NO_DUAL_RUNNING_TEMPLATE = '2efd21a0-d3f9-4e35-a732-ff3a1c8f3f12'.freeze
+  VSP_SP_SIGNING_TEMPLATE = '8342fbc4-a847-4587-932c-07065d471942'.freeze
+  VSP_SP_SIGNING_NO_DEADLINE_TEMPLATE = 'a07ac619-de15-4bde-97cd-7c722f2b950b'.freeze
+
+  def send_notification_email(mail_client:, certificate:, environment:, email_address:, deadline:)
+    component = certificate.component
+    is_dual_running = component.enabled_signing_certificates.length > 1
+
+    template = choose_template(
+      certificate: certificate,
+      component_type: component.type,
+      is_dual_running: is_dual_running,
+      deadline: deadline,
+    )
+
+    personalisation =
+      case template
+      when MSA_SIGNING_TEMPLATE
+        {
+          team_name: component.team.name,
+          environment: environment,
+          time_and_date: deadline,
+        }
+      when MSA_SIGNING_NO_DEADLINE_TEMPLATE
+        {
+          team_name: component.team.name,
+          environment: environment,
+        }
+      when MSA_VSP_DUAL_RUNNING_SP_ENCRYPTION_TEMPLATE
+        {
+          team_name: component.team.name,
+          component: component.display_long_name,
+          environment: environment,
+        }
+      when SP_ENCRYPTION_NO_DUAL_RUNNING_TEMPLATE
+        {
+          team_name: component.team.name,
+          environment: environment,
+        }
+      when VSP_SP_SIGNING_TEMPLATE
+        {
+          team_name: component.team.name,
+          component: component.display_long_name,
+          environment: environment,
+          time_and_date: deadline,
+        }
+      when VSP_SP_SIGNING_NO_DEADLINE_TEMPLATE
+        {
+          team_name: component.team.name,
+          component: component.display_long_name,
+          environment: environment,
+        }
+      end
+
+    mail_client.send_email(
+      email_address: email_address,
+      template_id: template,
+      personalisation: personalisation,
+    )
+  end
+
+private
+
+  def choose_template(certificate:, component_type:, is_dual_running:, deadline:)
+    if certificate.signing?
+      choose_template_for_signing_cert(component_type, deadline)
+    elsif component_type == COMPONENT_TYPE::SP_SHORT && !is_dual_running
+      SP_ENCRYPTION_NO_DUAL_RUNNING_TEMPLATE
+    else
+      MSA_VSP_DUAL_RUNNING_SP_ENCRYPTION_TEMPLATE
+    end
+  end
+
+  def choose_template_for_signing_cert(component_type, deadline)
+    if component_type == COMPONENT_TYPE::MSA_SHORT
+      if defined?(deadline)
+        MSA_SIGNING_TEMPLATE
+      else
+        MSA_SIGNING_NO_DEADLINE_TEMPLATE
+      end
+    elsif defined?(deadline)
+      VSP_SP_SIGNING_TEMPLATE
+    else
+      VSP_SP_SIGNING_NO_DEADLINE_TEMPLATE
+    end
+  end
+end

--- a/lib/notify/cert_status_notifications.rb
+++ b/lib/notify/cert_status_notifications.rb
@@ -8,7 +8,7 @@ module CertStatusNotifications
 
   def send_notification_email(mail_client:, certificate:, environment:, email_address:, deadline:)
     component = certificate.component
-    is_dual_running = component.enabled_signing_certificates.length > 1
+    is_dual_running = component.enabled_signing_certificates.count > 1
 
     template = choose_template(
       certificate: certificate,
@@ -17,44 +17,12 @@ module CertStatusNotifications
       deadline: deadline,
     )
 
-    personalisation =
-      case template
-      when MSA_SIGNING_TEMPLATE
-        {
-          team_name: component.team.name,
-          environment: environment,
-          time_and_date: deadline,
-        }
-      when MSA_SIGNING_NO_DEADLINE_TEMPLATE
-        {
-          team_name: component.team.name,
-          environment: environment,
-        }
-      when MSA_VSP_DUAL_RUNNING_SP_ENCRYPTION_TEMPLATE
-        {
-          team_name: component.team.name,
-          component: component.display_long_name,
-          environment: environment,
-        }
-      when SP_ENCRYPTION_NO_DUAL_RUNNING_TEMPLATE
-        {
-          team_name: component.team.name,
-          environment: environment,
-        }
-      when VSP_SP_SIGNING_TEMPLATE
-        {
-          team_name: component.team.name,
-          component: component.display_long_name,
-          environment: environment,
-          time_and_date: deadline,
-        }
-      when VSP_SP_SIGNING_NO_DEADLINE_TEMPLATE
-        {
-          team_name: component.team.name,
-          component: component.display_long_name,
-          environment: environment,
-        }
-      end
+    personalisation = {
+      team_name: component.team.name,
+      component: component.display_long_name,
+      environment: environment,
+      time_and_date: deadline,
+    }
 
     mail_client.send_email(
       email_address: email_address,

--- a/lib/notify/notification.rb
+++ b/lib/notify/notification.rb
@@ -113,6 +113,19 @@ module Notification
     Rails.logger.error(e.message)
   end
 
+  def send_cert_status_notification_email(certificate:, environment:, email_address:, team_name:, deadline:)
+    CertStatusNotifications.send_notification_email(
+      mail_client: mail_client,
+      certificate: certificate,
+      environment: environment,
+      email_address: email_address,
+      team_name: team_name,
+      deadline: deadline,
+    )
+  rescue Notifications::Client::RequestError => e
+    Rails.logger.error(e.message)
+  end
+
 private
 
   def url


### PR DESCRIPTION
When a certificate that has been added by a reying party is confirmed to be in use by the Hub, we will send them an email to confirm that the cert is ready.  This commit adds code which chooses which template to use and sends the email, but at present nothing calls it.

Once this PR is merged I will need to look into integrating it with the work Ola has been doing.

https://trello.com/c/OjUWN78Y/782-schedule-an-email-when-cert-is-confirmed-to-be-in-use-by-hub