### PR TITLE
HUB-540 Associated radio buttons with values

### DIFF
--- a/app/views/certificates/new/_msa_cert.html.erb
+++ b/app/views/certificates/new/_msa_cert.html.erb
@@ -6,11 +6,11 @@
     <div class="govuk-radios govuk-radios--inline">
       <div class="govuk-radios__item ">
         <%= f.radio_button :usage, CERTIFICATE_USAGE::SIGNING, class: 'govuk-radios__input'  %>
-        <%= f.label :usage, CERTIFICATE_USAGE::SIGNING, class: 'govuk-label govuk-radios__label' %>
+        <%= f.label :usage, CERTIFICATE_USAGE::SIGNING, value: CERTIFICATE_USAGE::SIGNING, class: 'govuk-label govuk-radios__label' %>
       </div>
       <div class="govuk-radios__item">
         <%= f.radio_button :usage, CERTIFICATE_USAGE::ENCRYPTION, class: 'govuk-radios__input'  %>
-        <%= f.label :usage, CERTIFICATE_USAGE::ENCRYPTION, class: 'govuk-label govuk-radios__label' %>
+        <%= f.label :usage, CERTIFICATE_USAGE::ENCRYPTION, value: CERTIFICATE_USAGE::ENCRYPTION, class: 'govuk-label govuk-radios__label' %>
       </div>
     </div>
   </div>

--- a/app/views/certificates/new/_sp_cert.html.erb
+++ b/app/views/certificates/new/_sp_cert.html.erb
@@ -6,11 +6,11 @@
     <div class="govuk-radios govuk-radios--inline">
       <div class="govuk-radios__item ">
         <%= f.radio_button :usage, CERTIFICATE_USAGE::SIGNING, class: 'govuk-radios__input'  %>
-        <%= f.label :usage, CERTIFICATE_USAGE::SIGNING, class: 'govuk-label govuk-radios__label' %>
+        <%= f.label :usage, CERTIFICATE_USAGE::SIGNING, value: CERTIFICATE_USAGE::SIGNING, class: 'govuk-label govuk-radios__label' %>
       </div>
       <div class="govuk-radios__item">
         <%= f.radio_button :usage, CERTIFICATE_USAGE::ENCRYPTION, class: 'govuk-radios__input'  %>
-        <%= f.label :usage, CERTIFICATE_USAGE::ENCRYPTION, class: 'govuk-label govuk-radios__label' %>
+        <%= f.label :usage, CERTIFICATE_USAGE::ENCRYPTION, value: CERTIFICATE_USAGE::ENCRYPTION, class: 'govuk-label govuk-radios__label' %>
       </div>
     </div>
   </div>

--- a/app/views/shared/_component_environments.erb
+++ b/app/views/shared/_component_environments.erb
@@ -4,7 +4,7 @@
     <% @hub_environments.each do |hub_environment| %>
       <div class="govuk-radios__item">
         <%= f.radio_button :environment, hub_environment, class: 'govuk-radios__input'  %>
-        <%= f.label :environment, hub_environment.capitalize, class: 'govuk-label govuk-radios__label' %>
+        <%= f.label :environment, hub_environment.capitalize, value: hub_environment, class: 'govuk-label govuk-radios__label' %>
       </div>
     <% end %>
   </div>

--- a/app/views/sp_components/edit.html.erb
+++ b/app/views/sp_components/edit.html.erb
@@ -19,11 +19,11 @@
       <div class="govuk-radios govuk-radios--inline">
         <div class="govuk-radios__item ">
           <%= f.radio_button :vsp, true, class: 'govuk-radios__input', checked: @component.vsp %>
-          <%= f.label :vsp, COMPONENT_TYPE::VSP_SHORT, class: 'govuk-label govuk-radios__label' %>
+          <%= f.label :vsp, COMPONENT_TYPE::VSP_SHORT, value: true, class: 'govuk-label govuk-radios__label' %>
         </div>
         <div class="govuk-radios__item">
           <%= f.radio_button :vsp, false, class: 'govuk-radios__input', checked: !@component.vsp %>
-          <%= f.label :vsp, COMPONENT_TYPE::SP_SHORT, class: 'govuk-label govuk-radios__label' %>
+          <%= f.label :vsp, COMPONENT_TYPE::SP_SHORT, value: false, class: 'govuk-label govuk-radios__label' %>
         </div>
       </div>
     </div>

--- a/app/views/sp_components/new.html.erb
+++ b/app/views/sp_components/new.html.erb
@@ -19,11 +19,11 @@
       <div class="govuk-radios govuk-radios--inline">
         <div class="govuk-radios__item ">
           <%= f.radio_button :component_type, COMPONENT_TYPE::VSP, class: 'govuk-radios__input' %>
-          <%= f.label :component_type, COMPONENT_TYPE::VSP_SHORT, class: 'govuk-label govuk-radios__label' %>
+          <%= f.label :component_type, COMPONENT_TYPE::VSP_SHORT, value: COMPONENT_TYPE::VSP, class: 'govuk-label govuk-radios__label' %>
         </div>
         <div class="govuk-radios__item">
           <%= f.radio_button :component_type, COMPONENT_TYPE::SP, class: 'govuk-radios__input'  %>
-          <%= f.label :component_type, COMPONENT_TYPE::SP_SHORT, class: 'govuk-label govuk-radios__label' %>
+          <%= f.label :component_type, COMPONENT_TYPE::SP_SHORT, value: COMPONENT_TYPE::SP, class: 'govuk-label govuk-radios__label' %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This fixes a bug in Self Service where by clicking on a radio button
label didn't involke the assumed associated radio button