### PR TITLE
BAU: Uppercase the GDS team name in the banner

### DIFF
--- a/app/views/layouts/main_layout.html.erb
+++ b/app/views/layouts/main_layout.html.erb
@@ -1,7 +1,16 @@
 <% content_for :banner do %>
   <div class="govuk-phase-banner">
     <p class="govuk-phase-banner__content">
-      <span class="govuk-phase-banner__text govuk-heading-s"><%= @team_name %></span>
+      <span class="govuk-phase-banner__text govuk-heading-s">
+        <% if @team_name == TEAMS::GDS %>
+          <%= @team_name.upcase %>
+            <strong class="govuk-tag">
+              <%= t 'users.admin_team' %>
+            </strong>
+        <% else %>
+          <%= @team_name %>
+        <% end %>
+      </span>
     </p>
   </div>
 <% end %>


### PR DESCRIPTION
So it's consistent with the Teams view.

**Before:**
<img width="275" alt="image" src="https://user-images.githubusercontent.com/30629434/72168606-61c38980-33c5-11ea-8c77-d0f498597cb8.png">

**After:**
<img width="276" alt="image" src="https://user-images.githubusercontent.com/30629434/72168611-65efa700-33c5-11ea-83e4-8b80a722f4d8.png">

