### PR TITLE
BAU: Fix admin display tabs that show separated IDP and RP teams

### DIFF
--- a/app/views/admin/_team.erb
+++ b/app/views/admin/_team.erb
@@ -1,6 +1,6 @@
 <%= link_to t('team.add_team'), new_team_path, class: "govuk-button" %>
 
-<% @teams.reverse.each do |team| %>
+<% teams.reverse.each do |team| %>
   <table class="govuk-table">
     <caption class="govuk-table__caption" id="teams/<%= team.id %>">Team ID: <%= team.id %></caption>
     <tbody class="govuk-table__body">


### PR DESCRIPTION
The partial was referring to the instance variable rather than the variable passed into the partial