### PR TITLE
HUB-713: Fix broken admin links

### DIFF
--- a/app/controllers/certificates_controller.rb
+++ b/app/controllers/certificates_controller.rb
@@ -11,6 +11,10 @@ class CertificatesController < ApplicationController
     )
   end
 
+  def show
+    @certificate = Certificate.find_by_id(params[:id])
+  end
+
   def create
     @upload = UploadCertificateEvent.create(upload_params)
     if @upload.valid?

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -8,6 +8,10 @@ class TeamsController < ApplicationController
     @team = NewTeamEvent.new
   end
 
+  def show
+    @team = Team.find_by_id(params[:id])
+  end
+
   def destroy
     team = Team.find_by_id(params[:id])
     change_event = DeleteTeamEvent.create(team: team, data: { group: team.name })

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -1,0 +1,13 @@
+module AdminHelper
+  def certificate_component_url(component, component_id)
+    component == 'SpComponent' ? sp_component_path(component_id) : msa_component_path(component_id)
+  end
+
+  def service_sp_component_url(service)
+    service.sp_component_id.nil? ? 'No SP configured' : (link_to service.sp_component_id, sp_component_path(service.sp_component_id))
+  end
+
+  def service_msa_component_url(service)
+    service.msa_component_id.nil? ? 'No MSA configured' : (link_to service.msa_component_id, msa_component_path(service.msa_component_id))
+  end
+end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -1,6 +1,6 @@
 module AdminHelper
-  def certificate_component_url(component, component_id)
-    component == 'SpComponent' ? sp_component_path(component_id) : msa_component_path(component_id)
+  def certificate_component_url(component_type, component_id)
+    component_type == COMPONENT_TYPE::SP ? sp_component_path(component_id) : msa_component_path(component_id)
   end
 
   def service_sp_component_url(service)

--- a/app/policies/certificates_controller_policy.rb
+++ b/app/policies/certificates_controller_policy.rb
@@ -10,6 +10,10 @@ class CertificatesControllerPolicy < ApplicationPolicy
     user.permissions.certificate_management
   end
 
+  def show?
+    user.permissions.certificate_management
+  end
+
   def create?
     user.permissions.certificate_management
   end

--- a/app/policies/teams_controller_policy.rb
+++ b/app/policies/teams_controller_policy.rb
@@ -10,6 +10,10 @@ class TeamsControllerPolicy < ApplicationPolicy
     user.permissions.team_management
   end
 
+  def show?
+    user.permissions.team_management
+  end
+
   def new?
     user.permissions.team_management
   end

--- a/app/views/admin/_certificate.erb
+++ b/app/views/admin/_certificate.erb
@@ -44,7 +44,7 @@
       </tr>
       <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">Component ID</th>
-        <td class="govuk-table__cell"><%= link_to certificate.component_id, "/admin##{certificate.component_type}/#{certificate.component_id}" %></td>
+        <td class="govuk-table__cell"><%= link_to certificate.component_id, certificate_component_url(certificate.component_type, certificate.component_id) %></td>
       </tr>
       <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">Component type</th>

--- a/app/views/admin/_msa_component.html.erb
+++ b/app/views/admin/_msa_component.html.erb
@@ -1,4 +1,4 @@
-<%= link_to "Create new MSA component", new_msa_component_path, class: "govuk-button"  %>
+<%= link_to "Create new MSA component", new_msa_component_path, class: "govuk-button" %>
 
 <% components.reverse.each do |component| %>
   <table class="govuk-table">

--- a/app/views/admin/_msa_component.html.erb
+++ b/app/views/admin/_msa_component.html.erb
@@ -14,7 +14,7 @@
       </tr>
       <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">Team ID</th>
-        <td class="govuk-table__cell"><%= link_to(component.team_id, "/admin#teams/#{component.team_id}") if component.team_id %></td>
+        <td class="govuk-table__cell"><%= link_to(component.team_id, team_path(component.team_id)) if component.team_id %></td>
       </tr>
       <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">Environment</th>
@@ -22,7 +22,7 @@
       </tr>
       <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">Encryption certificate ID</th>
-        <td class="govuk-table__cell"><%= link_to(component.encryption_certificate_id, "/admin#certificates/#{component.encryption_certificate_id}") if component.encryption_certificate_id %></td>
+        <td class="govuk-table__cell"><%= link_to(component.encryption_certificate_id, msa_component_certificate_path(component.id, component.encryption_certificate_id)) if component.encryption_certificate_id %></td>
       </tr>
       <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">Created</th>

--- a/app/views/admin/_service.erb
+++ b/app/views/admin/_service.erb
@@ -14,11 +14,11 @@
       </tr>
       <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">SP Component ID</th>
-        <td class="govuk-table__cell"><%= link_to service.sp_component_id, "/admin#SpComponent/#{service.sp_component_id}" %> </td>
+        <td class="govuk-table__cell"><%= service_sp_component_url(service) %></td>
       </tr>
       <tr class="govuk-table__row">
-        <th scope="row" class="govuk-table__header">MSA Component ID???</th>
-        <td class="govuk-table__cell"><%= service.msa_component_id %></td>
+        <th scope="row" class="govuk-table__header">MSA Component ID</th>
+        <td class="govuk-table__cell"><%= service_msa_component_url(service) %></td>
       </tr>
       <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">Created</th>
@@ -30,7 +30,6 @@
       </tr>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell govuk-table__cell--numeric" colspan="2">
-        <%= link_to 'Manage', '', class: 'govuk-button', data: { module: 'govuk-button' } %>
         <%= link_to 'Edit', edit_service_path(service), class: 'govuk-button', data: { module: 'govuk-button' } %>
         <%= link_to 'Delete', service_path(service), method: :delete, data: { confirm: 'Are you sure?' }, class: 'govuk-button govuk-button--warning' %>
         </td>

--- a/app/views/admin/_sp_component.html.erb
+++ b/app/views/admin/_sp_component.html.erb
@@ -14,7 +14,7 @@
       </tr>
       <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">Team ID</th>
-        <td class="govuk-table__cell"><%= link_to(component.team_id, "/admin#teams/#{component.team_id}") if component.team_id %></td>
+        <td class="govuk-table__cell"><%= link_to(component.team_id, team_path(component.team_id)) if component.team_id %></td>
       </tr>
       <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">Environment</th>
@@ -22,7 +22,7 @@
       </tr>
       <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">Encryption certificate ID</th>
-        <td class="govuk-table__cell"><%= link_to(component.encryption_certificate_id, "/admin#certificates/#{component.encryption_certificate_id}") if component.encryption_certificate_id %></td>
+        <td class="govuk-table__cell"><%= link_to(component.encryption_certificate_id, sp_component_certificate_path(component.id, component.encryption_certificate_id)) if component.encryption_certificate_id %></td>
       </tr>
       <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">Created</th>

--- a/app/views/admin/_team.erb
+++ b/app/views/admin/_team.erb
@@ -1,7 +1,7 @@
 <%= link_to t('team.add_team'), new_team_path, class: "govuk-button" %>
 
 <% teams.reverse.each do |team| %>
-  <table class="govuk-table">
+  <table class="govuk-table" >
     <caption class="govuk-table__caption" id="teams/<%= team.id %>">Team ID: <%= team.id %></caption>
     <tbody class="govuk-table__body">
       <tr class="govuk-table__row">

--- a/app/views/admin/_team.erb
+++ b/app/views/admin/_team.erb
@@ -1,7 +1,7 @@
 <%= link_to t('team.add_team'), new_team_path, class: "govuk-button" %>
 
 <% teams.reverse.each do |team| %>
-  <table class="govuk-table" >
+  <table class="govuk-table">
     <caption class="govuk-table__caption" id="teams/<%= team.id %>">Team ID: <%= team.id %></caption>
     <tbody class="govuk-table__body">
       <tr class="govuk-table__row">

--- a/app/views/certificates/show.html.erb
+++ b/app/views/certificates/show.html.erb
@@ -1,0 +1,65 @@
+<%= page_title t('certificates.title') %>
+
+<h1 class="govuk-heading-l">Certificate: <%= @certificate.usage %></h1>
+
+<table class="govuk-table">
+  <caption class="govuk-table__caption">Certificate ID: <%= @certificate.id %></caption>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">Name</th>
+      <td class="govuk-table__cell"><%= @certificate.x509.subject.to_s %></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">Enabled</th>
+      <td class="govuk-table__cell"><%= @certificate.enabled %></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">Usage</th>
+      <td class="govuk-table__cell"><%= @certificate.usage %></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">Valid from</th>
+      <td class="govuk-table__cell"><%= @certificate.x509.not_before %></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">Valid until</th>
+      <td class="govuk-table__cell"><%= @certificate.x509.not_after %></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">In use at</th>
+      <td class="govuk-table__cell"><%= @certificate.in_use_at %></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">Certificate</th>
+      <td class="govuk-table__cell">
+        <details class="govuk-details" data-module="govuk-details">
+          <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+              Show certificate
+            </span>
+          </summary>
+          <div class="govuk-details__text">
+            <pre><%= @certificate.x509.to_text %></pre>
+            <pre class="wrap-text"><%= @certificate.value %></pre>
+          </div>
+        </details>
+      </td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">Component ID</th>
+      <td class="govuk-table__cell"><%= link_to @certificate.component_id, certificate_component_url(@certificate.component_type, @certificate.component_id) %></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">Component type</th>
+      <td class="govuk-table__cell"><%= @certificate.component_type %></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">Created</th>
+      <td class="govuk-table__cell"><%= @certificate.created_at %></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">Updated</th>
+      <td class="govuk-table__cell"><%= @certificate.updated_at %></td>
+    </tr>
+  </tbody>
+</table>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -1,0 +1,30 @@
+<%= page_title t('team.title') %>
+
+<h1 class="govuk-heading-l">Team name: <%= @team.name %></h1>
+
+<table class="govuk-table" >
+  <caption class="govuk-table__caption">Team ID: <%= @team.id %></caption>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">Alias</th>
+      <td class="govuk-table__cell"><%= @team.team_alias %></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">Created</th>
+      <td class="govuk-table__cell"><%= @team.created_at %></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">Updated</th>
+      <td class="govuk-table__cell"><%= @team.updated_at %></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell govuk-table__cell--numeric" colspan="2">
+        <% unless @team.team_alias == TEAMS::GDS %>
+          <%= link_to t('users.invite.button'), invite_to_team_path(@team.id), class: 'govuk-button govuk-button--secondary'%>
+          <%= link_to 'Delete', team_path(id: @team.id), method: :delete, data: { confirm: 'Are you sure?' }, class: 'govuk-button govuk-button--warning' %>
+        <% end %>
+      </td>
+    </tr>
+  </tbody>
+</table>
+

--- a/spec/system/visit_certificate_show_spec.rb
+++ b/spec/system/visit_certificate_show_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe 'Certificate Show Page', type: :system do
+  include CognitoSupport
+
+  before(:each) do
+    login_gds_user
+  end
+
+  let(:user) { login_gds_user }
+  let(:msa_encryption_certificate) { create(:msa_encryption_certificate, component: create(:msa_component, team_id: user.team)) }
+  let(:sp_encryption_certificate) { create(:sp_encryption_certificate, component: create(:sp_component, team_id: user.team)) }
+
+  it 'displays the certificate show page for msa certificate' do
+    visit msa_component_certificate_path(msa_encryption_certificate.component.id ,msa_encryption_certificate.id)
+    expect(page).to have_content ("Certificate ID: #{msa_encryption_certificate.id} ")
+    expect(page).to have_content ("Name #{msa_encryption_certificate.x509.subject.to_s} ")
+    expect(page).to have_content ("Usage #{msa_encryption_certificate.usage} ")
+  end
+
+  it 'displays the certificate show page for sp certificate' do
+    visit sp_component_certificate_path(sp_encryption_certificate.component.id ,sp_encryption_certificate.id)
+    expect(page).to have_content ("Certificate ID: #{sp_encryption_certificate.id} ")
+    expect(page).to have_content ("Name #{sp_encryption_certificate.x509.subject.to_s} ")
+    expect(page).to have_content ("Usage #{sp_encryption_certificate.usage} ")
+  end
+end

--- a/spec/system/visit_team_show_spec.rb
+++ b/spec/system/visit_team_show_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe 'Team Show Page', type: :system do
+  include CognitoSupport
+
+  before(:each) do
+    login_gds_user
+  end
+
+  it 'displays the team show page' do
+    visit team_path(Team.first.id)
+    expect(page).to have_content (Team.first.id)
+    expect(page).to have_content (Team.first.team_alias)
+    expect(page).to have_content (Team.first.created_at)
+    expect(page).to have_content (Team.first.updated_at)
+  end
+end


### PR DESCRIPTION
Due to the way it is already set up you cant just jump to a section on the page as that would be an anchor inside an anchor.
Created a show view for the Team and Certificate so they can be viewed individually like we can with the components, this makes it possible to link across the admin pages.
Fixed links between Services and Components
Fixed links between Components and Teams
Fixed links between Components and (Encryption) Certificates
Fixed links between Certificates and Components
Added tests for the new show pages for the Team and Certificate

New show page for Team:
<img width="956" alt="Screenshot 2020-09-15 at 16 32 57" src="https://user-images.githubusercontent.com/24409958/93341330-e0f74000-f825-11ea-98c1-8d54743f8959.png">

New show page for Certificate:
<img width="985" alt="Screenshot 2020-09-15 at 16 31 20" src="https://user-images.githubusercontent.com/24409958/93341365-eb193e80-f825-11ea-81fc-42a02784cdbd.png">

