### PR TITLE
downgrade puma to allow acceptance tests to run

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'rails', '~> 6.1.7'
 # Use postgres as the database for Active Record
 gem 'pg'
 # Use Puma as the app server
-gem 'puma', '~> 6.0'
+gem 'puma', '~> 5.6.5'
 # Use SCSS for stylesheets
 gem 'sassc-rails'
 # Use Uglifier as compressor for JavaScript assets
@@ -58,7 +58,7 @@ gem 'mimemagic', '~> 0.4.3'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
-  gem 'capybara', '~> 3.35'  
+  gem 'capybara', '~> 3.35'
   gem 'factory_bot_rails'
   gem 'rubocop-govuk'
   gem 'scss_lint-govuk'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,7 +190,7 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (5.0.0)
-    puma (6.0.0)
+    puma (5.6.5)
       nio4r (~> 2.0)
     pundit (2.2.0)
       activesupport (>= 3.0.0)
@@ -386,7 +386,7 @@ DEPENDENCIES
   notifications-ruby-client
   pg
   pry
-  puma (~> 6.0)
+  puma (~> 5.6.5)
   pundit
   rack_session_access
   rails (~> 6.1.7)


### PR DESCRIPTION
Our version of Capybara doesn’t support Puma 6, so downgrading for now so the pipeline could be unblocked for Dockerfile updates