### PR TITLE
HUB-711: Fix broken URL in the password reset email

### DIFF
--- a/lib/notify/notification.rb
+++ b/lib/notify/notification.rb
@@ -90,7 +90,7 @@ module Notification
       template_id: ADMIN_RESET_USER_PASSWORD_TEMPLATE,
       personalisation: {
         first_name: first_name,
-        reset_url: "[#{url}#{reset_password_path}](#{reset_url})",
+        reset_url: "[#{url}#{reset_password_path}](#{url}#{reset_url})",
       },
      )
   rescue Notifications::Client::RequestError => e

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -251,7 +251,7 @@ RSpec.describe UsersController, type: :controller do
           template_id: "335cc196-0260-493a-9fc7-7440a7110e7e",
           personalisation: {
             first_name: "Cherry",
-            reset_url: "[http://www.test.com/reset-password](#{force_user_reset_password_path(email: 'cherry.one@test.com', reset_by_admin: true)})",
+            reset_url: "[http://www.test.com/reset-password](http://www.test.com#{force_user_reset_password_path(email: 'cherry.one@test.com', reset_by_admin: true)})",
           }
         }
         post :reset_user_password, params: { user_id: user_id }


### PR DESCRIPTION
When a user’s password reset is initiated through team member management, the email is delivered to that user with a broken link. 

Discovered that the URL was missing the first part of the address:
<img width="1054" alt="Screenshot 2020-09-15 at 11 42 42" src="https://user-images.githubusercontent.com/24409958/93201069-9227a880-f748-11ea-8275-90399072f870.png">

