### PR TITLE
Hub-721: change Cognito expired session sentry error to warnings

### DIFF
--- a/config/initializers/remote_authenticatable.rb
+++ b/config/initializers/remote_authenticatable.rb
@@ -37,6 +37,10 @@ module Devise
             clean_up_session
             Rails.logger.warn e
             fail!(:qr_code_expired)
+          rescue AuthenticationBackend::UserSessionTimeOutException => e
+            clean_up_session
+            Rails.logger.warn e
+            fail!(:invalid_session)
           rescue AuthenticationBackend::PasswordResetRequiredException => e
             Rails.logger.error e
             clean_up_session

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -20,6 +20,7 @@ en:
       unknown_cognito_response: "Something went wrong in our backend. Try again later."
       user:
         invalid_login: "Invalid username or password. Please try again."
+        invalid_session: "Invalid session for the user, session is expired."
         temporary_password_expired: "Your temporary password expired. Please contact your admin for a new one."
         qr_code_expired: "QR code has expired. Please try again."
         unknown_cognito_response: "Unknown authentication response."

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -21,6 +21,7 @@ en:
       user:
         invalid_login: "Invalid username or password. Please try again."
         temporary_password_expired: "Your temporary password expired. Please contact your admin for a new one."
+        qr_code_expired: "QR code has expired. Please try again."
         unknown_cognito_response: "Unknown authentication response."
     mailer:
       confirmation_instructions:

--- a/lib/auth/authentication_backend.rb
+++ b/lib/auth/authentication_backend.rb
@@ -4,6 +4,7 @@ require 'securerandom'
 
 module AuthenticationBackend
   class NotAuthorizedException < StandardError; end
+  class QRCodeExpiredException < StandardError; end
   class TemporaryPasswordExpiredException < StandardError; end
   class UserGroupNotFoundException < StandardError; end
   class AuthenticationBackendException < StandardError; end
@@ -428,30 +429,13 @@ private
       challenge_responses.merge!('SOFTWARE_TOKEN_MFA_CODE': params[:totp_code])
       send_challenge(session: params[:cognito_session_id], challenge_name: challenge_name, challenge_responses: challenge_responses)
     when 'MFA_SETUP'
-      totp_resp = client.verify_software_token(session: params[:cognito_session_id], user_code: params[:totp_code])
-      if totp_resp.status == 'SUCCESS'
-        challenge_responses.merge!('ANSWER': 'SOFTWARE_TOKEN_MFA')
-        resp = send_challenge(session: totp_resp.session, challenge_name: challenge_name, challenge_responses: challenge_responses)
-        set_mfa_preferences(access_token: resp.authentication_result[:access_token]) unless resp.authentication_result[:access_token].nil?
-        resp
-      else
-        raise AuthenticationBackendException.new("Unknown status returned by cognito when verifying software token.  Status returned: #{totp_resp.status}")
-      end
+      mfa_setup_response(params, challenge_name, challenge_responses)
     else
       raise AuthenticationBackendException.new("Unknown challenge_name returned by cognito.  Challenge name returned: #{challenge_name}")
     end
   rescue Aws::CognitoIdentityProvider::Errors::EnableSoftwareTokenMFAException,
          Aws::CognitoIdentityProvider::Errors::InvalidPasswordException => e
-    response_hash = {
-      type: RETRY,
-      email: params[:email],
-      secret_code: params[:secret_code],
-      session_id: params[:cognito_session_id],
-      challenge_name: "#{params[:challenge_name]}_RETRY",
-      challenge_parameters: params[:challenge_parameters],
-      flash_message: { code: e.code, message: e.message },
-    }
-    ChallengeResponse.new(response_hash)
+    response_hash(params, e)
   rescue Aws::CognitoIdentityProvider::Errors::InvalidParameterException,
          Aws::CognitoIdentityProvider::Errors::CodeMismatchException => e
     raise NotAuthorizedException.new(e)
@@ -476,5 +460,32 @@ private
 
   def user_pool_id
     Rails.configuration.cognito_user_pool_id
+  end
+
+  def response_hash(params, exception)
+    ChallengeResponse.new(
+      type: RETRY,
+      email: params[:email],
+      secret_code: params[:secret_code],
+      session_id: params[:cognito_session_id],
+      challenge_name: "#{params[:challenge_name]}_RETRY",
+      challenge_parameters: params[:challenge_parameters],
+      flash_message: { code: exception.code, message: exception.message },
+    )
+  end
+
+
+  def mfa_setup_response(params, challenge_name, challenge_responses)
+    totp_resp = client.verify_software_token(session: params[:cognito_session_id], user_code: params[:totp_code])
+    if totp_resp.status == 'SUCCESS'
+      challenge_responses.merge!('ANSWER': 'SOFTWARE_TOKEN_MFA')
+      resp = send_challenge(session: totp_resp.session, challenge_name: challenge_name, challenge_responses: challenge_responses)
+      set_mfa_preferences(access_token: resp.authentication_result[:access_token]) unless resp.authentication_result[:access_token].nil?
+      resp
+    else
+      raise AuthenticationBackendException.new("Unknown status returned by cognito when verifying software token.  Status returned: #{totp_resp.status}")
+    end
+  rescue Aws::CognitoIdentityProvider::Errors::NotAuthorizedException => e
+    raise QRCodeExpiredException.new(e)
   end
 end

--- a/spec/system/visit_sign_in_spec.rb
+++ b/spec/system/visit_sign_in_spec.rb
@@ -1,18 +1,18 @@
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'Sign in', type: :system do
+RSpec.describe "Sign in", type: :system do
   include CognitoSupport
 
-  scenario 'user cannot sign in if not registered' do
+  scenario "user cannot sign in if not registered" do
     SelfService.service(:cognito_client).stub_responses(:initiate_auth, Aws::CognitoIdentityProvider::Errors::UserNotFoundException.new(nil, "Stub Response"))
-    
-    sign_in('unregistered@example.com', 'testtest')
+
+    sign_in("unregistered@example.com", "testtest")
 
     expect(current_path).to eql new_user_session_path
-    expect(page).to have_content t('devise.failure.user.invalid_login')
+    expect(page).to have_content t("devise.failure.user.invalid_login")
   end
 
-  scenario 'user can sign in with valid credentials' do
+  scenario "user can sign in with valid credentials" do
     setup_simple_auth_stub
     user = FactoryBot.create(:user)
     sign_in(user.email, user.password)
@@ -20,29 +20,29 @@ RSpec.describe 'Sign in', type: :system do
     expect(current_path).to eql root_path
   end
 
-  scenario 'user cant sign in with unsigned jwt' do
+  scenario "user cant sign in with unsigned jwt" do
     user_hash = CognitoStubClient.stub_user_hash(role: ROLE::GDS, email_domain: "digital.cabinet-office.gov.uk", groups: %w[gds])
     payload, headers = user_hash, { kid: SelfService.service(:jwks).jwk.kid }
-    token = JWT.encode(payload, SelfService.service(:jwks).jwk.keypair, 'none')
+    token = JWT.encode(payload, SelfService.service(:jwks).jwk.keypair, "none")
 
-    stub_cognito_response(method: :initiate_auth, payload: { authentication_result: { access_token: 'valid-token', id_token: token } })
+    stub_cognito_response(method: :initiate_auth, payload: { authentication_result: { access_token: "valid-token", id_token: token } })
     user = FactoryBot.create(:user)
     sign_in(user.email, user.password)
 
     expect(current_path).to eql new_user_session_path
-    expect(page).to have_content t('devise.failure.user.unknown_cognito_response')
+    expect(page).to have_content t("devise.failure.user.unknown_cognito_response")
   end
 
-  scenario 'user can sign in with valid 2FA credentials' do
+  scenario "user can sign in with valid 2FA credentials" do
     setup_2fa_stub
 
     user = FactoryBot.create(:user_manager_user)
     sign_in(user.email, user.password)
     expect(current_path).to eql new_user_session_path
-    expect(page).to have_content t('sign_in.mfa_heading')
+    expect(page).to have_content t("sign_in.mfa_heading")
 
     fill_in "user[totp_code]", with: "000000"
-    click_button(t('sign_in.sign_in'))
+    click_button(t("sign_in.sign_in"))
     expect(current_path).to eql root_path
     # Ensure session is cleaned up from flow
     expect(page.get_rack_session.has_key?(:cognito_session_id)).to eql false
@@ -50,83 +50,83 @@ RSpec.describe 'Sign in', type: :system do
     expect(page.get_rack_session.has_key?(:challenge_parameters)).to eql false
   end
 
-  scenario 'user can abandon the sign-in flow' do
+  scenario "user can abandon the sign-in flow" do
     setup_2fa_stub
 
     user = FactoryBot.create(:user_manager_user)
     sign_in(user.email, user.password)
     expect(current_path).to eql new_user_session_path
-    expect(page).to have_content t('sign_in.mfa_heading')
-    old_session_id = page.get_rack_session_key('session_id')
+    expect(page).to have_content t("sign_in.mfa_heading")
+    old_session_id = page.get_rack_session_key("session_id")
     visit root_path
-    click_link(t('sign_in.cancel'))
+    click_link(t("sign_in.cancel"))
 
     expect(current_path).to eql new_user_session_path
-    expect(page).to have_content t('sign_in.heading')
+    expect(page).to have_content t("sign_in.heading")
     expect(page.get_rack_session.length).to eql 1
-    expect(page.get_rack_session_key('session_id')).not_to eql old_session_id
+    expect(page.get_rack_session_key("session_id")).not_to eql old_session_id
   end
 
-  scenario 'user cant sign in with wrong 2FA credentials' do
-    stub_cognito_response(method: :initiate_auth, payload: { challenge_name: "SOFTWARE_TOKEN_MFA", session: SecureRandom.uuid, challenge_parameters: { 'USER_ID_FOR_SRP' => '0000-0000' }})
+  scenario "user cant sign in with wrong 2FA credentials" do
+    stub_cognito_response(method: :initiate_auth, payload: { challenge_name: "SOFTWARE_TOKEN_MFA", session: SecureRandom.uuid, challenge_parameters: { "USER_ID_FOR_SRP" => "0000-0000" }})
     SelfService.service(:cognito_client).stub_responses(:respond_to_auth_challenge, Aws::CognitoIdentityProvider::Errors::CodeMismatchException.new(nil, "Stub Response"))
 
     user = FactoryBot.create(:user_manager_user)
     sign_in(user.email, user.password)
     expect(current_path).to eql new_user_session_path
-    expect(page).to have_content t('sign_in.mfa_heading')
+    expect(page).to have_content t("sign_in.mfa_heading")
 
     fill_in "user[totp_code]", with: "999999"
-    click_button(t('sign_in.sign_in'))
+    click_button(t("sign_in.sign_in"))
     expect(current_path).to eql new_user_session_path
-    expect(page).to have_content t('devise.failure.user.invalid_login')
+    expect(page).to have_content t("devise.failure.user.invalid_login")
   end
 
-  scenario 'user cannot sign in with wrong email' do
+  scenario "user cannot sign in with wrong email" do
     SelfService.service(:cognito_client).stub_responses(:initiate_auth, Aws::CognitoIdentityProvider::Errors::UserNotFoundException.new(nil, "Stub Response"))
 
     user = FactoryBot.create(:user_manager_user)
-    sign_in('invalid@email.com', user.password)
+    sign_in("invalid@email.com", user.password)
 
     expect(current_path).to eql new_user_session_path
-    expect(page).to have_content t('devise.failure.user.invalid_login')
+    expect(page).to have_content t("devise.failure.user.invalid_login")
   end
 
-  scenario 'user cannot sign in with wrong password' do
+  scenario "user cannot sign in with wrong password" do
     user = FactoryBot.create(:user_manager_user)
-    sign_in(user.email, 'invalidpassword')
+    sign_in(user.email, "invalidpassword")
 
     expect(current_path).to eql new_user_session_path
-    expect(page).to have_content t('devise.failure.user.invalid_login')
+    expect(page).to have_content t("devise.failure.user.invalid_login")
   end
 
-  scenario 'user cannot sign in with an expired password' do
-    SelfService.service(:cognito_client).stub_responses(:initiate_auth, Aws::CognitoIdentityProvider::Errors::NotAuthorizedException.new(nil, 'Temporary password has expired and must be reset by an administrator.'))
+  scenario "user cannot sign in with an expired password" do
+    SelfService.service(:cognito_client).stub_responses(:initiate_auth, Aws::CognitoIdentityProvider::Errors::NotAuthorizedException.new(nil, "Temporary password has expired and must be reset by an administrator."))
     user = FactoryBot.create(:user_manager_user)
-    sign_in(user.email, 'expiredpassword')
+    sign_in(user.email, "expiredpassword")
 
     expect(current_path).to eql new_user_session_path
-    expect(page).to have_content t('devise.failure.user.temporary_password_expired')
+    expect(page).to have_content t("devise.failure.user.temporary_password_expired")
   end
 
-  scenario 'user cannot access pages if not signed in' do
+  scenario "user cannot access pages if not signed in" do
     visit new_msa_component_path
 
     expect(current_path).to eql new_user_session_path
-    expect(page).to have_content t('devise.failure.unauthenticated')
+    expect(page).to have_content t("devise.failure.unauthenticated")
   end
 
-  scenario 'user is forced to change their temporary password' do
+  scenario "user is forced to change their temporary password" do
     setup_2fa_stub
-    stub_cognito_response(method: :initiate_auth, payload: { challenge_name: "NEW_PASSWORD_REQUIRED", session: SecureRandom.uuid, challenge_parameters: { 'USER_ID_FOR_SRP' => '0000-0000' }})
+    stub_cognito_response(method: :initiate_auth, payload: { challenge_name: "NEW_PASSWORD_REQUIRED", session: SecureRandom.uuid, challenge_parameters: { "USER_ID_FOR_SRP" => "0000-0000" }})
 
     user = FactoryBot.create(:user_manager_user)
     sign_in(user.email, user.password)
     expect(current_path).to eql new_user_session_path
-    expect(page).to have_content t('sign_in.new_password_heading')
+    expect(page).to have_content t("sign_in.new_password_heading")
 
     fill_in "user[new_password]", with: "000000"
-    click_button(t('sign_in.sign_in'))
+    click_button(t("sign_in.sign_in"))
     expect(current_path).to eql root_path
     # Ensure session is cleaned up from flow
     expect(page.get_rack_session.has_key?(:cognito_session_id)).to eql false
@@ -134,20 +134,20 @@ RSpec.describe 'Sign in', type: :system do
     expect(page.get_rack_session.has_key?(:challenge_parameters)).to eql false
   end
 
-  scenario 'User get prompted to setup MFA on first sign in' do
-    stub_cognito_response(method: :initiate_auth, payload: { challenge_name: "MFA_SETUP", session: SecureRandom.uuid, challenge_parameters: { 'USER_ID_FOR_SRP' => '0000-0000' }})
-    stub_cognito_response(method: :associate_software_token, payload: { secret_code: 'OC7YQ4VYEVRWQGIKSXV25B3MZUV355I5XUKKM4P7KGTO72OTXXUQ', session: SecureRandom.uuid })
+  scenario "User get prompted to setup MFA on first sign in" do
+    stub_cognito_response(method: :initiate_auth, payload: { challenge_name: "MFA_SETUP", session: SecureRandom.uuid, challenge_parameters: { "USER_ID_FOR_SRP" => "0000-0000" }})
+    stub_cognito_response(method: :associate_software_token, payload: { secret_code: "OC7YQ4VYEVRWQGIKSXV25B3MZUV355I5XUKKM4P7KGTO72OTXXUQ", session: SecureRandom.uuid })
     stub_cognito_response(method: :verify_software_token, payload: { status: "SUCCESS", session: SecureRandom.uuid })
 
     user = FactoryBot.create(:user_manager_user)
     sign_in(user.email, user.password)
     expect(current_path).to eql new_user_session_path
-    expect(page).to have_content t('mfa_enrolment.heading')
-    expect(page).to have_content t('mfa_enrolment.description')
+    expect(page).to have_content t("mfa_enrolment.heading")
+    expect(page).to have_content t("mfa_enrolment.description")
     expect(page).to have_css("#qr-code svg")
 
     fill_in "user[totp_code]", with: "000000"
-    click_button(t('sign_in.sign_in'))
+    click_button(t("sign_in.sign_in"))
 
     expect(current_path).to eql root_path
     # Ensure session is cleaned up from flow
@@ -156,42 +156,43 @@ RSpec.describe 'Sign in', type: :system do
     expect(page.get_rack_session.has_key?(:challenge_parameters)).to eql false
   end
 
-  scenario 'User is told when they enter a wrong code on setup and gets to try again' do
+  scenario "User is told when they enter a wrong code on setup and gets to try again" do
     SelfService.register_service(name: :cognito_client, client: Aws::CognitoIdentityProvider::Client.new(stub_responses: true))
-    stub_cognito_response(method: :initiate_auth, payload: { challenge_name: "MFA_SETUP", session: SecureRandom.uuid, challenge_parameters: { 'USER_ID_FOR_SRP' => '0000-0000' }})
-    stub_cognito_response(method: :associate_software_token, payload: { secret_code: 'OC7YQ4VYEVRWQGIKSXV25B3MZUV355I5XUKKM4P7KGTO72OTXXUQ', session: SecureRandom.uuid })
-    stub_cognito_response(method: :verify_software_token, payload: 'EnableSoftwareTokenMFAException')
+    stub_cognito_response(method: :initiate_auth, payload: { challenge_name: "MFA_SETUP", session: SecureRandom.uuid, challenge_parameters: { "USER_ID_FOR_SRP" => "0000-0000" }})
+    stub_cognito_response(method: :associate_software_token, payload: { secret_code: "OC7YQ4VYEVRWQGIKSXV25B3MZUV355I5XUKKM4P7KGTO72OTXXUQ", session: SecureRandom.uuid })
+    stub_cognito_response(method: :verify_software_token, payload: "EnableSoftwareTokenMFAException")
     user = FactoryBot.create(:user_manager_user)
     sign_in(user.email, user.password)
     expect(current_path).to eql new_user_session_path
-    expect(page).to have_content t('mfa_enrolment.heading')
+    expect(page).to have_content t("mfa_enrolment.heading")
     expect(page).to have_css("#qr-code svg")
 
     fill_in "user[totp_code]", with: "000000"
-    click_button(t('sign_in.sign_in'))
+    click_button(t("sign_in.sign_in"))
 
     expect(current_path).to eql new_user_session_path
-    expect(page).to have_content t('devise.sessions.EnableSoftwareTokenMFAException')
+    expect(page).to have_content t("devise.sessions.EnableSoftwareTokenMFAException")
     # Ensure session is cleaned up from flow
     expect(page.get_rack_session.has_key?(:cognito_session_id)).to eql false
     expect(page.get_rack_session.has_key?(:challenge_name)).to eql false
     expect(page.get_rack_session.has_key?(:challenge_parameters)).to eql false
   end
 
-  scenario 'User redirected back to sign in after QR code expires' do
-    stub_cognito_response(method: :initiate_auth, payload: { challenge_name: "MFA_SETUP", session: SecureRandom.uuid, challenge_parameters: { 'USER_ID_FOR_SRP' => '0000-0000' } })
-    stub_cognito_response(method: :associate_software_token, payload: { secret_code: 'OC7YQ4VYEVRWQGIKSXV25B3MZUV355I5XUKKM4P7KGTO72OTXXUQ', session: SecureRandom.uuid })
-    SelfService.service(:cognito_client).stub_responses(:verify_software_token, Aws::CognitoIdentityProvider::Errors::NotAuthorizedException.new(nil, "Invalid session for the user, session is expired."))
+  scenario "User redirected back to sign in after QR code expires" do
+    stub_cognito_response(method: :initiate_auth, payload: { challenge_name: "MFA_SETUP", session: SecureRandom.uuid, challenge_parameters: { "USER_ID_FOR_SRP" => "0000-0000" } })
+    stub_cognito_response(method: :associate_software_token, payload: { secret_code: "OC7YQ4VYEVRWQGIKSXV25B3MZUV355I5XUKKM4P7KGTO72OTXXUQ", session: SecureRandom.uuid })
+    SelfService.service(:cognito_client).stub_responses(:verify_software_token, Aws::CognitoIdentityProvider::Errors::NotAuthorizedException.new(nil, t("devise.failure.user.invalid_session")))
 
     user = FactoryBot.create(:user_manager_user)
+    expect(Rails.logger).to receive(:warn).with(AuthenticationBackend::QRCodeExpiredException)
     sign_in(user.email, user.password)
     expect(current_path).to eql new_user_session_path
-    expect(page).to have_content t('mfa_enrolment.heading')
-    expect(page).to have_content t('mfa_enrolment.description')
+    expect(page).to have_content t("mfa_enrolment.heading")
+    expect(page).to have_content t("mfa_enrolment.description")
     expect(page).to have_css("#qr-code svg")
 
     fill_in "user[totp_code]", with: "000000"
-    click_button(t('sign_in.sign_in'))
+    click_button(t("sign_in.sign_in"))
 
     expect(current_path).to eql new_user_session_path
     expect(page).to have_content t("devise.failure.user.qr_code_expired")
@@ -200,11 +201,35 @@ RSpec.describe 'Sign in', type: :system do
     expect(page.get_rack_session.has_key?(:challenge_name)).to eql false
     expect(page.get_rack_session.has_key?(:challenge_parameters)).to eql false
   end
-  scenario 'user redirected when PasswordResetRequiredException is raised' do
-    stub_cognito_response(method: :initiate_auth, payload: 'PasswordResetRequiredException')
+
+  scenario "User redirected back to sign in after Cognito session expiry" do
+    stub_cognito_response(method: :initiate_auth, payload: { challenge_name: "SOFTWARE_TOKEN_MFA", session: SecureRandom.uuid, challenge_parameters: { "USER_ID_FOR_SRP" => "0000-0000" } })
+    stub_cognito_response(method: :associate_software_token, payload: { secret_code: "OC7YQ4VYEVRWQGIKSXV25B3MZUV355I5XUKKM4P7KGTO72OTXXUQ", session: SecureRandom.uuid })
+    SelfService.service(:cognito_client).stub_responses(:respond_to_auth_challenge, Aws::CognitoIdentityProvider::Errors::NotAuthorizedException.new(nil, t("devise.failure.user.invalid_session")))
+
+    user = FactoryBot.create(:user_manager_user)
+    expect(Rails.logger).to receive(:warn).with(AuthenticationBackend::UserSessionTimeOutException)
+    sign_in(user.email, user.password)
+    expect(current_path).to eql new_user_session_path
+    expect(page).to have_content t("sign_in.mfa_heading")
+    expect(page).to have_content t("sign_in.mfa_description")
+
+    fill_in "user[totp_code]", with: "000000"
+    click_button(t("sign_in.sign_in"))
+
+    expect(current_path).to eql new_user_session_path
+    expect(page).to have_content t("devise.failure.user.invalid_session")
+    # Ensure session is cleaned up from flow
+    expect(page.get_rack_session.has_key?(:cognito_session_id)).to eql false
+    expect(page.get_rack_session.has_key?(:challenge_name)).to eql false
+    expect(page.get_rack_session.has_key?(:challenge_parameters)).to eql false
+  end
+
+  scenario "user redirected when PasswordResetRequiredException is raised" do
+    stub_cognito_response(method: :initiate_auth, payload: "PasswordResetRequiredException")
     user = FactoryBot.create(:user_manager_user)
     sign_in(user.email, user.password)
     expect(current_path).to eql reset_password_path(reset_by_admin: true)
-    expect(page).to have_content t('password.reset_password_heading')
+    expect(page).to have_content t("password.reset_password_heading")
   end
 end


### PR DESCRIPTION
See: https://govukverify.atlassian.net/browse/HUB-544 and https://govukverify.atlassian.net/browse/HUB-721

We have seen sentry events where a cogito session timeout results in a sentry event, 

example of HUB-721: https://sentry.tools.signin.service.gov.uk/verify/prod-self-service/issues/4702/?query=is%3Aunresolved
HUB-721 is a result of the **15 minutes** of inactivity or **60 minutes** timeout of a users session see below discussion
example of HUB-544: https://sentry.tools.signin.service.gov.uk/verify/prod-self-service/issues/3762/
HUB-544 was found to be as a result of QR code being stale after **3 minutes** so a more specific error is provided see first commit
Discussion at https://gds.slack.com/archives/GLYGVNMJM/p1584103738008300, (attached too)

We should rather log this event as a warning and send the user back to a login page.