### PR TITLE
ZD-3912824 De-associate deleted component reference

### DIFF
--- a/app/models/msa_component.rb
+++ b/app/models/msa_component.rb
@@ -1,6 +1,6 @@
 class MsaComponent < Component
   has_many :certificates, as: :component
-  has_many :services
+  has_many :services, dependent: :nullify
 
 private
 

--- a/app/models/sp_component.rb
+++ b/app/models/sp_component.rb
@@ -1,6 +1,6 @@
 class SpComponent < Component
   has_many :certificates, as: :component
-  has_many :services
+  has_many :services, dependent: :nullify
 
   def view_component_type(vsp)
     vsp ? COMPONENT_TYPE::VSP_SHORT : COMPONENT_TYPE::SP_SHORT

--- a/spec/models/assign_msa_component_to_service_spec.rb
+++ b/spec/models/assign_msa_component_to_service_spec.rb
@@ -37,6 +37,14 @@ RSpec.describe AssignMsaComponentToServiceEvent, type: :model do
     expect(event.errors.full_messages.first).to eq('Service Wrong component type')
   end
 
+  it 'deassociates msa component from the service' do
+    component = create(:msa_component)
+    event = create(:assign_msa_component_to_service_event, msa_component_id: component.id)
+    expect(event.service.msa_component_id).to eq(component.id)
+    DeleteComponentEvent.create(component: component)
+    expect(Service.find_by_id(event.service).msa_component_id).to be_nil
+  end
+
   context '#trigger_publish_event' do
     it 'when component is assigned to service is enabled' do
       event = create(:assign_msa_component_to_service_event, service: service, msa_component_id: component_1.id)

--- a/spec/models/assign_sp_component_to_service_spec.rb
+++ b/spec/models/assign_sp_component_to_service_spec.rb
@@ -37,6 +37,14 @@ RSpec.describe AssignSpComponentToServiceEvent, type: :model do
     expect(event.errors.full_messages.first).to eq('Service Wrong component type')
   end
 
+  it 'deassociates sp component from the service' do
+    component = create(:sp_component)
+    event = create(:assign_sp_component_to_service_event, service: service, sp_component_id: component.id)
+    expect(event.service.sp_component_id).to eq(component.id)
+    DeleteComponentEvent.create(component: component)
+    expect(Service.find_by_id(event.service).sp_component_id).to be_nil
+  end
+
   context '#trigger_publish_event' do
     it 'when component is assigned to service is enabled' do
       event = create(:assign_sp_component_to_service_event, service: service, sp_component_id: component_1.id)


### PR DESCRIPTION
Related to https://govuk.zendesk.com/agent/tickets/3912824
This is to ensure that when a component that has an association to a service is deleted.
The association i.e the component reference in the service is removed.
This would allow re-associating a new component to the existing service.