### PR TITLE
HUB-712: Add link to remove admin users

### DIFF
--- a/app/assets/stylesheets/_users.scss
+++ b/app/assets/stylesheets/_users.scss
@@ -20,6 +20,7 @@
 
 div .remove-user-link {
   color: $govuk-error-colour; 
+  font-size: 1.1875rem;
 }
 
 .align-member-status-right {

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -44,10 +44,7 @@
         </div>
       </fieldset>
     </div>
-
-    <div class="actions">
-      <%= f.submit t('users.update.button'), class: "govuk-button", data: { module: "govuk-button" } %>
-      <%= link_to t('users.remove_user.remove_link'), remove_user_path, class: "secondary-link remove-user-link" %></td>
-    </div>
+    <%= f.submit t('users.update.button'), class: "govuk-button", data: { module: "govuk-button" } %>
   <% end %>
+  <%= link_to t('users.remove_user.remove_link'), remove_user_path, class: "#{'secondary-link' if !@team_member.gds? } remove-user-link" %></td>
 <% end %>


### PR DESCRIPTION
Currently there is no way to remove an admin user (a GDS team user)
This is not right behaviour as the GDS team has users no longer working within GDS and need a way to be removed.
Moved the link outside the conditional statement so its displayed for the admin team

New link added to the admin team users display to remove user:
<img width="1188" alt="Screenshot 2020-09-22 at 14 45 50" src="https://user-images.githubusercontent.com/24409958/94002842-5c12a600-fd92-11ea-8f3e-627f942e1260.png">
