### PR TITLE
HUB-733: Remove environments array

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -2,5 +2,4 @@ Raven.configure do |config|
   config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
   config.transport_failure_callback = ->(event) { Rails.logger.error(event.to_s) }
   config.current_environment = ENV.fetch("SENTRY_ENV", "unspecified")
-  config.environments = %w[production staging integration]
 end


### PR DESCRIPTION
The rationale for this, is that we currently have verify-frontend https://github.com/alphagov/verify-frontend/blob/a5719acce2f8ddff1a0acbeea64a1062b9ae365e/config/initializers/logging.rb#L21
set up this way, so it should work with self-service as well
The reason for the array was to constraint sentry to run only in
the environment specified. I think we don't need to do this explicitly