### PR TITLE
HUB-835: Admin support for IDP & RP teams

### DIFF
--- a/app/controllers/user_journey_controller.rb
+++ b/app/controllers/user_journey_controller.rb
@@ -11,7 +11,7 @@ class UserJourneyController < ApplicationController
   before_action :find_team_name
 
   def index
-    return redirect_to users_path if helpers.idp_team_user?
+    return redirect_to users_path if helpers.idp_team?(current_user&.team)
 
     if current_user.permissions.component_management
       @components = SpComponent.all + MsaComponent.all

--- a/app/helpers/user_journey_helper.rb
+++ b/app/helpers/user_journey_helper.rb
@@ -51,11 +51,11 @@ module UserJourneyHelper
     components.map(&:current_certificates).flatten.select(&:expires_soon?).count
   end
 
-  def idp_team_user?
-    Team.find(current_user.team).team_type == TEAMS::IDP unless current_user.team.nil?
+  def idp_team?(team)
+    Team.find_by_id(team).idp? if Team.exists?(team)
   end
 
-  def rp_team_user?
-    Team.find(current_user.team).team_type == TEAMS::RP unless current_user.team.nil?
+  def determine_team_type
+    Team.find_by_id(current_user.permissions.admin_management ? params[:team_id] : current_user.team).team_type
   end
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -4,4 +4,8 @@ class Team < Aggregate
   validates_uniqueness_of :team_alias, message: I18n.t('team.errors.name_not_unique')
 
   scope :retrieve_teams_by_type, ->(team) { where(team_type: team) }
+
+  def idp?
+    team_type == TEAMS::IDP
+  end
 end

--- a/app/views/layouts/main_layout.html.erb
+++ b/app/views/layouts/main_layout.html.erb
@@ -19,7 +19,7 @@
     <div class="govuk-grid-column-one-quarter">
       <div class="side-navigation">
         <ul class="govuk-list">
-          <% unless idp_team_user? %>
+          <% unless idp_team?(current_user&.team) %>
             <li class="<%= 'active' if 'user_journey'.include?(params[:controller])  %>">
               <%= link_to t('components.title'), root_path, class: "govuk-link--no-visited-state" %>
             </li>

--- a/app/views/shared/_component_teams.erb
+++ b/app/views/shared/_component_teams.erb
@@ -1,7 +1,7 @@
 <div class="govuk-form-group <%= 'govuk-form-group--error' if @component.errors.key?(:team_id) %>">
   <h3 class="govuk-heading-m"><%= t 'components.team' %></h3>
   <div class="govuk-form-group">
-    <%= f.select(:team_id, teams.map{|t|[t.name, t.id]},
+    <%= f.select(:team_id, teams.reject(&:idp?).map { |t| [t.name, t.id] },
     {include_blank: 'Select'},
     {class: 'govuk-select'})
     %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -74,7 +74,7 @@
               <span class="govuk-hint email-wrapper"><%= @user.email == member.email ? t('users.you') : member.email %></span>
             </h3>
             <% unless member.gds? %>
-              <% unless idp_team_user? %>
+              <% unless idp_team?(params[:team_id] || current_user&.team) %>
                 <span class="tick-cross-<%= member.cert_manager? ? 'tick' : 'cross' %>">
                   <span class="govuk-visually-hidden"><%= member.cert_manager? ? t('users.permissions.can') : t('users.permissions.cannot') %></span>
                   <%= t 'users.roles.certmgr' %>
@@ -89,7 +89,7 @@
           <td class="govuk-table__cell">
             <div class="align-member-status-right">
               <% if @user.email != member.email %>
-                  <%= link_to t('users.change_details'), update_user_path(member.user_id) %>
+                  <%= link_to t('users.change_details'), update_user_path(member.user_id, team_type: determine_team_type)%>
                 <% if @gds || (member.user_status?('FORCE_CHANGE_PASSWORD') || member.user_status?('RESET_REQUIRED')) %>
                   <p><%= t("users.status.#{member.status}") unless member.status == "CONFIRMED" %></p>
                 <% end %>

--- a/app/views/users/invite.html.erb
+++ b/app/views/users/invite.html.erb
@@ -48,7 +48,7 @@
       <%= error_message_on(f.object.errors, :roles) if @form.errors.key?(:roles) %>
       <fieldset class="govuk-fieldset">
         <div class="govuk-checkboxes" id="invite_user_form_roles">
-          <% unless idp_team_user? %>
+          <% unless idp_team?(params[:team_id]) %>
             <div class="govuk-checkboxes__item">
               <%= f.check_box(:roles, { class: 'govuk-checkboxes__input', multiple: true }, ROLE::CERTIFICATE_MANAGER, nil) %>
               <%= f.label :roles, t("users.roles.#{ROLE::CERTIFICATE_MANAGER}"), class: 'govuk-label govuk-checkboxes__label' %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -33,7 +33,7 @@
         <%= t('users.show.select_one') %>
         </span>
         <div class="govuk-checkboxes">
-          <% unless idp_team_user? %>
+          <% unless params[:team_type] == TEAMS::IDP %>
             <div class="govuk-checkboxes__item">
               <%= f.check_box(:roles, { class: 'govuk-checkboxes__input', multiple: true }, ROLE::CERTIFICATE_MANAGER, nil) %>
               <%= f.label :roles, t("users.roles.#{ROLE::CERTIFICATE_MANAGER}"), class: 'govuk-label govuk-checkboxes__label' %>

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :user do
-    user_id { '000000'}
+    user_id { SecureRandom.uuid }
     first_name { 'John' }
     last_name  { 'Doe' }
     email { 'test@test.test' }

--- a/spec/system/visit_msa_component_new_spec.rb
+++ b/spec/system/visit_msa_component_new_spec.rb
@@ -8,7 +8,11 @@ RSpec.describe 'New MSA Component Page', type: :system do
 
   let(:entity_id) { SecureRandom.alphanumeric }
   let(:team) { create(:new_team_event).team }
-  let(:create_teams) { team }
+  let(:rp_team) { create(:new_team_event, team_type: 'rp').team }
+  let(:idp_team) { create(:new_team_event, team_type: 'idp').team }
+  let(:create_teams) { team
+                       idp_team
+                       rp_team }
   let(:msa_component) { create(:msa_component, entity_id: 'http://test-entity-id') }
 
   context 'creation is successful' do
@@ -20,6 +24,22 @@ RSpec.describe 'New MSA Component Page', type: :system do
       fill_in 'component_entity_id', with: entity
       select team.name, from: "component_team_id"
       choose('component_environment_staging')
+      click_button 'Create MSA component'
+
+      expect(current_path).to eql admin_path
+    end
+
+    it 'does not show IDP teams in team list' do
+      entity = entity_id
+      component_name = 'test component'
+      visit new_msa_component_path
+      fill_in 'component_name', with: component_name
+      fill_in 'component_entity_id', with: entity
+      select team.name, from: "component_team_id"
+      choose('component_environment_staging')
+      expect(page).to have_content(team.name)
+      expect(page).to have_content(rp_team.name)
+      expect(page).to_not have_content(idp_team.name)
       click_button 'Create MSA component'
 
       expect(current_path).to eql admin_path

--- a/spec/system/visit_sp_component_new_spec.rb
+++ b/spec/system/visit_sp_component_new_spec.rb
@@ -6,9 +6,12 @@ RSpec.describe 'New SP Component Page', type: :system do
     create_teams
   end
 
-  let(:entity_id) { 'http://test-entity-id' }
   let(:team) { create(:new_team_event).team }
-  let(:create_teams) { team }
+  let(:rp_team) { create(:new_team_event, team_type: 'rp').team }
+  let(:idp_team) { create(:new_team_event, team_type: 'idp').team }
+  let(:create_teams) { team
+                       idp_team
+                       rp_team }
 
   context 'creation is successful' do
     it 'when required input is specified' do
@@ -18,6 +21,22 @@ RSpec.describe 'New SP Component Page', type: :system do
       choose 'component_environment_staging'
       fill_in 'component_name', with: component_name
       select team.name, from: "component_team_id"
+      click_button 'Create SP component'
+
+      expect(current_path).to eql admin_path
+    end
+
+    it 'does not show IDP teams in team list' do
+      component_name = 'test component'
+      visit new_sp_component_path
+      choose 'component_component_type_vspcomponent', allow_label_click: true
+      choose 'component_environment_staging'
+      fill_in 'component_name', with: component_name
+      select team.name, from: "component_team_id"
+      choose('component_environment_staging')
+      expect(page).to have_content(team.name)
+      expect(page).to have_content(rp_team.name)
+      expect(page).to_not have_content(idp_team.name)
       click_button 'Create SP component'
 
       expect(current_path).to eql admin_path

--- a/spec/system/visit_users_details_page_spec.rb
+++ b/spec/system/visit_users_details_page_spec.rb
@@ -3,86 +3,168 @@ require 'rails_helper'
 RSpec.describe 'Update user Page', type: :system do
   include CognitoSupport
 
-  let(:member_user_id) { SecureRandom::uuid }
-  let(:member_first_name) { 'Tester' }
-  let(:member_family_name) { 'Testerator' }
-  let(:member_email) { 'test@test.com' }
 
-  let(:cognito_user) {
-    { username: member_user_id,
-      user_attributes: [{name: "given_name", value: member_first_name},
-                        {name: "family_name", value: member_family_name},
-                        {name: "email", value: member_email},
-                        {name: "custom:roles", value: "certmgr"}]}
-  }
+  context 'GDS user' do
+    let(:team_rp) { create(:team, team_type: 'rp') }
+    let(:team_idp) { create(:team, team_type: 'idp') }
+    let(:create_teams) { team_rp
+                         team_idp}
+    let(:idp_team_member) { create(:idp_user_manager_user, first_name: 'IDP USER' ,team: team_idp.id) }
+    let(:rp_team_member) { create(:rp_user_manager_user, first_name: 'RP USER', team: team_rp.id) }
 
-  let(:cognito_users) {
-    { users: [
-      { username: member_user_id,
-        attributes: [{name: "given_name", value: member_first_name},
-                          {name: "family_name", value: member_family_name},
-                          {name: "email", value: member_email},
+    let(:cognito_rp_user) {
+      { username: rp_team_member.user_id,
+        user_attributes: [{name: "given_name", value: rp_team_member.first_name},
+                          {name: "family_name", value: rp_team_member.last_name},
+                          {name: "email", value: rp_team_member.email},
                           {name: "custom:roles", value: "certmgr"}]}
+    }
+
+    let(:cognito_rp_users) {
+        { users: [
+          { username: rp_team_member.user_id,
+            attributes: [{name: "given_name", value: rp_team_member.first_name},
+                              {name: "family_name", value: rp_team_member.last_name},
+                              {name: "email", value: rp_team_member.email},
+                              {name: "custom:roles", value: "certmgr"}]}
+        ]}
+    }
+
+    let(:cognito_idp_user) {
+      { username: idp_team_member.user_id,
+        user_attributes: [{name: "given_name", value: idp_team_member.first_name},
+                          {name: "family_name", value: idp_team_member.last_name},
+                          {name: "email", value: idp_team_member.email},
+                          {name: "custom:roles", value: "usermgr"}]}
+    }
+
+    let(:cognito_idp_users) {
+      { users: [
+        { username: idp_team_member.user_id,
+          attributes: [{name: "given_name", value: idp_team_member.first_name},
+                            {name: "family_name", value: idp_team_member.last_name},
+                            {name: "email", value: idp_team_member.email},
+                            {name: "custom:roles", value: "usermgr"}]}
       ]}
     }
 
-  before(:each) do
-    stub_cognito_response(method: :admin_get_user, payload: cognito_user)
-  end
-
-  context 'GDS user' do
     before(:each) do
       login_gds_user
     end
 
     it 'renders the page' do
-      visit update_user_path(user_id: member_user_id)
-      expect(page).to have_title t('users.show.title', name: member_first_name + ' ' + member_family_name)
-      expect(page).to have_content member_first_name + ' ' + member_family_name
-    end
-  end
+      stub_cognito_response(method: :admin_get_user, payload: cognito_rp_user)
 
-  context 'User Manager' do
-    before(:each) do
-      user = FactoryBot.create(:user_manager_user)
-      login_as(user, scope: :user)
-      stub_cognito_response(method: :list_users_in_group, payload: cognito_users)
+      visit update_user_path(user_id: rp_team_member.user_id )
+      expect(page).to have_title t('users.show.title', name: rp_team_member.first_name + ' ' + rp_team_member.last_name)
+      expect(page).to have_content rp_team_member.first_name + ' ' + rp_team_member.last_name
     end
 
-    it 'shows team members' do
-      visit update_user_path(user_id: member_user_id)
-      expect(page).to have_title t('users.show.title', name: member_first_name + ' ' + member_family_name)
-      expect(page).to have_content member_first_name + ' ' + member_family_name
+    it 'does not show manage certificates role option when updating idp team user' do
+      stub_cognito_response(method: :admin_get_user, payload: cognito_idp_user)
+      stub_cognito_response(method: :list_users_in_group, payload: cognito_idp_users)
+
+      visit users_path
+      expect(page).to have_content t('team.heading')
+      click_link team_idp.name
+      expect(page).to have_content(team_idp.name)
+      expect(page).to have_css('table', text: t('users.roles.usermgr'))
+      expect(page).to_not have_css('table', text: t('users.roles.certmgr'))
+      find('#' + idp_team_member.user_id).click_link(t('users.change_details'))
+      expect(page).to have_title t('users.show.title', name: idp_team_member.first_name + ' ' + idp_team_member.last_name)
+      expect(page).to_not have_css('fieldset', text: t('users.roles.certmgr'))
+      expect(page).to have_css('fieldset', text: t('users.roles.usermgr'))
+    end
+
+    it 'does show manage certificates role option when updating rp team user' do
+      stub_cognito_response(method: :admin_get_user, payload: cognito_rp_user)
+      stub_cognito_response(method: :list_users_in_group, payload: cognito_rp_users)
+
+      visit users_path
+      expect(page).to have_content t('team.heading')
+      click_link team_rp.name
+      expect(page).to have_content(team_rp.name)
+      expect(page).to have_css('table', text: t('users.roles.usermgr'))
+      expect(page).to have_css('table', text: t('users.roles.certmgr'))
+      find('#' + rp_team_member.user_id).click_link(t('users.change_details'))
+      expect(page).to have_title t('users.show.title', name: rp_team_member.first_name + ' ' + rp_team_member.last_name)
+      expect(page).to have_css('fieldset', text: t('users.roles.certmgr'))
+      expect(page).to have_css('fieldset', text: t('users.roles.usermgr'))
     end
   end
 
   context 'RP user' do
+    let(:team_rp) { create(:team, team_type: 'rp') }
+    let(:create_teams) { team_rp }
+    let(:rp_team_member) { create(:rp_user_manager_user, first_name: 'RP USER', team: team_rp.id) }
+
+    let(:cognito_rp_user) {
+      { username: rp_team_member.user_id,
+        user_attributes: [{name: "given_name", value: rp_team_member.first_name},
+                          {name: "family_name", value: rp_team_member.last_name},
+                          {name: "email", value: rp_team_member.email},
+                          {name: "custom:roles", value: "certmgr"}]}
+    }
+
+    let(:cognito_rp_users) {
+        { users: [
+          { username: rp_team_member.user_id,
+            attributes: [{name: "given_name", value: rp_team_member.first_name},
+                              {name: "family_name", value: rp_team_member.last_name},
+                              {name: "email", value: rp_team_member.email},
+                              {name: "custom:roles", value: "certmgr"}]}
+        ]}
+    }
+
     before(:each) do
       login_rp_user
-      stub_cognito_response(method: :list_users_in_group, payload: cognito_users)
     end
 
-    it 'shows team members' do
-      visit update_user_path(user_id: member_user_id)
-      expect(page).to have_title t('users.show.title', name: member_first_name + ' ' + member_family_name)
-      expect(page).to have_content member_first_name + ' ' + member_family_name
-      expect(page).to have_content t('users.roles.certmgr')
-      expect(page).to have_content t('users.roles.usermgr')
+    it 'shows team members with the certificate manager role option' do
+      stub_cognito_response(method: :admin_get_user, payload: cognito_rp_user)
+      stub_cognito_response(method: :list_users_in_group, payload: cognito_rp_users)
+
+      visit update_user_path(user_id: rp_team_member.user_id, team_type: TEAMS::RP)
+      expect(page).to have_content rp_team_member.first_name + ' ' + rp_team_member.last_name
+      expect(page).to have_css('fieldset', text: t('users.roles.certmgr'))
+      expect(page).to have_css('fieldset', text: t('users.roles.usermgr'))
     end
   end
 
   context 'IDP user' do
+    let(:team_idp) { create(:team, team_type: 'idp') }
+    let(:create_teams) { team_idp }
+    let(:idp_team_member) { create(:idp_user_manager_user, first_name: 'IDP USER' ,team: team_idp.id) }
+
+    let(:cognito_idp_user) {
+      { username: idp_team_member.user_id,
+        user_attributes: [{name: "given_name", value: idp_team_member.first_name},
+                          {name: "family_name", value: idp_team_member.last_name},
+                          {name: "email", value: idp_team_member.email},
+                          {name: "custom:roles", value: "usermgr"}]}
+    }
+
+    let(:cognito_idp_users) {
+      { users: [
+        { username: idp_team_member.user_id,
+          attributes: [{name: "given_name", value: idp_team_member.first_name},
+                            {name: "family_name", value: idp_team_member.last_name},
+                            {name: "email", value: idp_team_member.email},
+                            {name: "custom:roles", value: "usermgr"}]}
+      ]}
+    }
     before(:each) do
       login_idp_user
-      stub_cognito_response(method: :list_users_in_group, payload: cognito_users)
     end
 
-    it 'shows team members' do
-      visit update_user_path(user_id: member_user_id)
-      expect(page).to have_title t('users.show.title', name: member_first_name + ' ' + member_family_name)
-      expect(page).to have_content member_first_name + ' ' + member_family_name
-      expect(page).to_not have_content t('users.roles.certmgr')
-      expect(page).to have_content t('users.roles.usermgr')
+    it 'shows team members without the certificate manager role option' do
+      stub_cognito_response(method: :admin_get_user, payload: cognito_idp_user)
+      stub_cognito_response(method: :list_users_in_group, payload: cognito_idp_users)
+
+      visit update_user_path(user_id: idp_team_member.user_id, team_type: TEAMS::IDP)
+      expect(page).to have_content(idp_team_member.first_name + ' ' + idp_team_member.last_name)
+      expect(page).to_not have_css('fieldset', text: t('users.roles.certmgr'))
+      expect(page).to have_css('fieldset', text: t('users.roles.usermgr'))
     end
   end
 end

--- a/spec/system/visit_users_spec.rb
+++ b/spec/system/visit_users_spec.rb
@@ -3,74 +3,49 @@ require 'rails_helper'
 RSpec.describe 'Users Page', type: :system do
   include CognitoSupport
 
-  before(:each) do
-    stub_cognito_response( method: :create_group, payload: {} )
-    create_teams
-  end
-
-  let(:team_apple) { create(:new_team_event) }
-  let(:team_banana) { create(:new_team_event) }
-  let(:team_cherry) { create(:new_team_event) }
-  let(:team_rp) { create(:new_team_event, team_type: 'rp') }
-  let(:team_idp) { create(:new_team_event, team_type: 'idp') }
-  let(:team_other) { create(:new_team_event, team_type: 'other') }
-
-  let(:create_teams) { team_apple
-                       team_banana
-                       team_cherry
-                       team_rp
-                       team_idp
-                       team_other
-                      }
-  let(:cognito_users) {
-  {users: [
-      {username: "111",
-        user_status: 'CONFIRMED',
-        attributes: [{name: "given_name", value: "Apple"},
-                    {name: "family_name", value: "One"},
-                    {name: "email", value: "apple.one@test.com"},
-                    {name: "custom:roles", value: "usermgr"}
-        ]},
-      {username: "222",
-        user_status: 'FORCE_CHANGE_PASSWORD',
-        attributes: [{name: "given_name", value: "Apple"},
-                    {name: "family_name", value: "Two"},
-                    {name: "email", value: "apple.two@test.com"},
-                    {name: "custom:roles", value: "certmgr,usermgr"}
-        ]},
-      {username: "333",
-        user_status: 'COMPROMISED',
-        attributes: [{name: "given_name", value: "Apple"},
-                    {name: "family_name", value: "Three"},
-                    {name: "email", value: "apple.three@test.com"},
-                    {name: "custom:roles", value: "certmgr"}
-        ]},
-        {username: "444",
-        user_status: 'RESET_REQUIRED',
-        attributes: [{name: "given_name", value: "Apple"},
-                      {name: "family_name", value: "Four"},
-                      {name: "email", value: "apple.four@test.com"},
-                      {name: "custom:roles", value: "certmgr"}
-        ]}
-        ]}
-  }
   let(:visible_statuses) { %w(FORCE_CHANGE_PASSWORD RESET_REQUIRED)}
 
-
   context 'GDS user' do
+    let(:team_rp) { create(:team, team_type: 'rp') }
+    let(:team_idp) { create(:team, team_type: 'idp') }
+    let(:create_teams) { team_rp
+                         team_idp}
+
+    let(:rp_team_member) { create(:idp_user_manager_user, email: 'rp@t.com', team: team_rp.id) }
+    let(:idp_team_member) { create(:idp_user_manager_user, email: 'idp@t.com', team: team_idp.id) }
+
+    let(:cognito_rp_users) {
+      { users: [
+        { username: rp_team_member.user_id,
+          attributes: [{name: "given_name", value: rp_team_member.first_name},
+                            {name: "family_name", value: rp_team_member.last_name},
+                            {name: "email", value: rp_team_member.email},
+                            {name: "custom:roles", value: "certmgr"}]}
+      ]}
+    }
+
+    let(:cognito_idp_users) {
+      { users: [
+        { username: idp_team_member.user_id,
+          attributes: [{name: "given_name", value: idp_team_member.first_name},
+                            {name: "family_name", value: idp_team_member.last_name},
+                            {name: "email", value: idp_team_member.email},
+                            {name: "custom:roles", value: "usermgr"}]}
+      ]}
+    }
+
     before(:each) do
       login_gds_user
     end
 
     it 'shows all teams' do
+      stub_cognito_response(method: :list_users_in_group, payload: cognito_rp_users)
+      stub_cognito_response(method: :list_users_in_group, payload: cognito_idp_users)
+
       visit users_path
       expect(page).to have_content t('team.heading')
-      expect(page).to have_link(team_apple.name)
-      expect(page).to have_link(team_banana.name)
-      expect(page).to have_link(team_cherry.name)
       expect(page).to have_link(team_rp.name)
       expect(page).to have_link(team_idp.name)
-      expect(page).to have_link(team_other.name)
     end
 
     it 'shows links to download csv lists' do
@@ -79,42 +54,80 @@ RSpec.describe 'Users Page', type: :system do
       expect(page).to have_content t('users.download_csv_list', team_type: TEAMS::IDP.upcase)
       expect(page).to have_content t('users.download_csv_list', team_type: TEAMS::ALL.upcase)
     end
-  end
 
-  context 'User Manager' do
-    before(:each) do
-      user = FactoryBot.create(:user_manager_user, team: team_apple.team.id)
-      login_as(user, scope: :user)
-      stub_cognito_response(method: :list_users_in_group, payload: cognito_users)
-    end
+    it 'does show manage certificates role option for rp team members' do
+      stub_cognito_response(method: :list_users_in_group, payload: cognito_rp_users)
 
-    it 'shows team members' do
       visit users_path
-      expect(page).to have_content t('users.title_for_team')+' '+team_apple.name
-      cognito_users[:users].each do |user|
-        if visible_statuses.include?(user[:user_status])
-          expect(page).to have_content(t("users.status.#{user[:user_status]}"))
-        else
-          expect(page).not_to have_content(t("users.status.#{user[:user_status]}"))
-        end
-
-        expect(page).to have_content(user[:attributes][0][:value] +' '+ user[:attributes][1][:value] )
-        within("##{user[:username]}") do
-          expect(page).to have_content((user[:attributes][3][:value].split(',').include?(ROLE::CERTIFICATE_MANAGER) ? 'Can' : 'Cannot' ) + ' ' + t('users.roles.certmgr'))
-          expect(page).to have_content((user[:attributes][3][:value].split(',').include?(ROLE::USER_MANAGER) ? 'Can' : 'Cannot' ) + ' ' + t('users.roles.usermgr'))
-        end
-      end
+      expect(page).to have_content t('team.heading')
+      expect(page).to have_link(team_rp.name)
+      click_link team_rp.name
+      expect(page).to have_content(team_rp.name)
+      expect(page).to have_css('table', text: t('users.roles.usermgr'))
+      expect(page).to have_css('table', text: t('users.roles.certmgr'))
     end
+
+    it 'does not show manage certificates role option for idp team members' do
+      stub_cognito_response(method: :list_users_in_group, payload: cognito_idp_users)
+
+      visit users_path
+      expect(page).to have_content t('team.heading')
+      expect(page).to have_link(team_idp.name)
+      click_link team_idp.name
+      expect(page).to have_content(team_idp.name)
+      expect(page).to have_css('table', text: t('users.roles.usermgr'))
+      expect(page).to_not have_css('table', text: t('users.roles.certmgr'))
+    end
+
   end
 
   context 'RP User' do
-    before(:each) do
-      user = FactoryBot.create(:rp_user_manager_user, team: team_rp.team.id)
-      login_as(user, scope: :user)
-      stub_cognito_response(method: :list_users_in_group, payload: cognito_users)
-    end
+    let(:team_rp) { create(:team, team_type: 'rp') }
+    let(:create_teams) { team_rp}
+  
+    let(:rp_team_member_1) { create(:idp_user_manager_user, email: 't1@t.com', team: team_rp.id) }
+    let(:rp_team_member_2) { create(:idp_user_manager_user, email: 't2@t.com', team: team_rp.id) }
+    let(:rp_team_member_3) { create(:idp_user_manager_user, email: 't3@t.com', team: team_rp.id) }
+    let(:rp_team_member_4) { create(:idp_user_manager_user, email: 't4@t.com', team: team_rp.id) }
+  
+    let(:cognito_users) {
+    {users: [
+        {username: "111",
+          user_status: 'CONFIRMED',
+          attributes: [{name: "given_name", value: rp_team_member_1.first_name},
+                      {name: "family_name", value: rp_team_member_1.last_name},
+                      {name: "email", value: rp_team_member_1.email},
+                      {name: "custom:roles", value: "certmgr"}
+          ]},
+        {username: "222",
+          user_status: 'FORCE_CHANGE_PASSWORD',
+           attributes: [{name: "given_name", value: rp_team_member_2.first_name},
+                      {name: "family_name", value: rp_team_member_2.last_name},
+                      {name: "email", value: rp_team_member_2.email},
+                      {name: "custom:roles", value: "usermgr"}
+          ]},
+        {username: "333",
+          user_status: 'COMPROMISED',
+          attributes: [{name: "given_name", value: rp_team_member_3.first_name},
+                      {name: "family_name", value: rp_team_member_3.last_name},
+                      {name: "email", value: rp_team_member_3.email},
+                      {name: "custom:roles", value: "certmgr"}
+          ]},
+          {username: "444",
+          user_status: 'RESET_REQUIRED',
+          attributes: [{name: "given_name", value: rp_team_member_4.first_name},
+                      {name: "family_name", value: rp_team_member_4.last_name},
+                      {name: "email", value: rp_team_member_4.email},
+                      {name: "custom:roles", value: "usermgr"}
+          ]}
+          ]}
+    }
 
     it 'shows team members' do
+      user = FactoryBot.create(:idp_user_manager_user, team: team_rp.id)
+      login_as(user, scope: :user)
+      stub_cognito_response(method: :list_users_in_group, payload: cognito_users)
+
       visit users_path
       expect(page).to have_content t('users.title_for_team')+' '+team_rp.name
       cognito_users[:users].each do |user|
@@ -141,14 +154,53 @@ RSpec.describe 'Users Page', type: :system do
   end
 
   context 'IDP User' do
-    before(:each) do
-      user = FactoryBot.create(:idp_user_manager_user, team: team_idp.team.id)
-      login_as(user, scope: :user)
-      stub_cognito_response(method: :list_users_in_group, payload: cognito_users)
-    end
+    let(:team_idp) { create(:team, team_type: 'idp') }
+    let(:create_teams) { team_idp}
+  
+    let(:idp_team_member_1) { create(:idp_user_manager_user, email: 't1@t.com', team: team_idp.id) }
+    let(:idp_team_member_2) { create(:idp_user_manager_user, email: 't2@t.com', team: team_idp.id) }
+    let(:idp_team_member_3) { create(:idp_user_manager_user, email: 't3@t.com', team: team_idp.id) }
+    let(:idp_team_member_4) { create(:idp_user_manager_user, email: 't4@t.com', team: team_idp.id) }
+  
+    let(:cognito_users) {
+    {users: [
+        {username: "111",
+          user_status: 'CONFIRMED',
+          attributes: [{name: "given_name", value: idp_team_member_1.first_name},
+                      {name: "family_name", value: idp_team_member_1.last_name},
+                      {name: "email", value: idp_team_member_1.email},
+                      {name: "custom:roles", value: "usermgr"}
+          ]},
+        {username: "222",
+          user_status: 'FORCE_CHANGE_PASSWORD',
+           attributes: [{name: "given_name", value: idp_team_member_2.first_name},
+                      {name: "family_name", value: idp_team_member_2.last_name},
+                      {name: "email", value: idp_team_member_2.email},
+                      {name: "custom:roles", value: "usermgr"}
+          ]},
+        {username: "333",
+          user_status: 'COMPROMISED',
+          attributes: [{name: "given_name", value: idp_team_member_3.first_name},
+                      {name: "family_name", value: idp_team_member_3.last_name},
+                      {name: "email", value: idp_team_member_3.email},
+                      {name: "custom:roles", value: "usermgr"}
+          ]},
+          {username: "444",
+          user_status: 'RESET_REQUIRED',
+          attributes: [{name: "given_name", value: idp_team_member_4.first_name},
+                      {name: "family_name", value: idp_team_member_4.last_name},
+                      {name: "email", value: idp_team_member_4.email},
+                      {name: "custom:roles", value: "usermgr"}
+          ]}
+          ]}
+    }
 
     it 'shows team members' do
-      visit users_path
+      user = FactoryBot.create(:idp_user_manager_user, team: team_idp.id)
+      login_as(user, scope: :user)
+      stub_cognito_response(method: :list_users_in_group, payload: cognito_users)
+
+      visit users_path       
       expect(page).to have_content t('users.title_for_team')+' '+team_idp.name
       cognito_users[:users].each do |user|
         if visible_statuses.include?(user[:user_status])


### PR DESCRIPTION
Subsequent to https://github.com/alphagov/verify-self-service/pull/395

Admin users can no longer see and click manage certificate role for idp team users
Remove IDP teams from list on components so you cannot add components to idp teams

Fix the testing suite, the way the initial setup was being done meant that the tests kept getting mixed information
 - made clear seperation between the test cases

No longer show the certificate manager role option:
<img width="500" alt="Screenshot 2021-03-02 at 14 26 31" src="https://user-images.githubusercontent.com/24409958/109662811-5bf9ac00-7b63-11eb-94d5-2ba8051ce3ab.png">

<img width="500" alt="Screenshot 2021-03-02 at 14 26 37" src="https://user-images.githubusercontent.com/24409958/109662841-64ea7d80-7b63-11eb-9897-979eb33e6498.png">
