### PR TITLE
BAU: Remove deprecation errors

### DIFF
--- a/app/controllers/user_journey_controller.rb
+++ b/app/controllers/user_journey_controller.rb
@@ -158,6 +158,6 @@ private
   end
 
   def errors_present?
-    (%i(certificate value cert_file) & @upload.errors.keys).any?
+    (%i(certificate value cert_file) & @upload.errors.attribute_names).any?
   end
 end

--- a/app/views/shared/_error_summary.html.erb
+++ b/app/views/shared/_error_summary.html.erb
@@ -5,7 +5,7 @@
     </h2>
     <div class="govuk-error-summary__body">
       <ul class="govuk-list govuk-error-summary__list">
-      <% errors.keys.each do |key| %>
+      <% errors.attribute_names.each do |key| %>
         <% errors.full_messages_for(key).each do |error| %>
           <li>
             <%= link_to error, "##{name}_#{key}" %>


### PR DESCRIPTION
Active model errors key changed to Active model error attributes_name

due to upgrade from rails 6.0.5.1 to 6.1.6.1 