### PR TITLE
Add a script to check integrity when onboarding a new service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ yarn-error.log
 
 # cached rubocop rules pulled locally
 .rubocop-h*
+
+# temp file for remote comparison
+tools/temp_remote_metadata.json

--- a/README.md
+++ b/README.md
@@ -45,6 +45,27 @@ To automagically fix any issues use the `-a` flag:
 
 `bundle exec rubocop -a`
 
+### Integrity checker when on-boarding a service
+
+The `/tools` directory contains a script `./check.rb` which allows us to check whether a service
+has been on-boarded correctly to the self-service app. There are a few steps required:
+
+1. Fully on-board the service (or MSA) to self-service, as per the [team manual instructions](https://verify-team-manual.cloudapps.digital/documentation/support/self-service/onboard-new-service.html)
+2. Make sure the [verify-hub-federation-config]() repository is on master and up-to-date
+3. Login to AWS using the gds-cli
+    - `gds aws verify-prod-a -e` for the production environment
+    - `gds aws verify-integration-a -e` for the integration environment
+4. Run the script using the environment and entityId you wish to check for
+
+    `./check.rb <prod | integration> <entityId> [--msa optional]`
+
+    For example:
+
+    `./check.rb prod http://prod-entity-id`
+
+The script will output whether the hub-fed-config is matching the config which self-service is publishing.
+This script can only be used while the certs are still in the hub-fed-config (i.e. before they were removed after the on-boarding)
+
 ## Licence
 
 [MIT License](LICENCE)

--- a/tools/check.rb
+++ b/tools/check.rb
@@ -8,8 +8,10 @@ ENVIRONMENT = ARGV[0]
 ENTITY_ID = ARGV[1]
 MSA = ARGV[2] == '--msa'
 
-if ENVIRONMENT.nil?
+if ENVIRONMENT.nil? || File.basename(Dir.getwd) != "tools"
   puts "USAGE: ./check.rb <environment> <entity_id> [--msa optional]"
+  puts "Needs to be run from the /tools directory"
+  exit 1
 end
 
 unless ENVIRONMENTS.include?(ENVIRONMENT)

--- a/tools/check.rb
+++ b/tools/check.rb
@@ -1,0 +1,67 @@
+#!/usr/bin/env ruby
+
+require 'yaml'
+require 'json'
+
+ENVIRONMENTS = ["prod", "integration"]
+ENVIRONMENT = ARGV[0]
+ENTITY_ID = ARGV[1]
+
+unless ENVIRONMENTS.include?(ENVIRONMENT)
+  puts "Invalid environment, accepted values are: #{ENVIRONMENTS}"
+  exit 1
+end
+
+if ENTITY_ID.nil?
+  puts "EntityID is missing"
+  exit 1
+end
+
+def compare(config)
+  entity_id = config['entityId']
+  certs = get_fed_config_certs(config)
+  published_certs = get_published_certs(entity_id)
+  puts "MISMATCH! Encryption certificates are not matching" unless certs[:encryption] == published_certs[:encryption]
+  puts "MISMATCH! Singing certificates are not matching" unless certs[:signing].sort == published_certs[:signing].sort
+  return true if certs[:encryption] == published_certs[:encryption] && certs[:signing].sort == published_certs[:signing].sort
+  false
+end
+
+def get_published_certs(entity_id)
+  json = `aws s3 cp s3://govukverify-self-service-#{ENVIRONMENT}-config-metadata/verify_services_metadata.json temp_remote_metadata.json`
+  published_metadata = JSON.parse(File.read('temp_remote_metadata.json'))
+  sp_id = published_metadata["connected_services"].find{ |component| component['entity_id'] == entity_id}&.fetch('service_provider_id', nil)
+  if sp_id.nil?
+    puts "ERROR! Component with the entityid is not being published by self-service"
+  end
+  certs = published_metadata["service_providers"].find{ |sp| sp['id'] == sp_id}
+  {
+    signing: certs.fetch('signing_certificates', [])&.map{|c| c['value']},
+    encryption: certs.dig('encryption_certificate', 'value')
+  }
+end
+
+def get_fed_config_certs(config)
+  {
+    signing: config.fetch('signatureVerificationCertificates', [])&.map{|c| c['x509']},
+    encryption: config.dig('encryptionCertificate', 'x509')
+  }
+end
+
+hub_fed_config_directory = "../../verify-hub-federation-config/configuration/config-service-data/#{ENVIRONMENT}/transactions/"
+config_files = Dir.children(hub_fed_config_directory)
+all_good = false
+
+config_files.each do |file|
+  config = YAML.load_file(File.join(hub_fed_config_directory, file))
+  if config['entityId'] == ENTITY_ID
+    all_good = compare(config)
+    break
+  end
+end
+
+if all_good
+  puts "WELL DONE! ALL LOOKS OK!"
+else
+  puts "Oh no, something is not correct"
+end

--- a/tools/check.rb
+++ b/tools/check.rb
@@ -3,16 +3,15 @@
 require 'yaml'
 require 'json'
 
-HUB_FED_CONFIG_DIRECTORY = "../../verify-hub-federation-config"
+HUB_FED_CONFIG_DIRECTORY = File.join(__dir__, '../../verify-hub-federation-config')
 
 ENVIRONMENTS = ["prod", "integration"]
 ENVIRONMENT = ARGV[0]
 ENTITY_ID = ARGV[1]
 MSA = ARGV[2] == '--msa'
 
-if ENVIRONMENT.nil? || File.basename(Dir.getwd) != "tools"
+if ENVIRONMENT.nil?
   puts "USAGE: ./check.rb <environment> <entity_id> [--msa optional]"
-  puts "Needs to be run from the /tools directory"
   exit 1
 end
 
@@ -30,8 +29,6 @@ Dir.chdir(HUB_FED_CONFIG_DIRECTORY){
     exit 1
   end
 }
-
-`git rev-parse --abbrev-ref HEAD`
 
 unless ENVIRONMENTS.include?(ENVIRONMENT)
   puts "Invalid environment, accepted values are: #{ENVIRONMENTS}"


### PR DESCRIPTION
- added a first stab of a script which checks whether everything is ok
- it compares the hub-fed-config with the remote config published by the self-service tool

Pre-requisite:
- logged in to AWS using gds-cli, to the account for which we're doing check

To run:
`./check <env> <entity_id>`

e.g.
`./check.rb prod https://www.fitness-to-drive.service.gov.uk/renew`

Ignoring MSA for the moment