### PR TITLE
HUB-766: Validate & format entity id's

### DIFF
--- a/app/models/aggregated_event.rb
+++ b/app/models/aggregated_event.rb
@@ -37,6 +37,10 @@ class AggregatedEvent < Event
     errors.add(:name, I18n.t('events.errors.missing_name')) unless name.present?
   end
 
+  def strip_entity_id
+    self.entity_id = self.entity_id.strip unless self.entity_id.nil?
+  end
+
 private
 
   def aggregate_exists_and_unchanged?

--- a/app/models/new_msa_component_event.rb
+++ b/app/models/new_msa_component_event.rb
@@ -4,11 +4,13 @@ class NewMsaComponentEvent < AggregatedEvent
   validate :msa_has_entity_id
   validate :component_is_new, on: :create
   validate :not_an_existing_msa_entity_id, on: :create
+  validates :entity_id, format: { without: /\s/, message: I18n.t('components.errors.invalid_entity_id_format') }
   validates_presence_of :name, message: I18n.t('events.errors.missing_name')
   validates_presence_of :team_id, message: I18n.t('components.errors.invalid_team')
   validates_presence_of :environment,
                         in: Rails.configuration.hub_environments.keys,
                         message: I18n.t('components.errors.invalid_environment')
+  before_validation :strip_entity_id
 
   def build_msa_component
     MsaComponent.new
@@ -32,7 +34,7 @@ class NewMsaComponentEvent < AggregatedEvent
 private
 
   def not_an_existing_msa_entity_id
-    errors.add(:entity_id, I18n.t('components.errors.invalid_entity_id')) if MsaComponent.exists? entity_id: entity_id
+    errors.add(:entity_id, I18n.t('components.errors.existing_entity_id')) if MsaComponent.exists? entity_id: entity_id
   end
 
   def msa_has_entity_id

--- a/app/models/new_msa_component_event.rb
+++ b/app/models/new_msa_component_event.rb
@@ -3,6 +3,7 @@ class NewMsaComponentEvent < AggregatedEvent
   data_attributes :name, :entity_id, :team_id, :environment
   validate :msa_has_entity_id
   validate :component_is_new, on: :create
+  validate :not_an_existing_msa_entity_id, on: :create
   validates_presence_of :name, message: I18n.t('events.errors.missing_name')
   validates_presence_of :team_id, message: I18n.t('components.errors.invalid_team')
   validates_presence_of :environment,
@@ -30,7 +31,11 @@ class NewMsaComponentEvent < AggregatedEvent
 
 private
 
+  def not_an_existing_msa_entity_id
+    errors.add(:entity_id, I18n.t('components.errors.invalid_entity_id')) if MsaComponent.exists? entity_id: entity_id
+  end
+
   def msa_has_entity_id
-    errors.add(:entity_id, message: I18n.t('components.errors.missing_entity_id')) unless entity_id.present?
+    errors.add(:entity_id, I18n.t('components.errors.missing_entity_id')) unless entity_id.present?
   end
 end

--- a/app/models/new_service_event.rb
+++ b/app/models/new_service_event.rb
@@ -1,8 +1,10 @@
 class NewServiceEvent < AggregatedEvent
   belongs_to_aggregate :service
   data_attributes :entity_id, :sp_component_id, :msa_component_id, :name
-  validates_presence_of :entity_id, message: 'ID is required'
+  validates_presence_of :entity_id, message: I18n.t('service.errors.missing_entity_id')
   validate :name_is_present
+  validates :entity_id, format: { without: /\s/, message: I18n.t('services.errors.invalid_entity_id_format') }
+  before_validation :strip_entity_id
 
   def build_service
     Service.new

--- a/app/models/new_service_event.rb
+++ b/app/models/new_service_event.rb
@@ -1,8 +1,8 @@
 class NewServiceEvent < AggregatedEvent
   belongs_to_aggregate :service
   data_attributes :entity_id, :sp_component_id, :msa_component_id, :name
-  validates_presence_of :entity_id, message: I18n.t('service.errors.missing_entity_id')
   validate :name_is_present
+  validates_presence_of :entity_id, message: I18n.t('services.errors.missing_entity_id')
   validates :entity_id, format: { without: /\s/, message: I18n.t('services.errors.invalid_entity_id_format') }
   before_validation :strip_entity_id
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -267,6 +267,7 @@ en:
       wrong_component_type: Wrong component type
       unknown_component_or_service: Invalid component or service
       missing_entity_id: ID is required for the Service
+      invalid_entity_id_format: ID cannot contain spaces
   shared:
     errors:
       error: Error
@@ -329,7 +330,8 @@ en:
       already_exists: already exists
       must_exist: must exist
       missing_entity_id: ID is required for the MSA component
-      invalid_entity_id: Entity ID already in use, must be unique
+      existing_entity_id: ID already in use, must be unique
+      invalid_entity_id_format: ID cannot contain spaces
       invalid_team: Component must belong to a valid team
       invalid_environment: Component must belong to a valid environment
       invalid_type: must be either VSP or SP

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -329,6 +329,7 @@ en:
       already_exists: already exists
       must_exist: must exist
       missing_entity_id: ID is required for the MSA component
+      invalid_entity_id: Entity ID already in use, must be unique
       invalid_team: Component must belong to a valid team
       invalid_environment: Component must belong to a valid environment
       invalid_type: must be either VSP or SP

--- a/spec/factories/components.rb
+++ b/spec/factories/components.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
   factory :msa_component do
     component_type { COMPONENT_TYPE::MSA }
     name { 'Test MSA'}
-    entity_id { 'https://test-entity-id' }
+    entity_id { SecureRandom.alphanumeric }
     team_id { create(:team).id }
     environment { 'staging' }
   end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
 
   factory :new_msa_component_event do
     name { SecureRandom.alphanumeric }
-    entity_id { 'https://test-entity-id' }
+    entity_id { SecureRandom.alphanumeric }
     team_id { create(:team).id }
     environment { 'staging' }
   end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -25,6 +25,12 @@ FactoryBot.define do
     component { create(:new_sp_component_event) }
   end
 
+  factory :new_service_event do
+    service { create(:service) }
+    name { SecureRandom.alphanumeric }
+    entity_id { SecureRandom.alphanumeric }
+  end
+
   factory :delete_service_event do
     service { create(:service) }
   end

--- a/spec/factories/service.rb
+++ b/spec/factories/service.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :service do
-    entity_id { 'https://not-a-real-entity-id' }
+    entity_id { SecureRandom.alphanumeric }
     name  { SecureRandom.alphanumeric }
     sp_component { }
     msa_component { }

--- a/spec/models/new_msa_component_event_spec.rb
+++ b/spec/models/new_msa_component_event_spec.rb
@@ -3,7 +3,8 @@ require 'rails_helper'
 RSpec.describe NewMsaComponentEvent, type: :model do
   include_examples 'components have data attributes', :new_msa_component_event, {
     name: 'Call me Ishmael',
-    environment: 'staging'
+    environment: 'staging',
+    entity_id: SecureRandom.alphanumeric
   }
   include_examples 'components are aggregated', :new_msa_component_event
   include_examples 'component creation event', :new_msa_component_event
@@ -29,6 +30,27 @@ RSpec.describe NewMsaComponentEvent, type: :model do
       event = build(:new_msa_component_event, environment: '')
       expect(event).to_not be_valid
       expect(event.errors[:environment]).to eql [t('components.errors.invalid_environment')]
+    end
+  end
+
+  context 'entity_id' do
+    it 'must be provided' do
+      event = build(:new_msa_component_event, entity_id: '')
+      expect(event).to_not be_valid
+      expect(event.errors[:entity_id]).to eql [t('components.errors.missing_entity_id')]
+    end
+
+    it 'is valid when there is only leading and trailing whitespaces' do
+      event = build(:new_msa_component_event, entity_id: ' https://test-entity-id ')
+      expect(event).to be_valid
+      expect(event.errors[:entity_id]).to eql []
+      expect(event.entity_id).to eql "https://test-entity-id"
+    end
+
+     it 'must not contain spaces between words' do
+      event = build(:new_msa_component_event, entity_id: 'https://test entity id')
+      expect(event).to_not be_valid
+      expect(event.errors[:entity_id]).to eql [t('components.errors.invalid_entity_id_format')]
     end
   end
 end

--- a/spec/models/new_service_event_spec.rb
+++ b/spec/models/new_service_event_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe NewServiceEvent, type: :model do
+  
+  context 'name' do
+    it 'must be provided' do
+      event = build(:new_service_event, name: '')
+      expect(event).to_not be_valid
+      expect(event.errors[:name]).to eql [t('events.errors.missing_name')]
+    end
+  end
+
+  context 'entity_id' do
+    it 'must be provided' do
+      event = build(:new_service_event, entity_id: '')
+      expect(event).to_not be_valid
+      expect(event.errors[:entity_id]).to eql [t('services.errors.missing_entity_id')]
+    end
+
+    it 'is valid when there is only leading and trailing whitespaces' do
+      event = build(:new_service_event, entity_id: ' https://test-entity-id ')
+      expect(event).to be_valid
+      expect(event.errors[:entity_id]).to eql []
+      expect(event.entity_id).to eql "https://test-entity-id"
+    end
+
+     it 'must not contain spaces between words' do
+      event = build(:new_service_event, entity_id: 'https://test entity id')
+      expect(event).to_not be_valid
+      expect(event.errors[:entity_id]).to eql [t('services.errors.invalid_entity_id_format')]
+    end
+  end
+end

--- a/spec/models/publish_services_event_metadata_spec.rb
+++ b/spec/models/publish_services_event_metadata_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe PublishServicesMetadataEvent, type: :model do
   end
   let(:published_at) { Time.now }
   let(:event_id) { 0 }
-  let(:component) { MsaComponent.create(name: 'lala', entity_id: 'https//test-entity') }
+  let(:component) { MsaComponent.create(name: 'lala', entity_id: SecureRandom.alphanumeric) }
   let(:event) { PublishServicesMetadataEvent.create(event_id: event_id, environment: 'test') }
   let(:current) { Time.current }
   let(:in_hours) { travel_to Time.zone.local(current.year, current.month, current.day, 12, 00, 00)}
@@ -340,7 +340,7 @@ RSpec.describe PublishServicesMetadataEvent, type: :model do
             .times(3)
 
           expect(Rails.logger).to receive(:error)
-            .with("Error getting signing certificates for entity_id: #{new_msa_encryption_certificate.component.entity_id}! (Code: 404)")
+            .with("Error getting signing certificates for entity_id: #{msa_signing_certificate.component.entity_id}! (Code: 404)")
             .twice
           expect(Certificate.find_by_id(msa_signing_certificate.id).in_use_at).to be_nil
           create(:upload_certificate_event, component: msa_signing_certificate.component)

--- a/spec/system/visit_msa_component_new_spec.rb
+++ b/spec/system/visit_msa_component_new_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'New MSA Component Page', type: :system do
   let(:entity_id) { SecureRandom.alphanumeric }
   let(:team) { create(:new_team_event).team }
   let(:create_teams) { team }
-  let(:msa_component) { create(:msa_component, entity_id: 'existing entity_id') }
+  let(:msa_component) { create(:msa_component, entity_id: 'http://test-entity-id') }
 
   context 'creation is successful' do
     it 'when required input with entity id for msa is specified' do
@@ -44,7 +44,7 @@ RSpec.describe 'New MSA Component Page', type: :system do
   context 'creation fails without unique entity id' do
     it 'when entity id already exists for a msa component' do
       existing_component = msa_component
-      entity = 'existing entity_id'
+      entity = 'http://test-entity-id'
       component_name = 'test component'
       visit new_msa_component_path
       fill_in 'component_name', with: component_name
@@ -53,7 +53,37 @@ RSpec.describe 'New MSA Component Page', type: :system do
       choose('component_environment_staging')
       click_button 'Create MSA component'
 
-      expect(page).to have_content t('components.errors.invalid_entity_id')
+      expect(page).to have_content t('components.errors.existing_entity_id')
+    end
+  end
+
+  context 'creation is successful with only leading and trailing whitespaces on entity id' do
+    it 'when entity id in a msa component has leading and trailing whitespaces' do
+      entity = ' http://test-entity-id-2 '
+      component_name = 'test component'
+      visit new_msa_component_path
+      fill_in 'component_name', with: component_name
+      fill_in 'component_entity_id', with: entity
+      select team.name, from: "component_team_id"
+      choose('component_environment_staging')
+      click_button 'Create MSA component'
+
+      expect(current_path).to eql admin_path
+    end
+  end
+
+  context 'creation fails with whitespaces within entity id' do
+    it 'when entity id in a msa component has spaces between words' do
+      entity = 'http://test entity id'
+      component_name = 'test component'
+      visit new_msa_component_path
+      fill_in 'component_name', with: component_name
+      fill_in 'component_entity_id', with: entity
+      select team.name, from: "component_team_id"
+      choose('component_environment_staging')
+      click_button 'Create MSA component'
+
+      expect(page).to have_content t('components.errors.invalid_entity_id_format')
     end
   end
 

--- a/spec/system/visit_msa_component_new_spec.rb
+++ b/spec/system/visit_msa_component_new_spec.rb
@@ -6,9 +6,10 @@ RSpec.describe 'New MSA Component Page', type: :system do
     create_teams
   end
 
-  let(:entity_id) { 'http://test-entity-id' }
+  let(:entity_id) { SecureRandom.alphanumeric }
   let(:team) { create(:new_team_event).team }
   let(:create_teams) { team }
+  let(:msa_component) { create(:msa_component, entity_id: 'existing entity_id') }
 
   context 'creation is successful' do
     it 'when required input with entity id for msa is specified' do
@@ -37,6 +38,22 @@ RSpec.describe 'New MSA Component Page', type: :system do
       click_button 'Create MSA component'
 
       expect(page).to have_content t('components.errors.missing_entity_id')
+    end
+  end
+
+  context 'creation fails without unique entity id' do
+    it 'when entity id already exists for a msa component' do
+      existing_component = msa_component
+      entity = 'existing entity_id'
+      component_name = 'test component'
+      visit new_msa_component_path
+      fill_in 'component_name', with: component_name
+      fill_in 'component_entity_id', with: entity
+      select team.name, from: "component_team_id"
+      choose('component_environment_staging')
+      click_button 'Create MSA component'
+
+      expect(page).to have_content t('components.errors.invalid_entity_id')
     end
   end
 

--- a/spec/system/visit_service_new_spec.rb
+++ b/spec/system/visit_service_new_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'New Service Page', type: :system do
       fill_in 'service_entity_id', with: entity_id
       click_button 'Create service'
 
-      expect(page).to have_content I18n.t('service.errors.missing_entity_id')
+      expect(page).to have_content I18n.t('services.errors.missing_entity_id')
     end
 
     it 'when entity id has spaces between words' do

--- a/spec/system/visit_service_new_spec.rb
+++ b/spec/system/visit_service_new_spec.rb
@@ -18,6 +18,17 @@ RSpec.describe 'New Service Page', type: :system do
 
       expect(current_path).to eql admin_path
     end
+
+    it 'when entity id has only leading and trailing spaces' do
+      service_name = 'test component'
+      entity_id = ' http://test-entity-id '
+      visit new_service_path
+      fill_in 'service_name', with: service_name
+      fill_in 'service_entity_id', with: entity_id
+      click_button 'Create service'
+
+      expect(current_path).to eql admin_path
+    end
   end
 
   context 'creation fails without name' do
@@ -29,11 +40,11 @@ RSpec.describe 'New Service Page', type: :system do
       fill_in 'service_entity_id', with: entity_id
       click_button 'Create service'
 
-      expect(page).to have_content 'Enter a name'
+      expect(page).to have_content I18n.t('events.errors.missing_name')
     end
   end
 
-  context 'creation fails without entity id' do
+  context 'creation fails on entity id' do
     it 'when entity id is not specified' do
       service_name = 'test component'
       entity_id = ''
@@ -42,7 +53,18 @@ RSpec.describe 'New Service Page', type: :system do
       fill_in 'service_entity_id', with: entity_id
       click_button 'Create service'
 
-      expect(page).to have_content 'Entity ID is required'
+      expect(page).to have_content I18n.t('service.errors.missing_entity_id')
+    end
+
+    it 'when entity id has spaces between words' do
+      service_name = 'test component'
+      entity_id = ' http://test entity id '
+      visit new_service_path
+      fill_in 'service_name', with: service_name
+      fill_in 'service_entity_id', with: entity_id
+      click_button 'Create service'
+
+      expect(page).to have_content I18n.t('services.errors.invalid_entity_id_format')
     end
   end
 end


### PR DESCRIPTION
https://govukverify.atlassian.net/browse/HUB-766

- Added validation to the new_msa_component_event when the component is being created
- Fixed existing tests relying on the same entity id across all MSA components, now uses SecureRandom.alphanumeric to generate the entity id
- Created a system test to show that you cannot create a second MSA component with an existing entity id
- Also fixed a error display message.

https://govukverify.atlassian.net/browse/HUB-707

- Removed trailing and leading whitespaces from service/msa entity_id
- Raises an error if there are spaces between the string
- Created system / model test to prove this works

The new validation displays: 
<img width="400" alt="Screenshot 2021-01-21 at 11 48 17" src="https://user-images.githubusercontent.com/24409958/105347348-aee45900-5bde-11eb-9fb9-90ddb73f734d.png">

<img width="400" alt="Screenshot 2021-01-21 at 11 48 54" src="https://user-images.githubusercontent.com/24409958/105347418-c885a080-5bde-11eb-8a89-92ebafddb0b6.png">
