### PR TITLE
HUB-981: Add support page with email

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ You can start the application with:
 
 `./startup.sh`
 
+Use these credentials when running Self-Service locally
+
+* email: any email address
+* password: any password with at least 8 characters
+
 ### Running the tests
 Test are run in docker environment pegged to use firefox-esr and can be run as follows:
 

--- a/app/controllers/support_controller.rb
+++ b/app/controllers/support_controller.rb
@@ -1,0 +1,6 @@
+class SupportController < ApplicationController
+  def index
+    @support_email = Rails.configuration.support_email
+    render :index
+  end
+end

--- a/app/models/user_role_permissions.rb
+++ b/app/models/user_role_permissions.rb
@@ -1,6 +1,6 @@
 class UserRolePermissions
   attr_reader :admin_management, :component_management, :team_management, :user_management, :event_management,
-              :certificate_management, :read_components, :update_profile, :change_password
+              :certificate_management, :read_components, :update_profile, :change_password, :view_support
 
   def initialize(roles_str, email = nil)
     all_users
@@ -15,6 +15,7 @@ class UserRolePermissions
     "read_components = #{read_components}\n" \
     "update_profile = #{update_profile}\n" \
     "change_password = #{change_password}\n" \
+    "view_support = #{view_support}\n" \
     "certificate_management = #{certificate_management}\n" \
     "component_management = #{component_management}\n" \
     "team_management = #{team_management}\n" \
@@ -33,6 +34,7 @@ private
     @read_components = true
     @update_profile = true
     @change_password = true
+    @view_support = true
     @certificate_management = false
     @component_management = false
     @team_management = false

--- a/app/policies/support_controller_policy.rb
+++ b/app/policies/support_controller_policy.rb
@@ -1,0 +1,7 @@
+class SupportControllerPolicy < ApplicationPolicy
+  attr_reader :user
+
+  def index?
+    user.permissions.view_support
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -62,7 +62,7 @@
                   <%= link_to t('layout.application.documentation'), t('user_journey.urls.rotation_documentation'), class: "govuk-header__link" %>
                 </li>
                 <li class="govuk-header__navigation-item">
-                  <%= link_to t('layout.application.support'), t('user_journey.urls.support'), class: "govuk-header__link" %>
+                  <%= link_to t('layout.application.support'), support_path, class: "govuk-header__link" %>
                 </li>
                 <li class="govuk-header__navigation-item">
                   <%= link_to t('layout.application.profile'), profile_path, class: "govuk-header__link" %>

--- a/app/views/support/index.html.erb
+++ b/app/views/support/index.html.erb
@@ -1,0 +1,31 @@
+<%= page_title 'Support' %>
+
+<main class="govuk-main-wrapper" id="main" role="main">
+  <div class="govuk-width-container">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">
+          Support
+        </h1>
+        <div>
+          <h2 class="govuk-heading-m">
+            What to do when your service is experiencing issues
+          </h2>
+          <p class="govuk-body">
+            If there are disruptions to your service and you think they’re connected to Verify, your Matching Service Adapter or Verify Service Provider:
+          </p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>
+              check if there are any
+              <a href="https://verifystatus.digital.cabinet-office.gov.uk/" class="govuk-link">ongoing incidents</a>:
+              if it's a known issue with the platform, it will show there and we'll keep our users updated on how the incident is progressing
+            </li>
+            <li>
+              if there are no incidents, <a href="mailto:<%= @support_email %>" class="govuk-link">email our support team</a> with the details of the problem your service is experiencing
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -99,5 +99,6 @@ Rails.application.configure do
 
   config.scheduler_polling_interval =  ENV.fetch('SCHEDULER_POLLING_INTERVAL','5s')
   config.notify_key = ENV.fetch('NOTIFY_KEY', 'test-11111111-1111-1111-1111-111111111111-11111111-1111-1111-1111-111111111111')
+  config.support_email = ENV.fetch('SUPPORT_EMAIL', 'default@mail.com')
   config.app_url = ENV.fetch('APP_URL', 'localhost:3000')
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -122,13 +122,13 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   config.aws_region = ENV.fetch('AWS_REGION')
-
   config.hub_environments = JSON.parse(ENV.fetch('HUB_ENVIRONMENTS'))
 
   config.cognito_client_id = ENV.fetch('AWS_COGNITO_CLIENT_ID')
   config.cognito_user_pool_id = ENV.fetch('AWS_COGNITO_USER_POOL_ID')
 
   config.notify_key = ENV.fetch('NOTIFY_KEY')
+  config.support_email = ENV.fetch('SUPPORT_EMAIL')
 
   config.app_url = ENV.fetch('APP_URL')
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -60,6 +60,7 @@ Rails.application.configure do
   config.cognito_user_pool_id = ENV['AWS_COGNITO_USER_POOL_ID']
   config.scheduler_polling_interval = ENV.fetch('SCHEDULER_POLLING_INTERVAL', '1s')
   config.notify_key = 'test-11111111-1111-1111-1111-111111111111-11111111-1111-1111-1111-111111111111'
+  config.support_email = 'test@mail.com'
   config.app_url = 'www.test.com'
 
   config.after_initialize do

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -400,7 +400,6 @@ en:
         signing: https://www.docs.verify.service.gov.uk/rotating-your-keys-and-certificates/service-provider-signing/#rotate-your-service-provider-signing-key-and-certificate
       connection_broken_or_compromised: https://www.docs.verify.service.gov.uk/emergency-procedures/#emergency-procedures
       rotation_documentation: https://www.docs.verify.service.gov.uk/rotating-your-keys-and-certificates/#rotating-your-keys-and-certificates
-      support: https://www.verify.service.gov.uk/support/
     dual_running:
       title: Dual running
       title_support_dual_running: Does your service provider support dual running?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,7 @@ Rails.application.routes.draw do
   get '/profile/update-mfa', to: 'profile#warn_mfa'
   get '/profile/update-mfa/get-code', to: 'profile#show_change_mfa'
   post '/profile/update-mfa', to: 'profile#change_mfa', as: :update_mfa_post
+  get '/support', to: 'support#index', as: :support
   get 'forgot-password', to: 'password#forgot_form'
   post 'forgot-password', to: 'password#send_code'
   get 'reset-password(/:reset_by_admin)', to: 'password#user_code', as: :reset_password

--- a/pre-commit-local.sh
+++ b/pre-commit-local.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-docker build . -f test.Dockerfile -t verify-selfservice-test
+docker build . -f test.Dockerfile -t verify-self-service-test
 
 docker container run -t --rm \
--v $(pwd):/verify-self-service \
--w /verify-self-service verify-selfservice-test \
+-v "$(pwd)":/verify-self-service \
+-w /verify-self-service verify-self-service-test \
 bash -c "/etc/init.d/postgresql start && ./pre-commit.sh"

--- a/spec/controllers/support_controller_spec.rb
+++ b/spec/controllers/support_controller_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe SupportController, type: :controller do
+  include AuthSupport
+
+  describe "Support Controller" do
+    context "logging in" do
+      it "redirects to log-in page if no user" do
+        get :index
+        expect(response.status).to eq(302)
+      end
+
+      it "shows support page if user is logged in" do
+        usermgr_stub_auth
+        get :index
+        expect(response.status).to eq(200)
+      end
+
+      describe "GET #index" do
+        it "renders the support page" do
+          usermgr_stub_auth
+          get :index
+          expect(response).to have_http_status(:success)
+          expect(subject).to render_template(:index)
+        end
+      end
+    end
+  end
+end

--- a/startup.sh
+++ b/startup.sh
@@ -1,21 +1,49 @@
 #!/bin/bash
 
-while true; do
-    read -p "Run using Docker? [y/n] " p
-    case $p in
-        y|Y|yes)    docker build . -f run.Dockerfile -t verify-self-service
-                    docker run --rm -p 8080:8080 -it verify-self-service
-                    break
-                    ;;
-        n|N|no)     set -e
-                    bundle check || bundle install
-                    yarn check || yarn install
-                    bin/rails s
-                    break
-                    ;;
-        x|X|exit)   exit 0
-                    ;;
-        *)          echo "Unknown option."
-                    ;;
-    esac
+RUN_IN_DOCKER=false
+
+show_help() {
+  cat << EOF
+Options:
+  -d , --docker   Run using docker
+EOF
+}
+
+while [ "$1" != "" ]; do
+  case $1 in
+      -d | --docker)    shift
+                        RUN_IN_DOCKER=true
+                        ;;
+      *)                echo -e "Unknown option $1...\n"
+                        show_help
+                        exit 1
+  esac
+  shift
 done
+
+if [[ $RUN_IN_DOCKER == 'false' ]]; then
+  while true; do
+      read -rp "Run using Docker? [y/n] " p
+      case $p in
+          y|Y|yes)    RUN_IN_DOCKER=true
+                      break
+                      ;;
+          n|N|no)     break
+                      ;;
+          x|X|exit)   exit 0
+                      ;;
+          *)          echo "Unknown option."
+                      ;;
+    esac
+  done
+fi
+
+if [[ $RUN_IN_DOCKER == 'true' ]]; then
+  docker build . -f run.Dockerfile -t verify-self-service
+  docker run --rm -p 8080:8080 -it verify-self-service
+else
+  set -e
+  bundle check || bundle install
+  yarn check || yarn install
+  bin/rails s
+fi


### PR DESCRIPTION
Added a new static support page to Self-Service instead of redirecting to an external page. The custom page is based on the page that we were redirecting to (https://www.verify.service.gov.uk/support/). The content has been cut down to only include information relevant to RPs or IDPs. A mailto link has been added so RPs and IDPs can find our support email address.

Use the environment variable 'support_email' to get the value for the email. This means the actual email address won't be included in the public repo.

  - Added the `view_support` permission set to `true` - this allows all users to view the support page and only logged in users can see the page

  - Added the `-d` option to the startup script so the user can run the app with docker without providing input on the console
  - Updated README to provide instructions to log in when running locally

<img width="998" alt="Screenshot 2021-06-25 at 12 36 01" src="https://user-images.githubusercontent.com/3608562/123419269-ef8f3680-d5b1-11eb-9dcb-58bffd28bb51.png">