### PR TITLE
Updated the change service event to publish metadata on save.

### DIFF
--- a/app/models/change_service_event.rb
+++ b/app/models/change_service_event.rb
@@ -2,6 +2,7 @@ class ChangeServiceEvent < AggregatedEvent
   belongs_to_aggregate :service
   data_attributes :attributes_changed
   validate :validate_changes
+  after_save TriggerMetadataEventCallback.publish
 
   def attributes_to_apply
     self.data = attributes_changed

--- a/app/models/trigger_metadata_event_callback.rb
+++ b/app/models/trigger_metadata_event_callback.rb
@@ -1,8 +1,11 @@
 class TriggerMetadataEventCallback
   def after_save(model)
+    env = environment(model)
+    return if env.nil?
+
     PublishServicesMetadataEvent.create(
       event_id: model.id,
-      environment: environment(model),
+      environment: env,
     )
   end
 
@@ -15,10 +18,12 @@ private
   def environment(model)
     if model.aggregate.respond_to?(:component)
       model.aggregate.component.environment
-    elsif model.respond_to?(:service) && model.respond_to?(:sp_component_id)
-      model.service.sp_component.environment
-    elsif model.respond_to?(:service) && model.respond_to?(:msa_component_id)
-      model.service.msa_component.environment
+    elsif model.respond_to?(:service)
+      if model.service.sp_component_id.present?
+        model.service.sp_component.environment
+      elsif model.service.msa_component_id.present?
+        model.service.msa_component.environment
+      end
     else
       model.aggregate.environment
     end


### PR DESCRIPTION
Fix for a bug that was discovered in verify self service which meant when you updated a services metadata (specifically its entity_id) it didn't publish the results to the S3 bucket.  This PR should fix that issue.