### PR TITLE
Hub-419 schedule email when certificate is being used by hub

### DIFF
--- a/app/models/certificate_expiry_reminder.rb
+++ b/app/models/certificate_expiry_reminder.rb
@@ -77,10 +77,5 @@ module CertificateExpiryReminder
         )
       end
     end
-
-    def team_recipients(team_alias)
-      users = get_users_in_group(group_name: team_alias)
-      users.map { |user| user.attributes.find { |att| att.name == 'email' }.value }
-    end
   end
 end

--- a/app/models/certificate_in_use_event.rb
+++ b/app/models/certificate_in_use_event.rb
@@ -1,8 +1,32 @@
+require 'notifications/client'
+require 'auth/authentication_backend'
+require 'notify/cert_status_notifications'
 class CertificateInUseEvent < AggregatedEvent
+  include AuthenticationBackend
+  include CertStatusNotifications
   belongs_to_aggregate :certificate
   data_attributes :in_use_at
+  after_create_commit :notification_service_team_members
 
   def attributes_to_apply
     { in_use_at: Time.now }
+  end
+
+  def notification_service_team_members
+    recipients = team_recipients(certificate.component.team.team_alias)
+    Rails.logger.error("No recipients found for #{certificate.component.team.name}!") if recipients.empty?
+
+    recipients.each { |email|
+      mail_client = Notifications::Client.new(Rails.configuration.notify_key)
+      send_notification_email(
+        mail_client: mail_client,
+        certificate: certificate,
+        environment: certificate.component.environment,
+        email_address: email,
+        deadline: certificate.component.enabled_signing_certificates&.second&.x509&.not_after,
+      )
+    }
+  rescue Notifications::Client::RequestError => e
+    Rails.logger.error(e.message)
   end
 end

--- a/lib/auth/authentication_backend.rb
+++ b/lib/auth/authentication_backend.rb
@@ -213,6 +213,11 @@ module AuthenticationBackend
     []
   end
 
+  def team_recipients(team_alias)
+    users = get_users_in_group(group_name: team_alias)
+    users.map { |user| user.attributes.find { |att| att.name == 'email' }.value }
+  end
+
   def update_user_email(user_id:, email:)
     email&.downcase!
     client.admin_update_user_attributes(

--- a/lib/notify/cert_status_notifications.rb
+++ b/lib/notify/cert_status_notifications.rb
@@ -36,24 +36,22 @@ private
   def choose_template(certificate:, component_type:, is_dual_running:, deadline:)
     if certificate.signing?
       choose_template_for_signing_cert(component_type, deadline)
-    elsif component_type == COMPONENT_TYPE::SP_SHORT && !is_dual_running
-      SP_ENCRYPTION_NO_DUAL_RUNNING_TEMPLATE
     else
-      MSA_VSP_DUAL_RUNNING_SP_ENCRYPTION_TEMPLATE
+      choose_template_for_encryption_cert(component_type, is_dual_running)
     end
   end
 
   def choose_template_for_signing_cert(component_type, deadline)
     if component_type == COMPONENT_TYPE::MSA_SHORT
-      if defined?(deadline)
-        MSA_SIGNING_TEMPLATE
-      else
-        MSA_SIGNING_NO_DEADLINE_TEMPLATE
-      end
-    elsif defined?(deadline)
-      VSP_SP_SIGNING_TEMPLATE
+      defined?(deadline) ? MSA_SIGNING_TEMPLATE : MSA_SIGNING_NO_DEADLINE_TEMPLATE
     else
-      VSP_SP_SIGNING_NO_DEADLINE_TEMPLATE
+      defined?(deadline) ? VSP_SP_SIGNING_TEMPLATE : VSP_SP_SIGNING_NO_DEADLINE_TEMPLATE
+    end
+  end
+
+  def choose_template_for_encryption_cert(component_type, is_dual_running)
+    if component_type == COMPONENT_TYPE::SP_SHORT
+      is_dual_running ? MSA_VSP_DUAL_RUNNING_SP_ENCRYPTION_TEMPLATE : SP_ENCRYPTION_NO_DUAL_RUNNING_TEMPLATE
     end
   end
 end

--- a/lib/notify/cert_status_notifications.rb
+++ b/lib/notify/cert_status_notifications.rb
@@ -1,57 +1,49 @@
 module CertStatusNotifications
+  ENCRYPTION_TEMPLATE = '6626922e-3eb7-45e3-b8a9-989ba32a9178'.freeze
   MSA_SIGNING_TEMPLATE = 'db78c8a3-54c5-443a-ba93-b64c21799b4c'.freeze
   MSA_SIGNING_NO_DEADLINE_TEMPLATE = 'ib86fd33c-59c1-4ea4-b643-4a88756c21eb'.freeze
-  MSA_VSP_DUAL_RUNNING_SP_ENCRYPTION_TEMPLATE = '3514d7ae-367f-428e-96d5-4eab3e09eeed'.freeze
-  SP_ENCRYPTION_NO_DUAL_RUNNING_TEMPLATE = '2efd21a0-d3f9-4e35-a732-ff3a1c8f3f12'.freeze
   VSP_SP_SIGNING_TEMPLATE = '8342fbc4-a847-4587-932c-07065d471942'.freeze
   VSP_SP_SIGNING_NO_DEADLINE_TEMPLATE = 'a07ac619-de15-4bde-97cd-7c722f2b950b'.freeze
+  attr_accessor :personalisation
 
-  def send_notification_email(mail_client:, certificate:, environment:, email_address:, deadline:)
+  def send_notification_email(mail_client:, certificate:, email_address:)
     component = certificate.component
-    is_dual_running = component.enabled_signing_certificates.count > 1
+    second_signing_certificate = component.enabled_signing_certificates.second
+
+    @personalisation = {
+      team_name: component.team.name,
+      component: component.display_long_name,
+      environment: component.environment,
+    }
 
     template = choose_template(
       certificate: certificate,
       component_type: component.type,
-      is_dual_running: is_dual_running,
-      deadline: deadline,
+      deadline: second_signing_certificate,
     )
-
-    personalisation = {
-      team_name: component.team.name,
-      component: component.display_long_name,
-      environment: environment,
-      time_and_date: deadline,
-    }
 
     mail_client.send_email(
       email_address: email_address,
       template_id: template,
-      personalisation: personalisation,
+      personalisation: @personalisation,
     )
   end
 
 private
 
-  def choose_template(certificate:, component_type:, is_dual_running:, deadline:)
-    if certificate.signing?
-      choose_template_for_signing_cert(component_type, deadline)
-    else
-      choose_template_for_encryption_cert(component_type, is_dual_running)
-    end
-  end
+  def choose_template(certificate:, component_type:, deadline:)
+    return ENCRYPTION_TEMPLATE unless certificate.signing?
 
-  def choose_template_for_signing_cert(component_type, deadline)
     if component_type == COMPONENT_TYPE::MSA_SHORT
-      defined?(deadline) ? MSA_SIGNING_TEMPLATE : MSA_SIGNING_NO_DEADLINE_TEMPLATE
-    else
-      defined?(deadline) ? VSP_SP_SIGNING_TEMPLATE : VSP_SP_SIGNING_NO_DEADLINE_TEMPLATE
-    end
-  end
+      return MSA_SIGNING_NO_DEADLINE_TEMPLATE unless deadline.present?
 
-  def choose_template_for_encryption_cert(component_type, is_dual_running)
-    if component_type == COMPONENT_TYPE::SP_SHORT
-      is_dual_running ? MSA_VSP_DUAL_RUNNING_SP_ENCRYPTION_TEMPLATE : SP_ENCRYPTION_NO_DUAL_RUNNING_TEMPLATE
+      @personalisation.merge!(time_and_date: deadline.x509.not_after)
+      MSA_SIGNING_TEMPLATE
+    else
+      return VSP_SP_SIGNING_NO_DEADLINE_TEMPLATE unless deadline.present?
+
+      @personalisation.merge!(time_and_date: deadline.x509.not_after)
+      VSP_SP_SIGNING_TEMPLATE
     end
   end
 end

--- a/lib/notify/notification.rb
+++ b/lib/notify/notification.rb
@@ -1,5 +1,5 @@
 require 'notifications/client'
-
+require 'notify/cert_status_notifications'
 module Notification
   INVITE_TEMPLATE = "afdb4827-0f71-4588-b35d-80bd514f5bdb".freeze
   REMINDER_TEMPLATE = "bbc34127-7fca-4d78-a95b-703da58e15ce".freeze
@@ -109,19 +109,6 @@ module Notification
         user_team: team.name,
       },
      )
-  rescue Notifications::Client::RequestError => e
-    Rails.logger.error(e.message)
-  end
-
-  def send_cert_status_notification_email(certificate:, environment:, email_address:, team_name:, deadline:)
-    CertStatusNotifications.send_notification_email(
-      mail_client: mail_client,
-      certificate: certificate,
-      environment: environment,
-      email_address: email_address,
-      team_name: team_name,
-      deadline: deadline,
-    )
   rescue Notifications::Client::RequestError => e
     Rails.logger.error(e.message)
   end

--- a/spec/models/certificate_in_use_event_spec.rb
+++ b/spec/models/certificate_in_use_event_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
-
 RSpec.describe CertificateInUseEvent, type: :model do
+  include NotifySupport
   it 'is valid and persisted with hub_use_confirmation_at not nil' do
+    stub_notify_response
     certificate = create(:sp_signing_certificate)
     expect(certificate.in_use_at).to be_nil
     certificate_in_use_event = create(:certificate_in_use_event, certificate: certificate)

--- a/spec/models/certificate_in_use_event_spec.rb
+++ b/spec/models/certificate_in_use_event_spec.rb
@@ -1,6 +1,39 @@
 require 'rails_helper'
 RSpec.describe CertificateInUseEvent, type: :model do
-  include NotifySupport
+  include NotifySupport, CognitoSupport
+  let(:email) { 'test@test.com' }
+  let(:cognito_users) {
+    { users: [
+        { username: '0000',
+         attributes: [{name: "given_name", value: "Cherry"},
+                      {name: "family_name", value: "One"},
+                      {name: "email", value: email},
+                      {name: "custom:roles", value: "certmgr"}
+         ]}
+    ]}
+  }
+  let(:many_cognito_users) {
+    { users: [
+        { username: '0000',
+         attributes: [{name: "given_name", value: "Cherry"},
+                      {name: "family_name", value: "One"},
+                      {name: "email", value: email},
+                      {name: "custom:roles", value: "certmgr"}
+        ]},
+        { username: '0001',
+          attributes: [{name: "given_name", value: "Cherry"},
+                       {name: "family_name", value: "Two"},
+                       {name: "email", value: email},
+                       {name: "custom:roles", value: "certmgr"}
+        ]},
+        { username: '0002',
+            attributes: [{name: "given_name", value: "Cherry"},
+                         {name: "family_name", value: "Three"},
+                         {name: "email", value: email},
+                         {name: "custom:roles", value: "certmgr"}
+        ]}
+    ]}
+  }
   it 'is valid and persisted with hub_use_confirmation_at not nil' do
     stub_notify_response
     certificate = create(:sp_signing_certificate)
@@ -9,5 +42,187 @@ RSpec.describe CertificateInUseEvent, type: :model do
     expect(certificate_in_use_event).to be_valid
     expect(certificate_in_use_event).to be_persisted
     expect(certificate.in_use_at).not_to be_nil
+  end
+  it 'emails notification with a template having defined deadline when msa signing certificate is uploaded' do
+    stub_notify_response
+    msa_component = create(:msa_component)
+    old_signing_certificate = create(:upload_certificate_event, component: msa_component).certificate
+    stub_cognito_response(method: :list_users_in_group, payload: cognito_users)
+
+    expect(subject.class).to receive(:create).with(any_args).and_call_original.at_least(:once)
+    certificate = create(:upload_certificate_event, component: msa_component).certificate
+    component = certificate.component
+
+    expected_body = {
+      email_address: 'test@test.com',
+      template_id: 'db78c8a3-54c5-443a-ba93-b64c21799b4c',
+      personalisation: {
+        team_name: component.team.name,
+        component: component.display_long_name,
+        environment: component.environment,
+        time_and_date: component.enabled_signing_certificates.second.x509.not_after,
+      }
+    }
+    expect(expected_body[:personalisation][:time_and_date]).to be_present
+    expect(stub_notify_request(expected_body)).to have_been_made.once
+    expect(certificate.events.map(&:class)).to eq [UploadCertificateEvent, CertificateInUseEvent, CertificateNotificationSentEvent]
+  end
+  it 'emails notification with a template having defined deadline when sp signing certificate is uploaded' do
+    old_signing_certificate = create(:upload_certificate_event).certificate
+    stub_cognito_response(method: :list_users_in_group, payload: cognito_users)
+    stub_notify_response
+
+    expect(subject.class).to receive(:create).with(any_args).and_call_original.at_least(:once)
+    create(:assign_sp_component_to_service_event, sp_component_id: old_signing_certificate.component.id)
+    certificate = create(:upload_certificate_event, component: old_signing_certificate.component).certificate
+    component = certificate.component
+
+    expected_body = {
+      email_address: 'test@test.com',
+      template_id: '8342fbc4-a847-4587-932c-07065d471942',
+      personalisation: {
+        team_name: component.team.name,
+        component: component.display_long_name,
+        environment: component.environment,
+        time_and_date: component.enabled_signing_certificates.second.x509.not_after,
+      }
+    }
+    expect(expected_body[:personalisation][:time_and_date]).to be_present
+    expect(stub_notify_request(expected_body)).to have_been_made.once
+    expect(certificate.events.map(&:class)).to eq [UploadCertificateEvent, CertificateInUseEvent, CertificateNotificationSentEvent]
+  end
+  it 'emails notification with a template without defined deadline when msa signing certificate is uploaded' do
+    stub_cognito_response(method: :list_users_in_group, payload: cognito_users)
+    stub_notify_response
+
+    expect(subject.class).to receive(:create).with(any_args).and_call_original.at_least(:once)
+    certificate = create(:upload_certificate_event, component: create(:msa_component)).certificate
+    component = certificate.component
+
+    expected_body = {
+      email_address: 'test@test.com',
+      template_id: 'ib86fd33c-59c1-4ea4-b643-4a88756c21eb',
+      personalisation: {
+        team_name: component.team.name,
+        component: component.display_long_name,
+        environment: component.environment,
+      }
+    }
+
+    expect(stub_notify_request(expected_body)).to have_been_made.once
+    expect(certificate.events.map(&:class)).to eq [UploadCertificateEvent, CertificateInUseEvent, CertificateNotificationSentEvent]
+  end
+  it 'emails notification with a template without defined deadline when sp signing certificate is uploaded' do
+    stub_cognito_response(method: :list_users_in_group, payload: cognito_users)
+    stub_notify_response
+
+    expect(subject.class).to receive(:create).with(any_args).and_call_original.at_least(:once)
+    sp_component = create(:sp_component)
+    create(:assign_sp_component_to_service_event, sp_component_id: sp_component.id)
+    certificate = create(:upload_certificate_event, component: sp_component).certificate
+    component = certificate.component
+
+    expected_body = {
+      email_address: 'test@test.com',
+      template_id: 'a07ac619-de15-4bde-97cd-7c722f2b950b',
+      personalisation: {
+        team_name: component.team.name,
+        component: component.display_long_name,
+        environment: component.environment,
+      }
+    }
+
+    expect(stub_notify_request(expected_body)).to have_been_made.once
+    expect(certificate.events.map(&:class)).to eq [UploadCertificateEvent, CertificateInUseEvent, CertificateNotificationSentEvent]
+  end
+  it 'emails notification with encryption template when msa encryption certificate is replaced' do
+    stub_cognito_response(method: :list_users_in_group, payload: cognito_users)
+    stub_notify_response
+    msa_encryption_certificate = create(:msa_encryption_certificate)
+
+    expect(subject.class).to receive(:create).with(any_args).and_call_original.at_least(:once)
+    event = create(:replace_encryption_certificate_event, encryption_certificate_id: msa_encryption_certificate.id, component: msa_encryption_certificate.component)
+    component = event.component
+    certificate = component.encryption_certificate
+
+    expected_body = {
+      email_address: 'test@test.com',
+      template_id: '6626922e-3eb7-45e3-b8a9-989ba32a9178',
+      personalisation: {
+        team_name: component.team.name,
+        component: component.display_long_name,
+        environment: component.environment,
+      }
+    }
+    expect(stub_notify_request(expected_body)).to have_been_made.once
+    expect(certificate.events.map(&:class)).to eq [CertificateInUseEvent, CertificateNotificationSentEvent]
+  end
+  it 'emails notification with encryption template when sp encryption certificate is replaced' do
+    stub_cognito_response(method: :list_users_in_group, payload: cognito_users)
+    stub_notify_response
+    sp_encryption_certificate = create(:sp_encryption_certificate)
+
+    create(:assign_sp_component_to_service_event, sp_component_id: sp_encryption_certificate.component.id)
+    expect(subject.class).to receive(:create).with(any_args).and_call_original.at_least(:once)
+    event = create(:replace_encryption_certificate_event, encryption_certificate_id: sp_encryption_certificate.id, component: sp_encryption_certificate.component)
+    component = event.component
+    certificate = component.encryption_certificate
+    expected_body = {
+      email_address: 'test@test.com',
+      template_id: '6626922e-3eb7-45e3-b8a9-989ba32a9178',
+      personalisation: {
+        team_name: component.team.name,
+        component: component.display_long_name,
+        environment: component.environment,
+      }
+    }
+    expect(stub_notify_request(expected_body)).to have_been_made.once
+    expect(certificate.events.map(&:class)).to eq [CertificateInUseEvent, CertificateNotificationSentEvent]
+  end
+  it 'emails notification sent to 3 team members when certificate is replaced' do
+    stub_cognito_response(method: :list_users_in_group, payload: many_cognito_users)
+    stub_notify_response
+    sp_encryption_certificate = create(:sp_encryption_certificate)
+
+    create(:assign_sp_component_to_service_event, sp_component_id: sp_encryption_certificate.component.id)
+    expect(subject.class).to receive(:create).with(any_args).and_call_original.at_least(:once)
+    event = create(:replace_encryption_certificate_event, encryption_certificate_id: sp_encryption_certificate.id, component: sp_encryption_certificate.component)
+    component = event.component
+    certificate = component.encryption_certificate
+    expected_body = {
+      email_address: 'test@test.com',
+      template_id: '6626922e-3eb7-45e3-b8a9-989ba32a9178',
+      personalisation: {
+        team_name: component.team.name,
+        component: component.display_long_name,
+        environment: component.environment,
+      }
+    }
+    expect(stub_notify_request(expected_body)).to have_been_made.times(3)
+    expect(certificate.events.map(&:class)).to eq [CertificateInUseEvent, CertificateNotificationSentEvent]
+  end
+  it 'logs error when mail client is return 404' do
+    stub_notify_error_response
+    stub_cognito_response(method: :list_users_in_group, payload: cognito_users)
+    sp_encryption_certificate = create(:sp_encryption_certificate)
+    create(:assign_sp_component_to_service_event, sp_component_id: sp_encryption_certificate.component.id)
+
+    expect(subject.class).to receive(:create).with(any_args).and_call_original.at_least(:once)
+    expect(Rails.logger).to receive(:error).with(any_args).and_call_original.at_least(:once)
+
+    event = create(:replace_encryption_certificate_event, encryption_certificate_id: sp_encryption_certificate.id, component: sp_encryption_certificate.component)
+    component = event.component
+    certificate = component.encryption_certificate
+
+    expected_body = {
+      email_address: 'test@test.com',
+      template_id: '6626922e-3eb7-45e3-b8a9-989ba32a9178',
+      personalisation: {
+        team_name: component.team.name,
+        component: component.display_long_name,
+        environment: component.environment,
+      }
+    }
+    expect(stub_notify_request(expected_body)).to have_been_made.once
   end
 end

--- a/spec/models/component_spec.rb
+++ b/spec/models/component_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Component, type: :model do
-  include StubHubConfigApiSupport
+  include StubHubConfigApiSupport, NotifySupport
   context '#to_service_metadata' do
     before(:each) do
       SpComponent.destroy_all
@@ -12,6 +12,7 @@ RSpec.describe Component, type: :model do
     let(:sp_component) { create(:sp_component) }
     let(:root) { PKI.new }
     let!(:upload_signing_certificate_event_1) do
+      stub_notify_response
       create(:upload_certificate_event,
         usage: CERTIFICATE_USAGE::SIGNING,
         value: root.generate_encoded_cert(expires_in: 6.months),
@@ -152,6 +153,7 @@ RSpec.describe Component, type: :model do
     before(:each) do
       SpComponent.destroy_all
       MsaComponent.destroy_all
+      stub_notify_response
     end
 
     let(:root) { PKI.new }

--- a/spec/support/notify_support.rb
+++ b/spec/support/notify_support.rb
@@ -6,6 +6,11 @@ module NotifySupport
       .to_return(status: 200, body: "{}", headers: {})
   end
 
+  def stub_notify_error_response
+    stub_request(:post, NOTIFY_ENDPOINT)
+      .to_return(status: 404, body: "{'errors': 'an error'}", headers: {})
+  end
+
   def stub_notify_request(body)
     a_request(:post, NOTIFY_ENDPOINT).with(body: body.to_json)
   end

--- a/spec/system/user_visits_events_page_spec.rb
+++ b/spec/system/user_visits_events_page_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'the events page', type: :system do
-  include CertificateSupport
+  include CertificateSupport, NotifySupport
   let(:component) { create(:msa_component) }
   let(:root) { PKI.new }
   before(:each) do
@@ -12,7 +12,7 @@ RSpec.describe 'the events page', type: :system do
     good_cert_1 = root.generate_encoded_cert(expires_in: 2.months)
     good_cert_2 = root.generate_encoded_cert(expires_in: 2.months)
     good_cert_3 = root.generate_encoded_cert(expires_in: 2.months)
-
+    stub_notify_response
     UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: good_cert_1, component: component)
     UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::SIGNING, value: good_cert_2, component: component)
     UploadCertificateEvent.create(usage: CERTIFICATE_USAGE::ENCRYPTION, value: good_cert_3, component: component)

--- a/spec/system/visit_index_page_spec.rb
+++ b/spec/system/visit_index_page_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'IndexPage', type: :system do
+  include NotifySupport
   let(:msa_signing_certificate) { create(:msa_signing_certificate) }
   let(:msa_encryption_certificate) { create(:msa_encryption_certificate) }
   let(:sp_encryption_certificate) { create(:sp_encryption_certificate) }
@@ -9,6 +10,7 @@ RSpec.describe 'IndexPage', type: :system do
     SpComponent.destroy_all
     MsaComponent.destroy_all
     login_gds_user
+    stub_notify_response
     create(:replace_encryption_certificate_event,
       component: sp_encryption_certificate.component,
       encryption_certificate_id: sp_encryption_certificate.id


### PR DESCRIPTION
**What?**

When Self Service polls the hub successful and a result is acquired. The app needs to inform the service by emailing members of the team that their certificate has been deployed successfully.

**Why?**

This would inform all service team members and provide a link into the app where they can view the certificate and continue with other activities associated with managing their certificates.

**How?**
Immediately after the in_use_at field has been updated an email would be sent to each team member.

- An email is sent to each member of the service team when the in_use_at field is updated
- The appropriate email template is used in to sending the email notification