### PR TITLE
[HUB-841] Use Docker Hub rather than GHCR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/alphagov/verify/ruby:2.6.6
+FROM ruby:2.6.6
 
 ADD Gemfile Gemfile
 ADD Gemfile.lock Gemfile.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM ruby:2.6.6
+ARG base_image=ruby:2.6.6
+FROM ${base_image}
 
 ADD Gemfile Gemfile
 ADD Gemfile.lock Gemfile.lock

--- a/run.Dockerfile
+++ b/run.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/alphagov/verify/ruby:2.6.6
+FROM ruby:2.6.6
 
 ADD Gemfile Gemfile
 ADD Gemfile.lock Gemfile.lock

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/alphagov/verify/ruby:2.6.6
+FROM ruby:2.6.6
 
 ADD Gemfile Gemfile
 ADD Gemfile.lock Gemfile.lock

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -1,4 +1,5 @@
-FROM ruby:2.6.6
+ARG base_image=ruby:2.6.6
+FROM ${base_image}
 
 ADD Gemfile Gemfile
 ADD Gemfile.lock Gemfile.lock


### PR DESCRIPTION
We have moved back to using DockerHub rather than GitHub container registry and have to replace our Dockerfiles with arguments using instructions from DockerHub. However, because we're also using oci-build-task now and registry-image rather than docker-image in concourse we also need to supply an IMAGE_ARG instruction so we're speedy.

I've added that in a companion commit over at https://github.com/alphagov/verify-terraform/pull/1457/files