### PR TITLE
HUB-733 Disable sentry environment reporting

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -2,5 +2,5 @@ Raven.configure do |config|
   config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
   config.transport_failure_callback = ->(event) { Rails.logger.error(event.to_s) }
   config.environments = %w[production]
-  config.current_environment = ENV.fetch('SENTRY_ENV', 'unspecified')
+  #config.current_environment = ENV.fetch('SENTRY_ENV', 'unspecified')
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,6 +1,6 @@
 Raven.configure do |config|
   config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
   config.transport_failure_callback = ->(event) { Rails.logger.error(event.to_s) }
-  config.environments = %w[production]
-  #config.current_environment = ENV.fetch('SENTRY_ENV', 'unspecified')
+  config.environments = %w[ production staging integration ]
+  config.current_environment = ENV.fetch('SENTRY_ENV', 'unspecified')
 end


### PR DESCRIPTION
Set the sentry environment information correctly and tell sentry to run in production, integration and staging.