### PR TITLE
bau-modify-self-service-acceptance-test

### DIFF
--- a/spec/acceptance/user_journey_spec.rb
+++ b/spec/acceptance/user_journey_spec.rb
@@ -6,7 +6,11 @@ include CertificateSupport
 
 RSpec.describe 'User journey', type: :feature, acceptance: true do
   let(:root) { PKI.new }
-  let(:cert) { root.generate_encoded_cert(expires_in: 2.months) }
+  let(:certificate) {
+    team = Team.find_or_create_by(name: 'acceptance test team')
+    component = build(:msa_component, entity_id: 'https://acceptance-test-msa-2.com', team_id: team.id )
+    create(:msa_encryption_certificate, component: component )
+  }
   let(:email) { ENV['ACCEPTANCE_TEST_EMAIL'] }
   let(:password) { ENV['ACCEPTANCE_TEST_PASSWORD'] }
   let(:totp) { ROTP::TOTP.new(ENV['TOTP_SECRET_CODE']) }
@@ -47,7 +51,7 @@ RSpec.describe 'User journey', type: :feature, acceptance: true do
     click_link 'I have updated my MSA configuration'
 
     choose t('user_journey.certificate.paste_certificate'), visible: false
-    fill_in 'certificate_value', with: cert, visible: false
+    fill_in 'certificate_value', with: certificate.value, visible: false
     click_button t('user_journey.continue')
 
     expect(page).to have_content t('user_journey.certificate.check_certificate_title')


### PR DESCRIPTION
- This is to allow self service acceptance test to use the component
   entity id specified in [Verify Hub federation configuration](https://github.com/alphagov/verify-hub-federation-config/pull/482)