### PR TITLE
BAU: Stop using deprecated include pundit

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  include Pundit
+  include Pundit::Authorization
   include UserInfo
   include ApplicationHelper
 

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,5 +1,5 @@
 class StaticController < ActionController::Base
-  include Pundit
+  include Pundit::Authorization
 
   layout 'full_width_layout'
 end


### PR DESCRIPTION
Changed from include Pundit to include Pundit::Authorization