### PR TITLE
BAU: Keep publishing expired certs

### DIFF
--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -76,8 +76,8 @@ class Component < Aggregate
   def to_metadata
     {
       name: name,
-      encryption_certificate: unexpired_encryption_certificate&.to_metadata,
-      signing_certificates: unexpired_enabled_signing_certificates.map(&:to_metadata),
+      encryption_certificate: encryption_certificate&.to_metadata,
+      signing_certificates: enabled_signing_certificates.map(&:to_metadata),
     }.merge(additional_metadata)
   end
 
@@ -101,23 +101,5 @@ class Component < Aggregate
 
   def active_cert?(certificate)
     current_certificates.include?(certificate)
-  end
-
-private
-
-  def unexpired_encryption_certificate
-    if encryption_certificate&.expired?
-      Rails.logger.error "When publishing the meta data the service '#{name}' has been identified as having an expired encryption certificate."
-      return nil
-    end
-    encryption_certificate
-  end
-
-  def unexpired_enabled_signing_certificates
-    valid_certs = enabled_signing_certificates.reject(&:expired?)
-    if valid_certs.size < enabled_signing_certificates.size
-      Rails.logger.error "When publishing the meta data the service '#{name}' has been identified as having expired signing certificate(s)."
-    end
-    valid_certs
   end
 end

--- a/spec/models/component_spec.rb
+++ b/spec/models/component_spec.rb
@@ -146,40 +146,6 @@ RSpec.describe Component, type: :model do
         service_providers: []
       }
     end
-
-    it 'does not include expired signing certs' do
-      expired_signing_cert = {
-        name: upload_signing_certificate_event_4.certificate.x509.subject.to_s,
-        value: upload_signing_certificate_event_4.certificate.value
-      }
-
-      travel_to Time.now + 2.months + 2.days
-
-      event_id = Event.first.id
-      actual_config = Component.to_service_metadata(event_id, 'staging', published_at)
-      expect(expected_config(event_id)).not_to eq(actual_config)
-      expect(actual_config[:service_providers][0][:signing_certificates].include?(expired_signing_cert)).to eq(false)
-    end
-
-    it 'does not include expired encryption certs' do
-      expired_signing_cert = {
-        name: upload_signing_certificate_event_4.certificate.x509.subject.to_s,
-        value: upload_signing_certificate_event_4.certificate.value
-      }
-
-      expired_encryption_cert = {
-        name: upload_encryption_event_2.certificate.x509.subject.to_s,
-        value: upload_encryption_event_2.certificate.value
-      }
-
-      travel_to Time.now + 4.months
-
-      event_id = Event.first.id
-      actual_config = Component.to_service_metadata(event_id, 'staging', published_at)
-      expect(expected_config(event_id)).not_to eq(actual_config)
-      expect(actual_config[:service_providers][0][:signing_certificates].include?(expired_signing_cert)).to eq(false)
-      expect(actual_config[:service_providers][0][:encryption_certificate]).to be_nil
-    end
   end
   context 'sorting certificates' do
     before(:each) do


### PR DESCRIPTION
This reverts [PR#260](https://github.com/alphagov/verify-self-service/pull/260). It turns out the hub is not able
to handle missing certs and fails with NullPointerException.
This will also make it possible for Grafana to see expired certs in the published metadata file.

Discovered from Sentry logs