### PR TITLE
BAU: Fix the incorrect reference

### DIFF
--- a/app/views/shared/_user_component_certificates.html.erb
+++ b/app/views/shared/_user_component_certificates.html.erb
@@ -11,7 +11,7 @@
         </caption>
         <thead class="govuk-table__head govuk-visually-hidden">
           <tr class="govuk-table__row">
-            <th class="govuk-table__header" scope="col"><%= t 'user_journey.certificate' %></th>
+            <th class="govuk-table__header" scope="col"><%= t 'user_journey.certificate_heading' %></th>
             <th class="govuk-table__header" scope="col"><%= t 'user_journey.status' %></th>
           </tr>
         </thead>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -342,7 +342,7 @@ en:
       VSP: VSP
       SP: service provider
     used_by: "used by %{services}"
-    certificate: Certificate
+    certificate_heading: Certificate
     status: Status
     missing: MISSING
     in_use: IN USE


### PR DESCRIPTION
The heading of the table was referring to `user_journey.certificate` however,
it's defined twice, once as a value and second time as a group including sub-keys.
The page was rendering the sub-keys. It wasn't visible to the user because of
being it visually hidden for screen readers.

This PR changes the certificate key to certificate_heading to remove the duplication.

**(This is a very old commit forgot to raise a PR for)**