### PR TITLE
Hub-416: change implementation certificate deploy status

### DIFF
--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -45,6 +45,6 @@ class Certificate < Aggregate
   end
 
   def deploying?
-    updated_at >= 10.minutes.ago
+    in_use_at.nil? || Time.now <= in_use_at
   end
 end

--- a/app/models/polling/dev_cert_status_updater.rb
+++ b/app/models/polling/dev_cert_status_updater.rb
@@ -1,5 +1,6 @@
 class DevCertStatusUpdater
   def update_hub_usage_status_for_cert(_hub_config_api, certificate)
-    CertificateInUseEvent.create(certificate: certificate)
+    time_cache_will_have_cleared_by = Time.now + Rails.configuration.hub_certs_cache_expiry
+    CertificateInUseEvent.create(certificate: certificate, in_use_at: time_cache_will_have_cleared_by)
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -362,10 +362,10 @@ en:
     secondary: (secondary)
     replacing_certificate_in_config: GOV.UK Verify is replacing your existing certificate with the new one
     adding_certificate_to_config: GOV.UK Verify is adding your certificate to its configuration
-    we_will_email_you: This usually takes around 10 minutes. We'll email you when this is done.
+    we_will_email_you: This usually takes a few minutes. We'll email you when this is done.
     add_new_signing_key_warning: After receiving this email you must add the new signing key to your %{component} config by %{date}, or your service’s connection to GOV.UK Verify will break.
     wait_for_an_email: Wait for an email from GOV.UK Verify confirming your new signing certificate is in use
-    how_long_it_takes: This usually takes around 10 minutes from the time you uploaded the new signing certificate.
+    how_long_it_takes: This usually takes a few minutes from the time you uploaded the new signing certificate.
     delete_old_signing_key_and_cert: Then you can delete the old signing key and certificate from your %{component} configuration.
     maintain_connection: You need to manage your certificates to make sure your service stays connected to GOV.UK Verify.
     connection_broken_or_compromised_guidance: If your connection has been broken or compromised, read
@@ -395,7 +395,7 @@ en:
       title_support_dual_running: Does your service provider support dual running?
       support_dual_running: If your service provider supports dual running, it can try to decrypt messages from the GOV.UK Verify Hub using both your old and new encryption keys. Your connection will not break.
       not_support_dual_running: Because your service provider does not support dual running, your connection to GOV.UK Verify will break when the GOV.UK Verify Hub starts using your new encryption certificate.
-      how_long_it_takes: This usually takes around 10 minutes.
+      how_long_it_takes: This usually takes a few minutes.
       connection_break: Wait for your connection to GOV.UK Verify to break.
       apply_changes: You should have added your new encryption key and certificate to your service provider configuration earlier. Apply the changes to fix the connection.
     before_you_start:
@@ -433,7 +433,7 @@ en:
       common_name: Common name
       used_by: Used by
       view_certificate: View full certificate
-      certificate_update_notice: Using this certificate will replace your old %{certificate} certificate in GOV.UK Verify's configuration within 10 minutes.
+      certificate_update_notice: Using this certificate will replace your old %{certificate} certificate in GOV.UK Verify's configuration within a few minutes.
       use_certificate: Use this certificate
       upload_different_certificate: Upload a different certificate
       certificate: "%{type} certificate"
@@ -446,8 +446,8 @@ en:
       certificate_will_be_added: Once you confirm you want to use this certificate, it will be added to the GOV.UK Verify Hub configuration alongside your old signing certificate.
       encrypt_messages_for_your_service: The GOV.UK Verify Hub will then use your new certificate to encrypt messages for your service.
       signed_mesages_from_your_service: The GOV.UK Verify Hub will then trust your old and new certificates to verify signatures on messages from your service.
-      how_long_it_takes: This takes around 10 minutes. Your connection will not break.
-      will_replace_old_certificate: Using this certificate will replace your old encryption certificate in GOV.UK Verify's configuration within 10 minutes.
+      how_long_it_takes: This will take a few minutes. Your connection will not break.
+      will_replace_old_certificate: Using this certificate will replace your old encryption certificate in GOV.UK Verify's configuration within a few minutes.
       sp_doesnt_support_dual_running: Because your service provider does not support dual running, your connection will break when the GOV.UK Verify Hub starts using your new certificate.
       restore_connection: As soon as this happens, you will need to restore your connection to GOV.UK Verify.
       choose_one: 'Choose one option:'
@@ -455,12 +455,12 @@ en:
       stop_using_primary_warning_html: "This is your primary (most recent) certificate. During a normal certificate rotation you should be disabling your %{href} instead."
       stop_using_secondary_link: secondary certificate
       stop_using_secondary_heading: Stop using this secondary certificate
-      stop_using_secondary_warning: By clicking the button below, GOV.UK Verify will stop using this certificate within 10 minutes. Make sure you're no longer using the corresponding private key.
+      stop_using_secondary_warning: By clicking the button below, GOV.UK Verify will stop using this certificate in a few minutes. Make sure you're no longer using the corresponding private key.
       stop_using: Stop using this certificate
     confirmation:
       title: Confirmation
       publish_failed_title: Publish failed
-      what_to_expect: This usually takes around 10 minutes. We'll email you when your new %{type} certificate is in use.
+      what_to_expect: This usually takes a few minutes. We'll email you when your new %{type} certificate is in use.
       next_steps: Next steps
       rotate_other_certificates: You can rotate other certificates straight away - you do not need to wait for the email.
       received_email: Once you've received the email, delete the old %{usage} key and certificate from your %{component} configuration.

--- a/spec/models/publish_services_event_metadata_spec.rb
+++ b/spec/models/publish_services_event_metadata_spec.rb
@@ -146,18 +146,6 @@ RSpec.describe PublishServicesMetadataEvent, type: :model do
       SCHEDULER.rufus_scheduler.shutdown(:kill)
     end
 
-    def wait_until(timeout=1.5, frequency=0.1, &block)
-      start = Time.now
-      loop {
-        sleep(frequency)
-        #return if block.call == true
-        r = block.call
-        return r if r
-        break if Time.now - start > timeout
-      }
-      fail "timeout after #{timeout}s"
-    end
-
     context 'does not occur' do
       require 'polling/dev_cert_status_updater'
       it 'updates certificate in_use_at' do

--- a/spec/support/time_helpers.rb
+++ b/spec/support/time_helpers.rb
@@ -1,3 +1,15 @@
 RSpec.configure do |config|
   config.include ActiveSupport::Testing::TimeHelpers
+
+  def wait_until(timeout=1.5, frequency=0.1, &block)
+    start = Time.now
+    loop {
+      sleep(frequency)
+      #return if block.call == true
+      r = block.call
+      return r if r
+      break if Time.now - start > timeout
+    }
+    fail "timeout after #{timeout}s"
+  end
 end

--- a/spec/system/visit_index_page_spec.rb
+++ b/spec/system/visit_index_page_spec.rb
@@ -34,10 +34,10 @@ RSpec.describe 'IndexPage', type: :system do
     expect(page).to have_content 'Manage certificates'
   end
 
-  it 'shows index page and successfully goes to next page' do   
+  it 'shows index page and successfully goes to next page' do
     visit root_path
     expect(page).to have_content 'Manage certificates'
-    within("##{msa_encryption_certificate.component_id}") do 
+    within("##{msa_encryption_certificate.component_id}") do
       click_link('Encryption certificate')
     end
     expect(current_path).to eql view_certificate_path(msa_encryption_certificate.id)
@@ -52,8 +52,14 @@ RSpec.describe 'IndexPage', type: :system do
   end
 
   it 'shows the primary signing certificate is deploying and secondary in use when deploying' do
-    old_signing_certificate = create(:msa_signing_certificate, updated_at: 15.minutes.ago)
-    new_signing_certificate = create(:msa_signing_certificate, component: old_signing_certificate.component)
+    msa_component = create(:msa_component)
+    old_signing_certificate = create(:upload_certificate_event, component: msa_component).certificate
+    new_signing_certificate = create(:msa_signing_certificate, component: msa_component)
+
+    expect(CERT_STATUS_UPDATER).to receive(:update_hub_usage_status_for_cert).with(any_args).at_least(:once)
+    expect(SCHEDULER).to receive(:mode).and_call_original.at_least(:once)
+    create(:assign_msa_component_to_service_event, msa_component_id: new_signing_certificate.component.id)
+
     visit root_path
     table_row_content_primary = page.find("##{new_signing_certificate.id}")
     table_row_content_secondary = page.find("##{old_signing_certificate.id}")
@@ -64,8 +70,10 @@ RSpec.describe 'IndexPage', type: :system do
   end
 
   it 'shows whether signing certificate is primary or secondary when there are two signing certificates' do
-    second_signing_certificate = create(:msa_signing_certificate, component: msa_signing_certificate.component)
-    travel_to Time.now + 11.minutes
+    expect(CERT_STATUS_UPDATER).to receive(:update_hub_usage_status_for_cert)
+      .with(any_args).and_call_original.at_least(:once)
+    second_signing_certificate = create(:upload_certificate_event, component: msa_signing_certificate.component).certificate
+    travel_to Time.now + Rails.configuration.hub_certs_cache_expiry
     visit root_path
     table_row_content_primary = page.find("##{second_signing_certificate.id}")
     table_row_content_secondary = page.find("##{msa_signing_certificate.id}")
@@ -118,21 +126,31 @@ RSpec.describe 'IndexPage', type: :system do
     cert_id = msa_signing_certificate.id
     visit root_path
     table_row_content = page.find("##{cert_id}")
+    msa_signing_certificate
+    expect(Certificate.find_by_id(msa_signing_certificate)).to be_deploying
     expect(table_row_content).to have_content 'DEPLOYING'
   end
 
   it 'shows in use tag if certificate is ok after deployment' do
+    expect(CERT_STATUS_UPDATER).to receive(:update_hub_usage_status_for_cert)
+      .with(any_args).and_call_original.at_least(:once)
+
     cert_id = msa_signing_certificate.id
-    travel_to Time.now + 11.minutes
+    create(:assign_msa_component_to_service_event, msa_component_id: msa_signing_certificate.component.id)
+    travel_to Time.now + Rails.configuration.hub_certs_cache_expiry
     visit root_path
     table_row_content = page.find("##{cert_id}")
     expect(table_row_content).to have_content 'IN USE'
   end
 
   it 'shows deploying tag if a second signing certificate has been uploaded' do
-    second_signing_certificate = create(:msa_signing_certificate, component: msa_signing_certificate.component)
+    expect(CERT_STATUS_UPDATER).to receive(:update_hub_usage_status_for_cert)
+    .with(any_args).at_least(:once)
+
+    second_signing_certificate = create(:upload_certificate_event, component: msa_signing_certificate.component).certificate
     visit root_path
     table_row_content = page.find("##{second_signing_certificate.id}")
+    expect(Certificate.find_by_id(second_signing_certificate)).to be_deploying
     expect(table_row_content).to have_content 'DEPLOYING'
   end
 


### PR DESCRIPTION
https://govukverify.atlassian.net/browse/HUB-416
Currently when deploying a certificate in the Self service application, the deploying status of the certificate is based on update_at field. New  or replaced certificates are shown as deploying for 10 minutes after which it is assumed that the are in use by the Hub. However, this logic should be based on the outcome of polling the hub, which updates the in_use_at field for the the certificate.

**Acceptance Criteria**
-   deploying status a certificate is driven  by the in_use_at field
-   All references to a 10 minutes deployment wait are removed
-   All specs depending on the deploying status pass