### PR TITLE
bau-fix-unitialized-scheduler

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -149,6 +149,9 @@ Rails.application.configure do
     require 'api/hub_config_api'
     HUB_CONFIG_API = HubConfigApi.new
 
+    require 'polling/scheduler'
+    SCHEDULER = Polling::Scheduler.new
+
     require 'polling/cert_status_updater'
     CERT_STATUS_UPDATER = CertStatusUpdater.new
   end


### PR DESCRIPTION
- Acceptance test fails because the Scheduler hasn't been initialized
- in production.rb