### PR TITLE
HUB-515: Connection pool timeout in self service

### DIFF
--- a/app/models/polling/scheduler.rb
+++ b/app/models/polling/scheduler.rb
@@ -7,7 +7,7 @@ module Polling
 
     def initialize(opts = { overlap: false, timeout: DEFAULT_TIMEOUT, times: DEFAULT_NUMBER_POLLS, frequency: Rails.configuration.scheduler_polling_interval })
       @opts = opts
-      @rufus_scheduler ||= Rufus::Scheduler.new(frequency: opts[:frequency])
+      @rufus_scheduler ||= Rufus::Scheduler.new(frequency: opts[:frequency], max_work_threads: ENV['DB_POOL'] || ENV['RAILS_MAX_THREADS'] || DEFAULT_NUMBER_POLLS)
       @rufus_scheduler.stderr = StringIO.new
     end
 

--- a/app/models/polling/scheduler.rb
+++ b/app/models/polling/scheduler.rb
@@ -3,11 +3,12 @@ module Polling
   class Scheduler
     attr_reader :rufus_scheduler, :job, :time, :opts
     DEFAULT_TIMEOUT = '100.0s'.freeze
-    DEFAULT_NUMBER_POLLS = 12
-
+    DEFAULT_NUMBER_POLLS = 8
+    # MAX_WORK_THREADS is set to a value substantially lower than db connection pool, so rufus is limited to creating only 2 connections from the pool
+    MAX_WORK_THREADS = 2
     def initialize(opts = { overlap: false, timeout: DEFAULT_TIMEOUT, times: DEFAULT_NUMBER_POLLS, frequency: Rails.configuration.scheduler_polling_interval })
       @opts = opts
-      @rufus_scheduler ||= Rufus::Scheduler.new(frequency: opts[:frequency], max_work_threads: ENV['DB_POOL'] || ENV['RAILS_MAX_THREADS'] || DEFAULT_NUMBER_POLLS)
+      @rufus_scheduler ||= Rufus::Scheduler.new(frequency: opts[:frequency], max_work_threads: MAX_WORK_THREADS)
       @rufus_scheduler.stderr = StringIO.new
     end
 
@@ -19,6 +20,8 @@ module Polling
     end
 
     def perform(action = -> {})
+      #rufus starts a new thread for every job, active record does not share connection between threads
+      # below allows the connection in the rufus thread to be released back to the pool when the thread is done
       ActiveRecord::Base.connection_pool.with_connection do
         @job = @rufus_scheduler.method("schedule_#{@mode}")
                               .call(time, **opts, &action)

--- a/app/models/polling/scheduler.rb
+++ b/app/models/polling/scheduler.rb
@@ -19,8 +19,10 @@ module Polling
     end
 
     def perform(action = -> {})
-      @job = @rufus_scheduler.method("schedule_#{@mode}")
-                            .call(time, **opts, &action)
+      ActiveRecord::Base.connection_pool.with_connection do
+        @job = @rufus_scheduler.method("schedule_#{@mode}")
+                              .call(time, **opts, &action)
+      end
       self
     rescue Rufus::Scheduler::NotRunningError => e
       rufus_scheduler.on_error(rufus_scheduler, e)

--- a/config/database.yml
+++ b/config/database.yml
@@ -14,7 +14,7 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 12 } %>
   timeout: 5000
 
 development:
@@ -35,4 +35,4 @@ production:
   password: <%= ENV['DATABASE_PASSWORD'] %>
   database: <%= ENV['DATABASE_NAME'] %>
   host: <%= ENV['DATABASE_HOST'] %>
-  pool: <%= ENV['DB_POOL'] || ENV['RAILS_MAX_THREADS'] || 10 %>
+  pool: <%= ENV['DB_POOL'] || ENV['RAILS_MAX_THREADS'] || 12 %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -156,6 +156,6 @@ Rails.application.configure do
     CERT_STATUS_UPDATER = CertStatusUpdater.new
   end
 
-  config.scheduler_polling_interval =  ENV.fetch('SCHEDULER_POLLING_INTERVAL','15s')
+  config.scheduler_polling_interval = ENV.fetch('SCHEDULER_POLLING_INTERVAL', '15s')
   config.authentication_header = ENV.fetch('SELF_SERVICE_AUTHENTICATION_HEADER', nil)
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -58,7 +58,7 @@ Rails.application.configure do
   config.cognito_aws_secret_access_key = ENV['COGNITO_AWS_SECRET_ACCESS_KEY']
   config.cognito_client_id = ENV['AWS_COGNITO_CLIENT_ID']
   config.cognito_user_pool_id = ENV['AWS_COGNITO_USER_POOL_ID']
-  config.scheduler_polling_interval =  ENV.fetch('SCHEDULER_POLLING_INTERVAL','1s')
+  config.scheduler_polling_interval = ENV.fetch('SCHEDULER_POLLING_INTERVAL', '1s')
   config.notify_key = 'test-11111111-1111-1111-1111-111111111111-11111111-1111-1111-1111-111111111111'
   config.app_url = 'www.test.com'
 

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -4,7 +4,7 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
+threads_count = ENV.fetch("RAILS_MAX_THREADS") { 12 }
 threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.

--- a/spec/models/publish_services_event_metadata_spec.rb
+++ b/spec/models/publish_services_event_metadata_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe PublishServicesMetadataEvent, type: :model do
     it 'creates a valid event which contains hard-coded data' do
       expect(event.data).to include(
         'event_id',
-        'services_metadata'
+        'services_metadata',
       )
       expect(event.data['services_metadata']).to include('published_at')
     end
@@ -54,7 +54,7 @@ RSpec.describe PublishServicesMetadataEvent, type: :model do
 
     it 'when environment is set to integration on component' do
       expect(
-        SelfService.service(:storage_client)
+        SelfService.service(:storage_client),
       ).to receive(:put_object).with(hash_including(bucket: "integration-bucket"))
 
       PublishServicesMetadataEvent.create(event_id: 0, environment: 'integration')
@@ -63,7 +63,7 @@ RSpec.describe PublishServicesMetadataEvent, type: :model do
     it 'when environment is set to production on component' do
       login_current_user
       expect(
-        SelfService.service(:storage_client)
+        SelfService.service(:storage_client),
       ).to receive(:put_object).with(hash_including(bucket: "production-bucket"))
 
       PublishServicesMetadataEvent.create(event_id: 0, environment: 'production')
@@ -143,7 +143,6 @@ RSpec.describe PublishServicesMetadataEvent, type: :model do
     after(:each) do
       SpComponent.destroy_all
       MsaComponent.destroy_all
-      SCHEDULER.rufus_scheduler.shutdown(:kill)
     end
 
     context 'does not occur' do
@@ -165,7 +164,7 @@ RSpec.describe PublishServicesMetadataEvent, type: :model do
         it 'called once and calls hub to update certificate in_use_at' do
           stub_signing_certificates_hub_request(
             environment: sp_signing_certificate.component.environment,
-            entity_id: service.entity_id
+            entity_id: service.entity_id,
           )
             .to_return(body: hub_response_for_signing(entity_id: service.entity_id, value: sp_signing_certificate.value))
 
@@ -178,7 +177,7 @@ RSpec.describe PublishServicesMetadataEvent, type: :model do
         it 'called once and calls hub exactly 3 times until certificate is in use' do
           stub_signing_certificates_hub_request(
             environment: sp_signing_certificate.component.environment,
-            entity_id: service.entity_id
+            entity_id: service.entity_id,
           )
             .to_return(status: 404)
             .times(2).then
@@ -197,7 +196,7 @@ RSpec.describe PublishServicesMetadataEvent, type: :model do
         it 'called many times and calls hub exactly 3 times until certificate is in use' do
           stub_signing_certificates_hub_request(
             environment: sp_signing_certificate.component.environment,
-            entity_id: service.entity_id
+            entity_id: service.entity_id,
           )
             .to_return(status: 404)
             .times(2).then
@@ -217,7 +216,7 @@ RSpec.describe PublishServicesMetadataEvent, type: :model do
         it 'called once and calls hub but certificate is never in use when response not successful' do
           stub_signing_certificates_hub_request(
             environment: sp_signing_certificate.component.environment,
-            entity_id: service.entity_id
+            entity_id: service.entity_id,
           )
             .to_return(status: 404, body: "")
             .times(3)
@@ -234,7 +233,7 @@ RSpec.describe PublishServicesMetadataEvent, type: :model do
         it 'called once and polls hub to update certificate in_use_at' do
           stub_encryption_certificate_hub_request(
             environment: new_msa_encryption_certificate.component.environment,
-            entity_id: new_msa_encryption_certificate.component.entity_id
+            entity_id: new_msa_encryption_certificate.component.entity_id,
           )
           .to_return(body: hub_response_for_encryption(entity_id: new_msa_encryption_certificate.component.entity_id, value: new_msa_encryption_certificate.value))
 
@@ -247,7 +246,7 @@ RSpec.describe PublishServicesMetadataEvent, type: :model do
         it 'called once and polls hub exactly 3 times until certificate is in use' do
           stub_encryption_certificate_hub_request(
             environment: new_msa_encryption_certificate.component.environment,
-            entity_id: new_msa_encryption_certificate.component.entity_id
+            entity_id: new_msa_encryption_certificate.component.entity_id,
           )
             .to_return(status: 404)
             .times(2).then
@@ -268,7 +267,7 @@ RSpec.describe PublishServicesMetadataEvent, type: :model do
         it 'called many times and polls hub exactly 3 times until certificate is in use' do
           stub_encryption_certificate_hub_request(
             environment: new_msa_encryption_certificate.component.environment,
-            entity_id: new_msa_encryption_certificate.component.entity_id
+            entity_id: new_msa_encryption_certificate.component.entity_id,
           )
             .to_return(status: 404)
             .times(2).then
@@ -288,7 +287,7 @@ RSpec.describe PublishServicesMetadataEvent, type: :model do
         it 'called once and polls hub but certificate is never in use when response not successful' do
           stub_encryption_certificate_hub_request(
             environment: new_msa_encryption_certificate.component.environment,
-            entity_id: new_msa_encryption_certificate.component.entity_id
+            entity_id: new_msa_encryption_certificate.component.entity_id,
           )
             .to_return(status: 404)
             .times(3)
@@ -305,7 +304,7 @@ RSpec.describe PublishServicesMetadataEvent, type: :model do
         it 'called once and polls hub to update certificate in_use_at' do
           stub_signing_certificates_hub_request(
             environment: msa_signing_certificate.component.environment,
-            entity_id: msa_signing_certificate.component.entity_id
+            entity_id: msa_signing_certificate.component.entity_id,
           )
             .to_return(body: hub_response_for_signing(entity_id: msa_signing_certificate.component.entity_id, value: msa_signing_certificate.value))
 
@@ -318,7 +317,7 @@ RSpec.describe PublishServicesMetadataEvent, type: :model do
         it 'called once and polls hub exactly 4 times until certificate is in use' do
           stub_signing_certificates_hub_request(
             environment: msa_signing_certificate.component.environment,
-            entity_id: msa_signing_certificate.component.entity_id
+            entity_id: msa_signing_certificate.component.entity_id,
           )
             .to_return(status: 404)
             .times(2).then
@@ -335,7 +334,7 @@ RSpec.describe PublishServicesMetadataEvent, type: :model do
         it 'called once and polls hub but certificate is never in use when response not successful' do
           stub_signing_certificates_hub_request(
             environment: msa_signing_certificate.component.environment,
-            entity_id: msa_signing_certificate.component.entity_id
+            entity_id: msa_signing_certificate.component.entity_id,
           )
             .to_return(status: 404)
             .times(3)


### PR DESCRIPTION
### [ HUB-515: Investigate Connection pool timeout in Self Service ](https://govukverify.atlassian.net/browse/HUB-515)
**What**
see
https://sentry.tools.signin.service.gov.uk/verify/prod-self-service/issues/4293)

https://sentry.tools.signin.service.gov.uk/verify/prod-self-service/issues/4291

https://sentry.tools.signin.service.gov.uk/verify/prod-self-service/issues/4292

https://sentry.tools.signin.service.gov.uk/verify/prod-self-service/issues/4293

When Rufus-scheduler run a schedule or piece of code, it creates a new thread. Self service app is configured to continue to poll the hub at 15s interval for a maximum of 12 times. During this period it interacts with the self service database and potentially a new thread with a connection to the database. Rufus scheduler also has a `max_work_threads` which is 28 by default.
The Active record database `connection pooling` and Puma web server `thread_count` are both set to `RAILS_MAX_THREADS` ENV variable.

The `max_work_threads` setting of Rufus-scheduler is currently higher than the value of the `RAILS_MAX_THREADS` ENV and this leads to the error

_could not obtain a connection from the pool within 5.000 seconds (waited 5.000 seconds); all pooled connections were in use_

**How**
To solve this problem the `max_work_threads` setting in the rufus-scheduler must be much lower than connection pool i.e. `MAX_WORK_THREADS` is set to a value of 2.
The current rufus job is also explicitly configured to release Active record database connection once done back to pool.
