### PR TITLE
[HUB-841] Remove yarn install dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,6 @@ RUN bundle install
 
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && apt-get install -y nodejs
 
-RUN npm install yarn -g
-
 ADD . /verify-self-service/
 
 WORKDIR /verify-self-service


### PR DESCRIPTION
`EEXIST: file already exists, symlink '../lib/node_modules/yarn/bin/yarn.js' -> '/usr/bin/yarn'` is causing the pipeline to fail.

I've removed the reference to install yarn for the time being to see if it builds. The setup_10.x script referencing installing yarn but only when flagged by the look of it. I'm assuming the base image already has it and/or it's installed somewhere between but haven't entirely dug down to see.



Signed-off-by: Chris Mills <7100370+chriscoffee@users.noreply.github.com>