### PR TITLE
HUB-852: Download buttons to retrieve emails from self-service

### DIFF
--- a/app/assets/stylesheets/_users.scss
+++ b/app/assets/stylesheets/_users.scss
@@ -26,3 +26,7 @@ div .remove-user-link {
 .align-member-status-right {
   text-align: right;
 }
+
+.download_csv {
+  float: right;
+}

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -2,4 +2,6 @@ class Team < Aggregate
   has_many :components
   validates_uniqueness_of :name, message: I18n.t('team.errors.name_not_unique')
   validates_uniqueness_of :team_alias, message: I18n.t('team.errors.name_not_unique')
+
+  scope :retrieve_teams_by_type, ->(team) { where(team_type: team) }
 end

--- a/app/policies/users_controller_policy.rb
+++ b/app/policies/users_controller_policy.rb
@@ -53,4 +53,8 @@ class UsersControllerPolicy < ApplicationPolicy
   def reset_user_password?
     user.permissions.user_management
   end
+
+  def emails_csv?
+    user.permissions.user_management
+  end
 end

--- a/app/views/admin/_team.erb
+++ b/app/views/admin/_team.erb
@@ -1,6 +1,6 @@
 <%= link_to t('team.add_team'), new_team_path, class: "govuk-button" %>
 
-<% teams&.each do |team| %>
+<% teams&.reverse&.each do |team| %>
   <table class="govuk-table">
     <caption class="govuk-table__caption" id="teams/<%= team.id %>">Team ID: <%= team.id %></caption>
     <tbody class="govuk-table__body">
@@ -14,7 +14,7 @@
       </tr>
       <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">Team type</th>
-        <td class="govuk-table__cell"><%= team.team_type %></td>
+        <td class="govuk-table__cell"><%= team.team_type.upcase %></td>
       </tr>
       <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">Created</th>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,21 +1,58 @@
 <%= page_title t('users.title') %>
 
 <% if @gds && params['team_id'].nil? %>
-  <h1 class="govuk-heading-l"><%= t 'team.heading' %></h1>
+
+  <h2 class="govuk-heading-m"><%= t 'team.heading' %>
+    <%= link_to t('users.download_csv_list', team_type: TEAMS::ALL.upcase), 
+        emails_csv_path(format: :csv, :team => TEAMS::ALL), 
+        class: 'govuk-button download_csv', data: { module: 'govuk-button' } %>
+  </h2><br>
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">  
+
+  <h2 class="govuk-heading-m"><%= t 'team.relying_parties' %>
+    <%= link_to t('users.download_csv_list', team_type: TEAMS::RP.upcase), 
+        emails_csv_path(format: :csv, :team => TEAMS::RP), 
+        class: 'govuk-button download_csv', data: { module: 'govuk-button' } %>
+  </h2>
   <ul class="govuk-list">
-    <% @teams.reverse.each do |team| %>
+    <% @rps&.reverse&.each do |team| %>
       <li>
-      <% if team.name == TEAMS::GDS %>
-        <%= link_to team.name.upcase, admin_users_path(team.id) %>
+        <%= link_to team.name, admin_users_path(team.id) %>
+      </li>
+    <% end %>
+  </ul>
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+  <h2 class="govuk-heading-m"><%= t 'team.identity_providers' %>
+    <%= link_to t('users.download_csv_list', team_type: TEAMS::IDP.upcase), 
+        emails_csv_path(format: :csv, :team => TEAMS::IDP), 
+        class: 'govuk-button download_csv', data: { module: 'govuk-button' } %>
+  </h2>
+  <ul class="govuk-list">
+    <% @idps&.reverse&.each do |team| %>
+      <li>
+        <%= link_to team.name, admin_users_path(team.id) %>
+      </li>
+    <% end %>
+  </ul>
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+  <h2 class="govuk-heading-m"><%= t 'team.other' %></h2>
+  <ul class="govuk-list">
+    <% @other&.reverse&.each do |team| %>
+      <li>
+        <% if team.name == TEAMS::GDS %>
+          <%= link_to team.name.upcase, admin_users_path(team.id) %>
           <strong class="govuk-tag">
             <%= t 'users.admin_team' %>
           </strong>
-        </li>
-      <% else %>
-        <%= link_to team.name, admin_users_path(team.id) %>
-      <% end %>
+        <% else %>
+          <%= link_to team.name, admin_users_path(team.id) %>
+        <% end %>
+      </li>
     <% end %>
   </ul>
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 <% else %>
   <% if @gds %>
     <%= link_to t('common.back'), users_path, class: 'govuk-back-link' %>

--- a/config/initializers/constants/teams.rb
+++ b/config/initializers/constants/teams.rb
@@ -5,4 +5,5 @@ module TEAMS
   RP = 'rp'.freeze
   IDP = 'idp'.freeze
   OTHER = 'other'.freeze
+  ALL = 'all'.freeze
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -59,6 +59,7 @@ en:
     title_for_team: Team members for
     change_details: Change details
     user_details: User details
+    download_csv_list: Download %{team_type} contacts
     invite:
       title: Invite a new user
       button: Invite user
@@ -279,6 +280,9 @@ en:
     heading: All teams
     name: Name
     add_team: Add new team
+    relying_parties: RPs
+    identity_providers: IDPs
+    other: Other
     new:
       title: New team
       heading: Add a team

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,7 @@ Rails.application.routes.draw do
   delete '/users/:user_id/remove-user', to: 'users#remove_user', as: :remove_user_post
   get '/users/:user_id/reset-user-password', to: 'users#show_reset_user_password', as: :reset_user_password
   post '/users/:user_id/reset-user-password', to: 'users#reset_user_password', as: :reset_user_password_post
+  get '/users/emails-csv', to: 'users#emails_csv', as: :emails_csv
 
   get '/profile/change-password', to: 'password#password_form'
   post '/profile/change-password', to: 'password#update_password'

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -23,14 +23,12 @@ RSpec.describe UsersController, type: :controller do
                         {name: "custom:roles", value: "certmgr"}]}
   }
 
-
   context 'GDS User' do
     before(:each) do
       gdsuser_stub_auth
     end
 
     describe '#index' do
-
 
       it 'renders the page' do
         get :index
@@ -48,7 +46,6 @@ RSpec.describe UsersController, type: :controller do
         expect(subject).to render_template(:index)
         expect(response).to have_http_status(:success)
       end
-
     end
 
     describe '#show' do
@@ -456,6 +453,38 @@ RSpec.describe UsersController, type: :controller do
         expect(subject).to redirect_to(update_user_path(user_id: user_id))
         expect(flash[:error]).to eq(t('users.update.resend_invitation.error'))
         expect(flash[:success]).to be_nil
+      end
+    end
+  end
+
+  context 'GDS User CSV download' do
+    render_views
+    before(:each) do
+      gdsuser_stub_auth
+    end
+
+    let(:rp_team) { create(:team, team_type: 'rp') }
+
+    describe '#emails_csv' do
+      it 'returns success if request format is CSV' do
+        get :emails_csv, format: :csv, params: { team: TEAMS::RP }
+        expect(response).to have_http_status(:success)
+        expect(response.header['Content-Type']).to include 'text/csv'
+      end
+
+      it 'get expected headers in CSV' do
+        get :emails_csv, format: :csv, params: { team: TEAMS::RP }
+        csv_data = response.body
+        csv_headers = CSV.parse(csv_data)[0]
+        expected_headers = ['email address']
+        expect(csv_headers).to match_array(expected_headers)
+      end
+
+      it 'get expected data in csv' do
+        get :emails_csv, format: :csv, params: { team: TEAMS::RP }
+        csv_first_row = CSV.parse(response.body)[1][0]
+        expected_first_row = ['cherry.one@test.com']
+        expect(expected_first_row).to match_array(csv_first_row)
       end
     end
   end

--- a/spec/system/visit_users_spec.rb
+++ b/spec/system/visit_users_spec.rb
@@ -13,9 +13,15 @@ RSpec.describe 'Users Page', type: :system do
   let(:team_cherry) { create(:new_team_event) }
   let(:team_rp) { create(:new_team_event, team_type: 'rp') }
   let(:team_idp) { create(:new_team_event, team_type: 'idp') }
+  let(:team_other) { create(:new_team_event, team_type: 'other') }
+
   let(:create_teams) { team_apple
-                        team_banana
-                        team_cherry }
+                       team_banana
+                       team_cherry
+                       team_rp
+                       team_idp
+                       team_other
+                      }
   let(:cognito_users) {
   {users: [
       {username: "111",
@@ -62,6 +68,16 @@ RSpec.describe 'Users Page', type: :system do
       expect(page).to have_link(team_apple.name)
       expect(page).to have_link(team_banana.name)
       expect(page).to have_link(team_cherry.name)
+      expect(page).to have_link(team_rp.name)
+      expect(page).to have_link(team_idp.name)
+      expect(page).to have_link(team_other.name)
+    end
+
+    it 'shows links to download csv lists' do
+      visit users_path
+      expect(page).to have_content t('users.download_csv_list', team_type: TEAMS::RP.upcase)
+      expect(page).to have_content t('users.download_csv_list', team_type: TEAMS::IDP.upcase)
+      expect(page).to have_content t('users.download_csv_list', team_type: TEAMS::ALL.upcase)
     end
   end
 
@@ -115,6 +131,13 @@ RSpec.describe 'Users Page', type: :system do
         end
       end
     end
+
+    it 'does not shows links to download csv lists' do
+      visit users_path
+      expect(page).to_not have_content t('users.download_csv_list', team_type: TEAMS::RP.upcase)
+      expect(page).to_not have_content t('users.download_csv_list', team_type: TEAMS::IDP.upcase)
+      expect(page).to_not have_content t('users.download_csv_list', team_type: TEAMS::ALL.upcase)
+    end
   end
 
   context 'IDP User' do
@@ -140,6 +163,13 @@ RSpec.describe 'Users Page', type: :system do
           expect(page).to have_content((user[:attributes][3][:value].split(',').include?(ROLE::USER_MANAGER) ? 'Can' : 'Cannot' ) + ' ' + t('users.roles.usermgr'))
         end
       end
+    end
+
+    it 'does not shows links to download csv lists' do
+      visit users_path
+      expect(page).to_not have_content t('users.download_csv_list', team_type: TEAMS::RP.upcase)
+      expect(page).to_not have_content t('users.download_csv_list', team_type: TEAMS::IDP.upcase)
+      expect(page).to_not have_content t('users.download_csv_list', team_type: TEAMS::ALL.upcase)
     end
   end
 end


### PR DESCRIPTION
Added download buttons to collect RP, IDP, ALL emails as CSV for Notify, from self-service.
The first column of each CVS is named email address (with a space) so it’s compatible with Notify.

Rearranged the Team members page to clearly put IDP, RP, OTHER team types into there own lists

It also adds the idasupport email address to each of the csv files that can be generated.

Before: 
<img width="500" alt="Screenshot 2021-02-24 at 17 14 21" src="https://user-images.githubusercontent.com/24409958/109167052-435d5080-7775-11eb-8cef-0a3d97256a20.png">

After: 
<img width="500" alt="Screenshot 2021-02-25 at 16 46 06" src="https://user-images.githubusercontent.com/24409958/109186557-f3888480-7788-11eb-9d97-a3d803bd377a.png">

The generated CSV looks like this:
<img width="500" alt="Screenshot 2021-02-25 at 14 23 09" src="https://user-images.githubusercontent.com/24409958/109167168-5ff98880-7775-11eb-9b67-bd387748909d.png">